### PR TITLE
feat: add roborev integration

### DIFF
--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+# roborev post-commit hook v3 - auto-reviews every commit
+ROBOREV=$(command -v roborev 2>/dev/null)
+if [ -z "$ROBOREV" ] || [ ! -x "$ROBOREV" ]; then exit 0; fi
+"$ROBOREV" enqueue --quiet

--- a/.githooks/post-rewrite
+++ b/.githooks/post-rewrite
@@ -1,0 +1,5 @@
+#!/bin/sh
+# roborev post-rewrite hook v2 - remaps reviews after rebase/amend
+ROBOREV=$(command -v roborev 2>/dev/null)
+if [ -z "$ROBOREV" ] || [ ! -x "$ROBOREV" ]; then exit 0; fi
+"$ROBOREV" remap --quiet

--- a/claude/rules/git-conventions.md
+++ b/claude/rules/git-conventions.md
@@ -23,6 +23,10 @@
 ## Pushing
 
 - Never push directly to `main` or `master`
+- If roborev is installed, check review status before pushing: `roborev list`
+  - If any reviews failed, fix them: `roborev fix` or `roborev refine`
+  - Only push after all branch reviews pass (zero unaddressed failures)
+  - If roborev is not installed or the daemon is not running, skip this gate
 - Fetch latest before pushing: `git fetch origin`
 - Rebase onto main if needed — check with `git merge-base --is-ancestor origin/main HEAD` (exit 0 = clean)
   - If rebase hits conflicts: abort, inform the user of the conflicting files, and stop

--- a/claude/rules/skill-triggers.md
+++ b/claude/rules/skill-triggers.md
@@ -33,7 +33,8 @@ When the user's request matches an intent below, invoke the skill before startin
 | `/observability` | Tracing, metrics, health checks | "add tracing", "instrument", "health check" |
 | `/web-security` | Security review or hardening | "security review", "add auth", "CORS", "harden" |
 | `/documentation` | Doc audit, writing, or restructuring | "audit docs", "update docs", "docs are stale", "revamp documentation" |
-| `/github` | After every push | Per `git-conventions` — automatic, not user-triggered |
+| `/roborev` | Automated review management | "check reviews", "fix findings", "review status", "before push" |
+| `/github` | After every push | Per `git-conventions` — automatic, not user-triggered. `/roborev` runs first |
 
 ## Composite workflows
 
@@ -50,6 +51,7 @@ Most real tasks need multiple skills. When a task matches a pattern below, load 
 | Security hardening | `/web-security` | `/rust` or `/react` | "security audit", "pen test findings" |
 | Testing campaign | `/typescript` | `/react` or `/rust` | "add test coverage", "write E2E tests" |
 | Performance optimization | `/typescript` | `/css-responsive` | "bundle analysis", "lighthouse", "CLS" |
+| Pre-push workflow | `/roborev` | `/github` (after push) | "push my changes", "ready to push" |
 
 For full-stack features: check the project's `CLAUDE.md` for an end-to-end feature skill (e.g., `/new-feature`) that orchestrates the pipeline order.
 

--- a/claude/skills/roborev/SKILL.md
+++ b/claude/skills/roborev/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: roborev
+description: |
+  Automated code review management with roborev daemon and CLI.
+  Covers: review status, fixing findings, pre-push workflow, daemon management, per-project config.
+  Use when: checking reviews, fixing findings, managing review status, or before pushing.
+version: 1.0.0
+date: 2026-02-26
+user-invocable: true
+---
+
+# Roborev — Automated Code Review
+
+Roborev is a daemon-based automated code review tool. It runs post-commit hooks that trigger AI-powered reviews, and provides CLI commands to inspect, fix, and iterate on findings.
+
+## When to Use
+
+- Before pushing — check that all branch reviews pass
+- After roborev flags issues — read findings, fix them, verify
+- When the push workflow in `git-conventions` references roborev
+
+## Commands
+
+### Setup
+
+```sh
+roborev init          # Initialize a new repo (creates .roborev.toml + installs hooks)
+roborev install-hook  # Install hooks only (when .roborev.toml already exists)
+```
+
+### Check status
+
+```sh
+roborev list          # List reviews for current branch
+roborev show          # Show review for HEAD commit
+roborev show <sha>    # Show review for a specific commit
+```
+
+### Fix findings
+
+```sh
+roborev fix           # One-shot fix for all unaddressed findings
+roborev refine        # Iterative fix loop: fix → re-review → repeat until passing
+```
+
+### Interactive TUI
+
+```sh
+roborev tui --repo --branch   # Terminal UI filtered to current repo + branch
+roborev tui                   # Full TUI (all repos)
+```
+
+### Manual review
+
+```sh
+roborev review              # Review HEAD commit (if hook missed it)
+roborev review --branch     # Review all commits on current branch vs main
+roborev review --dirty      # Review uncommitted changes
+roborev review --since HEAD~3  # Review last 3 commits
+```
+
+## Pre-Push Workflow
+
+1. `roborev list` — check for unaddressed failures
+2. If failures exist: `roborev fix` or `roborev refine`
+3. Verify fixes pass: `roborev list` again
+4. Only push when all reviews pass (zero unaddressed failures)
+
+This integrates with the pushing section in `git-conventions` — roborev review status replaces the old manual self-review step.
+
+## Per-Project Config
+
+Each repo has a `.roborev.toml` at the root with:
+
+- `agent` — which AI agent to use (e.g. `copilot`, `claude-code`)
+- `backup_agent` — fallback agent if primary is unavailable
+- `review_guidelines` — project-specific rules injected into every review prompt
+- `excluded_branches` — branches that skip review (e.g. `main`, `wip`, `scratch`)
+
+The review guidelines should encode the project's hard invariants so roborev flags violations as blockers automatically.
+
+## Daemon
+
+The roborev daemon runs in the background, processing review jobs:
+
+```sh
+roborev daemon start   # Start daemon
+roborev daemon stop    # Stop daemon
+roborev status         # Check daemon health + recent jobs
+```
+
+The post-commit hook sends jobs to the daemon. If the daemon is not running, reviews queue and process when it starts.
+
+## Anti-patterns
+
+- Pushing without checking review status — always `roborev list` first
+- Ignoring blocker-level findings — these represent hard invariant violations
+- Running `roborev init` in a repo that already has `.roborev.toml` — use `install-hook` instead
+- Manually editing review results — use `roborev address` or `roborev comment` to interact with findings


### PR DESCRIPTION
## Summary
- Add git hooks (post-commit, post-rewrite) for automatic roborev review enqueue and remap
- Add roborev skill with proper frontmatter, setup docs, and CLI workflow
- Add pre-push review gate to git-conventions with graceful degradation
- Add roborev entries to skill-triggers routing table

Fixes #102

## Test plan
- [x] `just ci` passes
- [x] Hooks use `command -v` (cross-platform, no hardcoded Cellar path)
- [x] Hooks use `if/fi` guard for clarity
- [x] Hooks show stderr on errors (no silent `2>/dev/null`)
- [x] SKILL.md has proper frontmatter
- [x] No `just review-*` references (direct `roborev` commands only)
- [x] git-conventions gate skips when roborev not installed
- [x] `just setup` enables hooks (`core.hooksPath` set to `.githooks`)
- [x] `roborev enqueue` + `roborev list` confirms review pipeline works