### PR TITLE
chore: clean up stale worktree and lint-json-yaml refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Individual targets:
 | Target                 | Description                                          |
 | ---------------------- | ---------------------------------------------------- |
 | `just lint-shell`      | ShellCheck on `bin/*` and zsh files                  |
-| `just lint-json-yaml`  | Validate `claude/settings.json` and `alacritty.yml`  |
+| `just lint-yaml`       | Validate YAML files (`alacritty.yml`)                |
 | `just lint-markdown`   | markdownlint-cli2                                    |
 | `just lint-brewfile`   | Ruby syntax check on Brewfiles                       |
 | `just lint-mise`       | Validate mise config                                 |

--- a/claude/rules/task-lifecycle.md
+++ b/claude/rules/task-lifecycle.md
@@ -56,7 +56,7 @@ For iterating on plans before implementation, see the annotation cycle in `/code
 
 - Use subagents liberally — one focused task per subagent
 - For complex problems, throw more compute at it: spin up multiple subagents in parallel
-- When spawning teammates for implementation, use worktree isolation so agents don't conflict
+- When spawning teammates for implementation, give each agent a focused, non-overlapping scope to avoid conflicts
 
 ## Verify
 


### PR DESCRIPTION
## Summary

- Remove worktree isolation reference from `task-lifecycle.md` — replaced with scope-based conflict avoidance guidance
- Rename `lint-json-yaml` to `lint-yaml` in `README.md` to match current justfile recipe
- (Local-only) Remove stale `request_copilot_review` and `lint-json-yaml` permissions from `.claude/settings.local.json`

Fixes #117

## Test plan

- [x] `just ci` passes
- [x] roborev passes clean