### PR TITLE
fix(zsh): detect OS dark mode for Claude Code ANSI theme

### DIFF
--- a/zsh/functions/claude
+++ b/zsh/functions/claude
@@ -1,9 +1,21 @@
 #!/usr/bin/env zsh
-local CLAUDE_THEME="light"
+local CLAUDE_THEME="light-ansi"
 
 if [[ "$PLATFORM" == "macos" ]] && command -v defaults &>/dev/null; then
   if [[ "$(defaults read -g AppleInterfaceStyle 2>/dev/null)" == "Dark" ]]; then
-    CLAUDE_THEME="dark"
+    CLAUDE_THEME="dark-ansi"
+  else
+    CLAUDE_THEME="light-ansi"
+  fi
+elif [[ -f /proc/sys/fs/binfmt_misc/WSLInterop || -n "$WSL_DISTRO_NAME" ]]; then
+  local reg_val
+  reg_val="$(/mnt/c/Windows/System32/reg.exe query \
+    'HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize' \
+    /v AppsUseLightTheme 2>/dev/null | grep -oP '0x\d+')"
+  if [[ "$reg_val" == "0x0" ]]; then
+    CLAUDE_THEME="dark-ansi"
+  else
+    CLAUDE_THEME="light-ansi"
   fi
 fi
 


### PR DESCRIPTION
## Summary

- Add WSL dark mode detection via Windows registry (`AppsUseLightTheme`)
- Switch all platforms from `light`/`dark` to `light-ansi`/`dark-ansi` theme variants
- Fix theme always reverting to light on WSL (macOS-only check silently failed on Linux)

## Test plan

- [x] Verify `reg.exe` registry query returns `0x0` on WSL with Windows dark mode
- [x] Launch `claude` on WSL — confirm `~/.claude.json` gets `dark-ansi`
- [x] Toggle Windows to light mode, relaunch — confirm `light-ansi`