### PR TITLE
Add Windows interop paths to WSL PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Cross-platform dotfiles for macOS and Linux/WSL2 Ubuntu.
 
 3. **Install essential tools:**
    ```sh
-   sudo apt install -y coreutils zsh git curl build-essential
+   sudo apt install -y coreutils zsh git curl build-essential libffi-dev libyaml-dev zlib1g-dev
    ```
 
 4. **Install Homebrew (optional but recommended):**

--- a/bin/stack-update
+++ b/bin/stack-update
@@ -7,7 +7,7 @@ brew update \
   && brew bundle cleanup --force \
   && brew doctor
 
-mas upgrade
+command -v mas > /dev/null && mas upgrade
 
 mise install
 

--- a/zshenv
+++ b/zshenv
@@ -72,15 +72,14 @@ fi
 
 # WSL: Add Windows interop paths
 if [[ $PLATFORM == "wsl" ]]; then
-  local wsl_paths=(
-    "/mnt/c/Users/thoma/AppData/Local/Programs/Microsoft VS Code/bin"  # code
-    "/mnt/c/Windows/System32"                                          # clip.exe, cmd.exe, wsl.exe
-    "/mnt/c/Windows"                                                   # explorer.exe
-    "/mnt/c/Program Files/PowerShell/7"                                # pwsh.exe
-  )
-  for p in $wsl_paths; do
-    [[ -d "$p" ]] && path+="$p"
-  done
+  # VS Code (detect Windows user dynamically)
+  _vscode=(/mnt/c/Users/*/AppData/Local/Programs/Microsoft\ VS\ Code/bin(NY1))
+  (( ${#_vscode} )) && path+="$_vscode[1]"
+  # Windows system utilities (clip.exe, explorer.exe, cmd.exe, pwsh.exe)
+  [[ -d "/mnt/c/Windows/System32" ]] && path+="/mnt/c/Windows/System32"
+  [[ -d "/mnt/c/Windows" ]] && path+="/mnt/c/Windows"
+  [[ -d "/mnt/c/Program Files/PowerShell/7" ]] && path+="/mnt/c/Program Files/PowerShell/7"
+  unset _vscode
 fi
 
 # Common paths (including standard system paths)


### PR DESCRIPTION
## Summary
- Since `zshenv` builds PATH from scratch, Windows-inherited paths are dropped in WSL
- Adds commonly needed Windows binaries to PATH when `$PLATFORM == "wsl"`:
  - **VS Code** (`code`) — launch editor from WSL
  - **System32** (`clip.exe`, `cmd.exe`, `wsl.exe`) — clipboard, shell interop
  - **Windows** (`explorer.exe`) — open files/folders in Explorer
  - **PowerShell 7** (`pwsh.exe`) — modern PowerShell
- All paths are guarded with `[[ -d ]]` existence checks

## Test plan
- [ ] Open a new WSL terminal and verify `which code` resolves
- [ ] Verify `echo test | clip.exe` copies to Windows clipboard
- [ ] Verify `explorer.exe .` opens current directory
- [ ] Verify `pwsh.exe --version` runs PowerShell 7