### PR TITLE
chore(claude): tighten rules for AI mentions, test failures, git workflow

### DIFF
--- a/claude/commands/commit-push-pr.md
+++ b/claude/commands/commit-push-pr.md
@@ -78,4 +78,5 @@ EOF
 - After merge completes:
   1. Switch back to main: `git checkout main`
   2. Pull latest: `git pull`
-  3. Delete the local feature branch: `git branch -D <branch-name>` (squash merge requires `-D` since commit hashes differ)
+  3. Delete the remote branch: `git push origin --delete <branch-name>` (skip if already deleted by GitHub)
+  4. Delete the local feature branch: `git branch -D <branch-name>` (squash merge requires `-D` since commit hashes differ)

--- a/claude/rules/commits.md
+++ b/claude/rules/commits.md
@@ -1,7 +1,8 @@
 # Commit Conventions
 
+- Never mention Claude, AI, or LLM anywhere in git output — commit messages, PR titles, PR bodies, branch names
 - Never include `Co-Authored-By` lines mentioning Claude or any AI
-- Never mention Claude, AI, or LLM in commit messages
+- Never add "Generated with Claude Code" or similar footers to PRs
 - Use conventional commit format: `type(scope): description`
   - `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `ci`, `perf`
 - Keep the first line under 72 characters

--- a/claude/rules/git-workflow.md
+++ b/claude/rules/git-workflow.md
@@ -2,6 +2,7 @@
 
 ## Squash merge
 
+- Delete the remote branch after merge: `git push origin --delete <branch>` (skip if already deleted by GitHub)
 - Use `git branch -D` (not `-d`) after squash merge — squash creates new commit hashes, so git never considers the branch "fully merged"
 - Check PR `state` is `OPEN` before acting on it — `gh pr view` returns merged/closed PRs too
 - Detect stale branches early — PRs can be merged outside your control (GitHub UI, standalone `gh`); check before committing on top

--- a/claude/rules/plan-first.md
+++ b/claude/rules/plan-first.md
@@ -28,9 +28,17 @@ Before writing any code, determine how to verify it works:
 
 Run verification **after every edit**, not batched at the end. If a test fails, fix it before moving on.
 
+## Failing tests are blockers
+
+- **Never dismiss a test failure** — "pre-existing", "unrelated", or "infrastructure issue" are not valid reasons to skip investigation
+- If a test fails during verification, **stop and fix it** before continuing with the original task
+- If the fix is genuinely out of scope, explain the root cause to the user and let them decide — don't silently move on
+- Run **all** verification commands in the plan (`just check`, `just test`, `just test-e2e`), not just the ones you expect to pass
+
 ## Anti-patterns
 
 - Writing code before reading the files you'll change
 - Making speculative fixes without understanding root cause
 - Batching all verification to the end
 - Skipping plan mode to "save time" — it costs more time when changes need rework
+- Dismissing failing tests as "pre-existing" or "unrelated" without investigating


### PR DESCRIPTION
## Summary

- Extend no-AI rule to cover PR bodies, titles, and all git output (not just commit messages)
- Add "failing tests are blockers" section to plan-first rules
- Add remote branch deletion step to squash merge workflow and commit-push-pr command

## Files changed

- `claude/rules/commits.md` — broadened no-AI-mentions rule
- `claude/rules/plan-first.md` — added failing tests section
- `claude/rules/git-workflow.md` — added remote branch deletion
- `claude/commands/commit-push-pr.md` — added remote branch deletion step