### PR TITLE
fix(claude): harden Copilot review polling

### DIFF
--- a/claude/rules/git-workflow.md
+++ b/claude/rules/git-workflow.md
@@ -83,7 +83,7 @@ GitHub may auto-trigger a Copilot review on the first push to a PR. Subsequent p
 
   ```sh
   gh api graphql -f query='query { repository(owner: "OWNER", name: "REPO") {
-    pullRequest(number: PR_NUMBER) { reviewThreads(first: 100) { nodes {
+    pullRequest(number: <PR_NUMBER>) { reviewThreads(first: 100) { nodes {
       id isResolved comments(first: 5) { nodes { body author { login }
         pullRequestReview { databaseId } } } } } } } }' \
     | jq --arg newReviewId "$NEW_REVIEW_ID" \


### PR DESCRIPTION
## Summary
- Snapshot the last review ID before pushing and poll by comparing IDs so stale reviews are never mistaken for fresh ones
- Pipe to `jq` for `--arg` variable passing (not a `gh api` flag)
- Use `test("^copilot-pull-request-reviewer")` regex to match both login variants consistently
- Request Copilot review after push with `|| true` — safe whether auto-triggered or not
- Switch inline comment retrieval from REST to GraphQL for reliable access to threads on outdated diff lines, with null-safety checks
- Formalize the review-fix cycle as an explicit numbered sequence

## Test plan
- [x] CI passes
- [x] Copilot review round 1 — 2 comments
- [x] Copilot review round 2 — 2 comments
- [x] Copilot review round 3 — 6 comments
- [x] Copilot review round 4 — 2 comments
- [x] Copilot review round 5 — 5 comments (pipe to jq, regex login matching)
- [ ] Copilot review round 6