### PR TITLE
fix(rules): remove stale .claude/docs/ reference in workflow

### DIFF
--- a/claude/rules/workflow.md
+++ b/claude/rules/workflow.md
@@ -10,7 +10,7 @@ At the start of any task, read the project's `CLAUDE.md`. It contains:
 
 - Which verification commands to run and when
 - Critical constraints specific to this codebase
-- Pointers to reference docs (`.claude/docs/`) for the domain you're working in
+- Pointers to rules (`.claude/rules/`) — path-scoped rules auto-load for matching files
 
 ## Assess
 


### PR DESCRIPTION
## Summary
- Fix stale `.claude/docs/` reference in `workflow.md` project grounding section
- The docs tier was consolidated into path-scoped rules in #78 — this reference was missed

## Test plan
- [x] Reference now points to `.claude/rules/` with path-scoping note
- [ ] CI passes