### PR TITLE
fix: improve rules and CLAUDE.md from tmux session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,15 @@ just update
 just setup
 ```
 
+## Cross-Platform Discipline
+
+This repo targets **three platforms**: macOS, Linux, and WSL2. Every change must consider all three:
+
+- Shell config: guard platform-specific code with `$PLATFORM` checks (set in `zshenv`)
+- Brewfiles: edit **both** `Brewfile` and `Brewfile.linux` for CLI tools (see `.claude/rules/brewfile.md`)
+- tmux: use `if-shell` platform detection for OS-specific commands (clipboard, terminfo)
+- Never assume macOS-only tools exist (`pbcopy`, `open`) — provide WSL (`clip.exe`) and Linux (`xclip`) alternatives
+
 ## Architecture
 
 ### Platform Detection
@@ -56,6 +65,10 @@ The `justfile` defines local CI targets mirroring the GitHub Actions workflow:
 - `just lint-shell` — shellcheck on `bin/*` and zsh files
 - `just setup` — enables `.githooks/pre-commit`
 
+### tmux
+
+`tmux.conf` (symlinked to `~/.tmux.conf` by rcm). Prefix is `C-a`, vi-style bindings, platform-aware clipboard. See `docs/tmux.md` for the full cheat sheet.
+
 ### Git Configuration
 
 - SSH key signing via 1Password (`op-ssh-sign`)
@@ -82,3 +95,17 @@ When spawning subagents via the Task tool, always set `isolation: "worktree"` so
 ## GitHub Integration
 
 GitHub PR workflows (creating, reviewing, merging) use the GitHub MCP Server (`github`, configured in `~/.claude.json` user scope). The `/github` skill (`claude/skills/github/SKILL.md`) provides the full workflow instructions. The always-on `claude/rules/git-conventions.md` handles local git safety only.
+
+## Project-Local Rules
+
+`.claude/rules/` contains rules specific to this repo (not symlinked to other projects):
+
+| Rule | Scope | Purpose |
+| --- | --- | --- |
+| `brewfile.md` | `Brewfile`, `Brewfile.linux` | Dual-Brewfile sync and alphabetical sorting |
+
+## Documentation
+
+Detailed guides live in `docs/`:
+
+- `docs/tmux.md` — configuration overview, cheat sheet, troubleshooting

--- a/claude/rules/claude-config.md
+++ b/claude/rules/claude-config.md
@@ -52,4 +52,13 @@ Reference other config files with relative paths from the project root:
 
 **Global skills and rules must never reference project-local files** (`.claude/rules/`, project source paths). Global config is reusable across projects — project-specific bridging belongs in each project's `CLAUDE.md`. Use generic language like "check the project's `CLAUDE.md`" instead.
 
+## Placement: project-local vs global
+
+When creating a new rule, decide where it lives:
+
+- **`.claude/rules/`** (project-local) — constraints specific to this repo: file conventions, repo structure, project-specific workflows. Not symlinked elsewhere
+- **`claude/rules/`** (global, via dotfiles) — constraints that apply to all projects: git workflow, secrets, shell compatibility, task lifecycle
+
+**Test:** "Would this rule make sense in a completely different repo?" If no → project-local. If yes → global.
+
 For detailed authoring methodology (how to write rules, skills, CLAUDE.md, memory), evolution triggers, and hygiene checklists → `/claude-authoring`.

--- a/claude/rules/git-conventions.md
+++ b/claude/rules/git-conventions.md
@@ -46,6 +46,15 @@
 - Always squash merge — never use merge or rebase strategies
 - Post-merge cleanup is handled by the `/github` skill
 
+## Merge gates
+
+Before merging any PR, **all** of these must be true:
+
+- Zero unresolved review threads
+- All test plan items checked — never merge with unchecked items. If an item cannot be verified (e.g., requires manual testing), remove it with an explanation or ask the user before merging
+- CI passes — use `gh pr checks <number> --watch` to confirm
+- PR is still in `OPEN` state
+
 ## Worktree isolation
 
 - Always use git worktrees for new tasks — never work directly in the main working tree

--- a/claude/rules/task-lifecycle.md
+++ b/claude/rules/task-lifecycle.md
@@ -43,6 +43,7 @@ For iterating on plans before implementation, see the annotation cycle in `/code
 
 ## Implement
 
+- **Scope to what was asked** — do not build features, integrations, or configuration the user did not request. If you think something adjacent would be valuable, suggest it and wait for approval. "Add a tmux conf" does not mean "add iTerm2 keybindings"
 - **Just-first**: if the project has a `Justfile`, always use `just` recipes instead of raw tool commands (`yarn`, `cargo`, `npx`, `docker compose`). Load the `/just` skill when editing or reviewing the Justfile
 - Mark each task complete as you go — never stop mid-implementation with tasks unchecked
 - Run verification (typecheck, lint, tests) **after every edit**, not batched at the end. If a test fails, fix it before moving on
@@ -66,6 +67,7 @@ Before presenting work as done:
 - **Staff engineer bar** — "Would a staff engineer approve this?" If the answer is hesitant, improve it before presenting
 - **Demand elegance (non-trivial changes only)** — pause and ask "is there a more elegant way?" If a fix feels hacky: "Knowing everything I know now, what's the clean solution?" Skip this for simple, obvious fixes
 - **Diff against intent** — does the change do exactly what was asked? No more, no less?
+- **CLAUDE.md drift check** — if the PR adds new files, config, rules, or docs, verify CLAUDE.md still reflects reality. New config files need architecture entries, new rules need the rules index, new docs need the documentation section. Update CLAUDE.md in the same PR — not as a follow-up
 
 ### Failing tests are blockers
 
@@ -99,3 +101,4 @@ The goal is zero repeat mistakes. If the same correction happens twice, the rule
 - Dismissing failing tests as "pre-existing" or "unrelated" without investigating
 - Incrementally patching a bad approach instead of reverting and re-planning
 - Running raw `yarn test`, `cargo test`, `docker compose up` when a `just` recipe exists for the same operation
+- Building adjacent features the user didn't ask for (e.g., adding keybindings when asked for a config file)


### PR DESCRIPTION
Fixes #96

## Summary

- **CLAUDE.md**: add cross-platform discipline section, tmux architecture entry, project-local rules table, and docs index
- **git-conventions.md**: add merge gates (zero unresolved threads, test plan items checked, CI passes, PR still open)
- **task-lifecycle.md**: add "scope to what was asked" rule, CLAUDE.md drift check in Verify, and anti-pattern for building unasked features
- **claude-config.md**: add placement guidance for project-local (`.claude/rules/`) vs global (`claude/rules/`) with decision test

## Test plan

- [x] Linters pass (`just ci`)
- [x] markdownlint clean on all markdown files
- [x] All changes are rule/doc edits — no functional code to verify