### PR TITLE
fix(claude): use branch -D after squash merge

### DIFF
--- a/claude/commands/commit-push-pr.md
+++ b/claude/commands/commit-push-pr.md
@@ -62,8 +62,6 @@ gh pr create --title "short title" --body "$(cat <<'EOF'
 ## Test plan
 - [ ] Tests pass locally
 - [ ] CI passes
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
 EOF
 )"
 ```


### PR DESCRIPTION
## Summary
- Use `git branch -D` instead of `-d` in merge cleanup step, since squash merge creates different commit hashes and `-d` always fails

## Test plan
- [ ] Verify merge cleanup deletes branch without error