### PR TITLE
chore: add CI integrity rule, issues-first workflow, no-commit-to-main

### DIFF
--- a/claude/rules/ci-integrity.md
+++ b/claude/rules/ci-integrity.md
@@ -1,0 +1,29 @@
+# CI Integrity
+
+CI must reflect reality. Green means it works — no exceptions.
+
+## Rules
+
+- Never use `continue-on-error: true` to silence failing tests or checks
+- Never append `|| true`, `|| exit 0`, or `set +e` to test/lint/check commands
+- Never skip, disable, or comment out test suites to work around missing infrastructure
+- Never mark a failing CI step as non-blocking to "unblock the PR"
+- If tests cannot run (missing DB, missing service, auth not configured), fix the infrastructure — do not hide the failure
+- If a pre-existing test fails, it is still a blocker — investigate before proceeding
+
+## When tests legitimately cannot run
+
+- Add the infrastructure (Docker service, test fixture, config) so they can run
+- If the fix is out of scope, create a GitHub issue and inform the user — do not merge with broken tests
+- Temporarily removing a test suite requires explicit user approval and a tracking issue
+
+## Audit entries
+
+When auditing CI configuration, flag:
+
+- `continue-on-error` on any test/lint/check step
+- `|| true` or `|| exit 0` after test commands
+- `if: false` on test/check steps (disabling them)
+- `if: always()` on test/check steps (forcing them to "pass" regardless of prior failures — legitimate only on artifact-upload steps)
+- `set +e` in shell blocks that run tests
+- Commented-out test steps with no tracking issue

--- a/claude/rules/git-conventions.md
+++ b/claude/rules/git-conventions.md
@@ -2,7 +2,8 @@
 
 ## Branching
 
-- If on `main` or `master`, create a new feature branch before committing
+- Never commit directly to `main` or `master` — always create a feature branch first
+- If on `main` or `master` with uncommitted changes, create a branch before committing
 - Branch naming: `type/short-description` (lowercase, hyphens, no spaces)
 - Derive the branch name from the changes (e.g. `feat/add-libpq`, `fix/shell-startup`)
 - Detect stale branches early — PRs can be merged outside your control (GitHub UI, standalone `gh`); check before committing on top
@@ -31,6 +32,14 @@
   - If push fails because the remote branch was deleted: re-push with `-u` to recreate it
 - After every push, invoke the `/github` skill — to create a PR if none exists, or to update the PR, request a Copilot review, and process review comments. Wait for the Copilot review first (it arrives faster), then check CI only at merge time
 - Never use `gh pr create` or `gh pr edit` directly — all PR operations go through the `/github` skill
+
+## Issue linking
+
+- Each PR should reference at least one GitHub issue
+- Multi-concern PRs: each distinct fix or feature gets its own issue
+- Use `Fixes #N` (auto-closes on merge) or `Addresses #N` (no auto-close) in the PR body
+- If work addresses something not yet tracked, create the issue before or at PR time
+- Branch names may include the issue number: `fix/42-shell-startup`
 
 ## Merge strategy
 

--- a/claude/skills/github/SKILL.md
+++ b/claude/skills/github/SKILL.md
@@ -4,7 +4,7 @@ description: |
   GitHub PR & review skill powered by GitHub MCP Server.
   Use when: creating PRs, updating PRs, requesting Copilot reviews, processing review comments,
   merging PRs, or reviewing PRs as a code reviewer.
-  Covers: PR lifecycle, automated Copilot reviews, outbound code review, merge gates.
+  Covers: PR lifecycle, issue linking, automated Copilot reviews, outbound code review, merge gates.
 version: 1.0.0
 date: 2026-02-23
 user-invocable: true
@@ -23,6 +23,17 @@ Before creating a PR, check for an existing one:
 - **MCP**: `get_me` to identify the current user, then `list_pull_requests` or `get_pull_request`
 - **Fallback**: `gh pr view --json number,url,state 2>/dev/null`
 - Check `state` is `OPEN` before acting — closed/merged PRs are also returned
+
+### Link issues before creating or updating a PR
+
+Before creating or updating a PR, ensure every distinct fix or feature on the branch has a corresponding GitHub issue:
+
+1. Review all commits on the branch vs main — enumerate each distinct change
+2. Check for existing issues: **MCP** `list_issues` or `search_issues`, **Fallback** `gh issue list --search "keyword"`
+3. Create missing issues: **MCP** `issue_write`, **Fallback** `gh issue create --title "short title" --body "description"`
+4. Reference all linked issues in the PR body using `Fixes #N` (auto-closes on merge) or `Addresses #N` (no auto-close)
+
+If a single commit addresses multiple concerns, each concern should have its own issue.
 
 ### Create a PR
 


### PR DESCRIPTION
## Summary

- New global rule `ci-integrity.md` — never silence failing tests in CI (`continue-on-error`, `|| true`, `set +e`). Fix infrastructure, don't hide failures. Includes an audit checklist for reviewing CI config.
- Updated `git-conventions.md` — added Issue Linking section requiring PRs to reference GitHub issues. Hardened branching rule from "create a branch" to "never commit directly to main/master."
- Updated `/github` skill — added "Link issues before creating or updating a PR" step to PR lifecycle (check for existing issues, create missing ones, reference in PR body). Updated skill description to mention issue linking.

Addresses tgautier/r8n#55, tgautier/r8n#59

## Test plan

- [x] `just claude-check-refs` passes (r8n)
- [x] `just claude-check-escaping` passes (r8n)
- [x] `just claude-check-rule-scopes` passes (r8n)
- [x] markdownlint passes (dotfiles pre-commit hook)
- [x] New rule under 80 lines (29 lines)
- [x] git-conventions under 80 lines (58 lines)
- [x] github skill within 200-800 lines (232 lines)