### PR TITLE
docs(rules): table-driven methods anti-patterns + pipeline safety

### DIFF
--- a/claude/rules/quality-standards.md
+++ b/claude/rules/quality-standards.md
@@ -34,3 +34,5 @@ The goal is zero repeat mistakes. If the same correction happens twice, the rule
 - Adding a comment or annotation as a substitute for actual validation or implementation
 - Presenting review findings as bare option lists without reasoning about which action fits the architecture
 - Auto-resolving review findings without the user's explicit decision — Claude recommends, the user decides
+- Writing per-entry tests for a data mapping (switch/match) instead of refactoring to a table lookup
+- Testing a loader/handler to prove inline logic works instead of extracting the pure function

--- a/claude/skills/web-security/SKILL.md
+++ b/claude/skills/web-security/SKILL.md
@@ -536,6 +536,13 @@ Redundant sanitization is cheap. A single missed boundary is an open redirect.
 | Storage | Store outside web root, serve via controlled endpoint |
 | Malware | Scan with antivirus on upload |
 
+### Pipeline safety (parse, don't validate)
+
+- Each function in a sanitize→transform pipeline must be independently safe for any input
+- Don't rely on callers invoking pipeline steps in order — make each step idempotent for untrusted input
+- When validating against external formats (OAuth codes, HTTP headers), cite the actual spec grammar, not assumptions from observed values
+- Prototype pollution guard: in JS/TS, use `Object.hasOwn()` or `Map` for lookups, never bare `record[key] ?? fallback` — prototype keys like `constructor` or `__proto__` bypass the fallback
+
 > See **Rust skill** (`/rust` §12) for Diesel parameterized queries (SQL injection prevention).
 > See **TypeScript skill** (`/typescript` §11) for framework-level input handling.
 


### PR DESCRIPTION
## Summary

- Add two anti-patterns to `quality-standards.md`: per-entry tests for data mappings, testing inline logic via loader/handler
- Add "Pipeline safety" subsection to `/web-security` SKILL.md: idempotent pipeline steps, spec-cited validation, `Object.hasOwn()` prototype pollution guard

Companion to tgautier/r8n#123 (merged). Codifies lessons from PR #122 where refactoring a switch to a Record lookup eliminated 9 tests.

Addresses tgautier/r8n#121

## Test plan

- [x] `markdownlint-cli2` passes (ran in pre-commit)
- [x] `shellcheck` passes (ran in pre-commit)
- [x] `quality-standards.md` under 80-line limit (38 lines)