### PR TITLE
Fix cross-platform git commit signing

### DIFF
--- a/bin/op-ssh-sign
+++ b/bin/op-ssh-sign
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Cross-platform wrapper for 1Password SSH signing
+case "$(uname -s)" in
+    Darwin)
+        exec /Applications/1Password.app/Contents/MacOS/op-ssh-sign "$@"
+        ;;
+    Linux)
+        for f in "/mnt/c/Program Files/WindowsApps"/Agilebits.1Password_*/op-ssh-sign-wsl; do
+            [ -x "$f" ] && exec "$f" "$@"
+        done
+        echo "op-ssh-sign-wsl not found" >&2
+        exit 1
+        ;;
+esac

--- a/gitconfig
+++ b/gitconfig
@@ -53,7 +53,7 @@
 	format = ssh
 
 [gpg "ssh"]
-	program = "/Applications/1Password.app/Contents/MacOS/op-ssh-sign"
+	program = op-ssh-sign
 
 [grep]
 	extendRegexp = true
@@ -71,3 +71,9 @@
 	name = Thomas Gautier
 	useconfigonly = true
 	signingkey = ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBRkKL/xhEWzA+O2DnrqTofc3gB42ixv5+P77K6zELfC
+[credential "https://github.com"]
+	helper =
+	helper = !/usr/bin/gh auth git-credential
+[credential "https://gist.github.com"]
+	helper =
+	helper = !/usr/bin/gh auth git-credential


### PR DESCRIPTION
## Summary
- Replace hardcoded macOS 1Password `op-ssh-sign` path with a cross-platform wrapper script in `bin/op-ssh-sign`
- Wrapper auto-detects macOS vs WSL2 and uses the correct signing binary
- Add `gh` as git credential helper for GitHub/Gist authentication

## Test plan
- [x] Verified `op-ssh-sign` wrapper finds and executes `op-ssh-sign-wsl` on WSL2
- [x] Verified git commit signing works with the new config