### PR TITLE
chore: extract context-management rule from task-lifecycle

### DIFF
--- a/claude/rules/context-management.md
+++ b/claude/rules/context-management.md
@@ -1,0 +1,30 @@
+# Context Management
+
+How Claude manages context window resources across a session. Extracted from *task-lifecycle* (which governs process); this rule governs context discipline.
+
+## Subagent delegation
+
+- Use subagents for research — offload exploration and parallel analysis to keep the main context clean
+- One focused task per subagent; for complex problems, spin up multiple in parallel
+- When spawning teammates for implementation, give each a non-overlapping scope to avoid conflicts
+- Never duplicate work a subagent is already doing
+
+## Proactive compaction
+
+- Compact at ~50% context usage — don't wait for auto-compaction
+- Manual `/compact` preserves more useful context than automatic truncation
+- After compaction, verify you still have the critical details (file paths, plan items, constraints)
+
+## Context loading
+
+- Read only the files you'll change and their immediate callers/importers
+- Don't speculatively read files "just in case" — fetch on demand
+- For broad exploration, use an Explore subagent rather than polluting the main window
+- Large search results belong in subagents, not the main conversation
+
+## Anti-patterns
+
+- Reading every file in a directory before knowing which ones matter
+- Pasting full file contents when a targeted grep would suffice
+- Running exploratory searches in the main context instead of a subagent
+- Waiting for auto-compaction instead of compacting proactively

--- a/claude/rules/task-lifecycle.md
+++ b/claude/rules/task-lifecycle.md
@@ -29,7 +29,7 @@ Before planning, deeply read all code that will be affected:
 1. Read the files you'll change AND the files that call/import them
 2. Document findings: existing patterns, conventions, gotchas, and integration points
 
-Use subagents for research to keep the main context window clean. Offload exploration and parallel analysis — don't pollute the main conversation with hundreds of lines of search results.
+Use subagents for research — see *context-management* rule for delegation strategy.
 
 ## Plan
 
@@ -50,13 +50,7 @@ For iterating on plans before implementation, see the annotation cycle in `/code
 - Do not add unnecessary comments, jsdocs, or type annotations to code you didn't change
 - Keep corrections terse — single-sentence when context already exists. Reference existing code for consistency: "match the pattern in X"
 - If an approach isn't working after one fix attempt, **revert and re-plan** rather than layering patches. One failed fix attempt is the signal to step back — don't push through a bad approach
-- Compact proactively at ~50% context. Don't wait for auto-compaction — manual `/compact` preserves more useful context
-
-### Subagent strategy
-
-- Use subagents liberally — one focused task per subagent
-- For complex problems, throw more compute at it: spin up multiple subagents in parallel
-- When spawning teammates for implementation, give each agent a focused, non-overlapping scope to avoid conflicts
+- Compact proactively — see *context-management* rule for compaction and subagent strategy
 
 ## Verify
 


### PR DESCRIPTION
## Summary

- Extract context management concerns (subagent delegation, proactive compaction, context loading) from `task-lifecycle.md` into a new `context-management.md` rule
- `task-lifecycle.md` retains cross-references to the new rule (105 → 98 lines)
- New rule is 30 lines, focused on context window discipline

Companion to tgautier/r8n PR which updates the concern map and rules index.

## Test plan

- [x] `markdownlint` passes (pre-commit hook verified)
- [x] `rcup` syncs without errors
- [ ] New Claude Code session loads `context-management` rule from dotfiles