### PR TITLE
fix(rules): add PR body update and todo merge gates

### DIFF
--- a/claude/rules/git-conventions.md
+++ b/claude/rules/git-conventions.md
@@ -57,8 +57,10 @@ Before merging any PR, **all** of these must be true:
 
 - Zero unresolved review threads
 - All test plan items checked — never merge with unchecked items. If an item cannot be verified (e.g., requires manual testing), remove it with an explanation or ask the user before merging
-- CI passes — use `gh pr checks <number> --watch` to confirm
+- CI passes — use `gh pr checks <number> --repo {owner}/{repo} --watch` to confirm
 - PR is still in `OPEN` state
+- All session todos completed — never merge with pending or in-progress task items
+- PR body is up to date — check off verified test plan items (`[x]`), update summary/title if commits changed. Do this via `gh pr edit` **before** merging, not after
 
 ## Principles
 

--- a/claude/skills/github/SKILL.md
+++ b/claude/skills/github/SKILL.md
@@ -65,22 +65,18 @@ After every push to a branch with an open PR:
 
 ## 2. Merge Gates
 
-Before merging, verify all gates pass:
+Verify all gates from `claude/rules/git-conventions.md` § Merge gates. Implementation details for checking:
 
-1. **Zero unresolved threads** — check via `get_pull_request_comments` or GraphQL:
+- **Unresolved threads** — `get_pull_request_comments` or GraphQL:
 
-   ```sh
-   gh api graphql -f query='query { repository(owner: "OWNER", name: "REPO") {
-     pullRequest(number: <PR_NUMBER>) { reviewThreads(first: 100) { nodes { id isResolved } } } } }' \
-     --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length'
-   ```
+  ```sh
+  gh api graphql -f query='query { repository(owner: "OWNER", name: "REPO") {
+    pullRequest(number: <PR_NUMBER>) { reviewThreads(first: 100) { nodes { id isResolved } } } } }' \
+    --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length'
+  ```
 
-   If the count is not `0`, stop and resolve remaining threads first
-
-2. **All test plan items checked** — never merge with unchecked items. If an item cannot be completed, remove it with an explanation or ask the user
-3. **CI passes** — use `gh pr checks <number> --repo {owner}/{repo} --watch` to block until all checks complete. This is the only point where you wait for CI — never block on CI earlier in the workflow. The MCP `get_status` method only reads legacy commit statuses, not GitHub Actions check runs, so it will miss CI results
-4. **PR still OPEN** — confirm immediately before merging
-5. **All todo list tasks completed** — never merge with pending or in-progress items
+- **CI** — use `gh pr checks <number> --repo {owner}/{repo} --watch` to block until all checks complete. This is the only point where you wait for CI — never block on CI earlier in the workflow. The MCP `get_status` method only reads legacy commit statuses, not GitHub Actions check runs, so it will miss CI results
+- **PR state** — confirm `state == "OPEN"` immediately before merging (`gh pr view <number> --repo {owner}/{repo} --json state` or MCP `get_pull_request`); another actor may have closed it between the CI check and the merge call
 
 ### Execute merge
 


### PR DESCRIPTION
## Summary

- Add two missing merge gates to git-conventions: update PR body before merging (check off test plan items), verify all session todos completed
- Deduplicate github skill merge gates to reference git-conventions as single source of truth, keeping only implementation details (GraphQL for threads, CI caveats, PR state race condition)
- Add `--repo {owner}/{repo}` to `gh pr checks` in the rule for portability across projects

Fixes #115

## Test plan

- [x] `just ci` passes
- [x] roborev review passes (2 rounds, findings addressed or rejected with rationale)
- [x] CI passes