### PR TITLE
feat: add roborev to Brewfiles

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,4 @@
+tap "roborev-dev/tap"
 tap "terror/tap"
 
 # CLI Tools & Development
@@ -77,6 +78,7 @@ brew "pnpm"
 brew "podman"
 brew "rcm"
 brew "redis"
+brew "roborev"
 brew "rustup"
 brew "shellcheck"
 brew "sops"

--- a/Brewfile.linux
+++ b/Brewfile.linux
@@ -2,6 +2,8 @@
 # Install Homebrew on Linux: https://docs.brew.sh/Homebrew-on-Linux
 # Usage: brew bundle --file=~/.Brewfile.linux
 
+tap "roborev-dev/tap"
+
 # CLI Tools & Development
 brew "act"
 brew "argocd"
@@ -51,6 +53,7 @@ brew "pnpm"
 brew "podman"
 brew "rcm"
 brew "redis"
+brew "roborev"
 brew "rustup"
 brew "sops"
 brew "step"


### PR DESCRIPTION
## Summary
- Add `roborev-dev/tap` and `roborev` to both macOS and Linux Brewfiles

Fixes #98

## Test plan
- [x] `just ci` passes locally (Brewfile syntax check, linters)
- [ ] CI passes