### PR TITLE
fix(justfile): canonicalize justfile path, not directory

### DIFF
--- a/justfile
+++ b/justfile
@@ -37,7 +37,7 @@ lint-mise:
 update: update-brew update-mas update-mise update-rust
 
 # Resolve through symlink so this works when just finds ~/.justfile
-dotfiles_dir := canonicalize(justfile_directory())
+dotfiles_dir := parent_directory(canonicalize(justfile()))
 
 # Platform-specific Brewfile
 brewfile := dotfiles_dir / if os() == "macos" { "Brewfile" } else { "Brewfile.linux" }


### PR DESCRIPTION
## Summary
- Fix `dotfiles_dir` resolution: `canonicalize(justfile_directory())` was a no-op because it resolved `$HOME` (a real directory), not the `~/.justfile` symlink
- Use `parent_directory(canonicalize(justfile()))` to follow the symlink to the real file first, then extract the directory

## Test plan
- [x] `just --justfile ~/.justfile --evaluate dotfiles_dir` resolves to repo path
- [x] `just --evaluate dotfiles_dir` from inside repo also resolves correctly
- [x] `just --dry-run update-brew` from `/tmp` via symlink shows correct Brewfile path
- [ ] CI passes