### PR TITLE
fix(web-security): add redirect validation section

### DIFF
--- a/claude/skills/web-security/SKILL.md
+++ b/claude/skills/web-security/SKILL.md
@@ -404,7 +404,7 @@ OAuth redirect URIs are validated by the provider, but applications often build 
 **Rules:**
 - Every `Location` header derived from user input must be validated
 - Allow only relative paths starting with `/`
-- Reject protocol-relative URLs (`//evil.com`) and backslash-relative URLs (`/\evil.com` — browsers normalize `\` to `/`)
+- Reject protocol-relative URLs (`//evil.com`) and backslash-relative URLs (`/\evil.com` — some URL parsers normalize `\` to `/`, resolving it as `//evil.com`)
 - Reject absolute URLs (`https://...`), `javascript:` URIs, and `data:` URIs
 - Fallback to a safe default (`/`) when validation fails — never echo the invalid input
 


### PR DESCRIPTION
## Summary

- Add "Application-level redirect validation" subsection to `/web-security` skill (Section 9)
- Covers OWASP Unvalidated Redirects: sanitization rules, defense-in-depth at every trust boundary, anti-patterns
- Extends existing OAuth redirect URI matching guidance to cover app-level redirects (`returnTo`, post-action redirects)

Companion to tgautier/r8n#103 (merged) which implements this pattern with `sanitizeReturnTo()`.

## Test plan

- [x] markdownlint passes (verified by pre-commit hook)
- [x] Backslash normalization claim verified for factual accuracy