### PR TITLE
fix(justfile): WSL2 compat for update recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -51,9 +51,9 @@ update-brew:
     brew bundle cleanup --force --file={{brewfile}}
     -brew doctor
 
-# Update Mac App Store apps (macOS only)
+# Update Mac App Store apps (no-op on non-macOS)
 update-mas:
-    {{ if os() == "macos" { "mas upgrade" } else { "true" } }}
+    {{ if os() == "macos" { "if command -v mas >/dev/null 2>&1; then mas upgrade; fi" } else { "true" } }}
 
 # Show outdated mise tools and upgrade them
 update-mise:


### PR DESCRIPTION
## Summary
- Use `canonicalize(justfile_directory())` to resolve through the `~/.justfile` symlink, fixing the Brewfile path on WSL2 where `justfile_directory()` returns `$HOME` instead of the repo
- Restrict `update-mas` to macOS with inline `os()` conditional — `mas` is Mac App Store only, runs `true` (no-op) on Linux

## Test plan
- [x] `just --dry-run update-brew` shows absolute repo path for Brewfile
- [x] `just --dry-run update` runs all recipes correctly
- [x] `just --list` parses correctly
- [ ] CI passes