### PR TITLE
feat(claude): enforce skill triggers, audit scopes, fix hook contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,16 +93,20 @@ Global rules (`claude/rules/`) are symlinked from this repo to all projects:
 | Rule | Purpose |
 | --- | --- |
 | `git-conventions.md` | Branching, commits, push workflow, merge strategy |
-| `skill-triggers.md` | Routing table — maps intents and file patterns to skills |
+| `skill-triggers.md` | Routing tables — file-pattern and task-triggered mappings to skills |
+| `skill-routing.md` | Composite workflows and disambiguation for multi-skill tasks |
 | `task-lifecycle.md` | How to assess, plan, implement, and verify work |
+| `findings-capture.md` | Capture non-obvious discoveries; verify claims before asserting |
+| `quality-principles.md` | Always-on conduct: no laziness, no quality degradation, correctness over progress |
+| `claude-config.md` | Two-tier config system (rules vs skills) |
+| `config-audit.md` | Checklist for adding/removing config files |
+| `coherence-check.md` | Sunk-cost defense prevention — evaluate own code objectively |
+| `restore-readiness.md` | Verify a real, restorable backup exists before any destructive action |
 | `ci-integrity.md` | CI must reflect reality — no silencing failures |
 | `secrets.md` | Never commit credentials outside dotfiles-private |
 | `shell.md` | zsh `!` corruption, jq compatibility |
-| `claude-config.md` | Two-tier config system (rules vs skills) |
-| `coherence-check.md` | Sunk-cost defense prevention — evaluate own code objectively |
-| `restore-readiness.md` | Verify a real, restorable backup exists before any destructive action |
 
-Skills (`claude/skills/`) provide on-demand methodology invoked via `/skill-name`. Routing is defined in `skill-triggers.md`.
+Skills (`claude/skills/`) provide on-demand methodology invoked via `/skill-name`. Routing is defined in `skill-triggers.md` and `skill-routing.md`.
 
 ## Project-Local Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,8 +96,8 @@ Global rules (`claude/rules/`) are symlinked from this repo to all projects:
 | `skill-triggers.md` | Routing tables — file-pattern and task-triggered mappings to skills |
 | `skill-routing.md` | Composite workflows and disambiguation for multi-skill tasks |
 | `task-lifecycle.md` | How to assess, plan, implement, and verify work |
-| `findings-capture.md` | Capture non-obvious discoveries; verify claims before asserting |
-| `quality-principles.md` | Always-on conduct: no laziness, no quality degradation, correctness over progress |
+| `findings-capture.md` | Capture non-obvious discoveries (drift, quirks, working patterns) before moving on |
+| `quality-principles.md` | Always-on conduct: no laziness, no quality degradation, correctness over progress, verify before asserting |
 | `claude-config.md` | Two-tier config system (rules vs skills) |
 | `config-audit.md` | Checklist for adding/removing config files |
 | `coherence-check.md` | Sunk-cost defense prevention — evaluate own code objectively |

--- a/claude/hooks/roborev-gate.sh
+++ b/claude/hooks/roborev-gate.sh
@@ -16,8 +16,11 @@ set -euo pipefail
 command -v jq >/dev/null 2>&1 || exit 0
 command -v roborev >/dev/null 2>&1 || exit 0
 
-# Extract the command from Bash tool input (|| true: invalid/missing JSON → empty command → exit 0)
-COMMAND=$(echo "${TOOL_INPUT:-}" | jq -r '.command // empty' 2>/dev/null) || true
+# Extract the command from Bash tool input. Claude Code passes the tool payload
+# as JSON on stdin; the field path is .tool_input.command.
+# (|| true: invalid/missing JSON → empty command → exit 0)
+input=$(cat 2>/dev/null) || true
+COMMAND=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null) || true
 [ -z "$COMMAND" ] && exit 0
 
 # Only gate push and merge commands

--- a/claude/hooks/roborev-review-reminder.sh
+++ b/claude/hooks/roborev-review-reminder.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# PostToolUse hook: after reading roborev findings, remind to use AskUserQuestion.
+# Fires after any Bash command that runs `roborev show`.
+# Exit 0 with message on stdout = non-blocking reminder injected into context.
+
+set -euo pipefail
+
+COMMAND=$(echo "${TOOL_INPUT:-}" | jq -r '.command // empty' 2>/dev/null) || true
+[ -z "$COMMAND" ] && exit 0
+
+case "$COMMAND" in
+  roborev\ show*)
+    echo "REMINDER: Follow /roborev interactive mode. Present each finding individually via AskUserQuestion with your recommendation. Never auto-dismiss or batch-resolve. The user decides: Fix, Dismiss, Discuss, or Skip."
+    ;;
+esac
+
+exit 0

--- a/claude/hooks/roborev-review-reminder.sh
+++ b/claude/hooks/roborev-review-reminder.sh
@@ -1,16 +1,22 @@
 #!/usr/bin/env bash
 # PostToolUse hook: after reading roborev findings, remind to use AskUserQuestion.
 # Fires after any Bash command that runs `roborev show`.
-# Exit 0 with message on stdout = non-blocking reminder injected into context.
+# Claude Code passes the tool payload as JSON on stdin (the field path is
+# .tool_input.command). The reminder is injected via
+# hookSpecificOutput.additionalContext — plain stdout is not reliably surfaced.
 
 set -euo pipefail
 
-COMMAND=$(echo "${TOOL_INPUT:-}" | jq -r '.command // empty' 2>/dev/null) || true
+command -v jq >/dev/null 2>&1 || exit 0
+
+input=$(cat 2>/dev/null) || exit 0
+COMMAND=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null) || exit 0
 [ -z "$COMMAND" ] && exit 0
 
 case "$COMMAND" in
   roborev\ show*)
-    echo "REMINDER: Follow /roborev interactive mode. Present each finding individually via AskUserQuestion with your recommendation. Never auto-dismiss or batch-resolve. The user decides: Fix, Dismiss, Discuss, or Skip."
+    msg="REMINDER: Follow /roborev interactive mode. Present each finding individually via AskUserQuestion with your recommendation. Never auto-dismiss or batch-resolve. The user decides: Fix, Dismiss, Discuss, or Skip."
+    jq -n --arg msg "$msg" '{ hookSpecificOutput: { hookEventName: "PostToolUse", additionalContext: $msg } }' || exit 0
     ;;
 esac
 

--- a/claude/hooks/skill-trigger-reminder.sh
+++ b/claude/hooks/skill-trigger-reminder.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# PreToolUse hook on Edit/Write — emits a reminder when the target path
+# PreToolUse hook on Edit/Write: emits a reminder when the target path
 # matches a file-pattern trigger in ~/.claude/rules/skill-triggers.md.
 #
 # Keep the pattern list in sync with the "File-pattern triggers" table in
@@ -32,7 +32,10 @@ matched=""
 
 [ -z "$matched" ] && exit 0
 
-unique=$(echo "$matched" | tr ' ' '\n' | awk 'NF && !seen[$0]++' | tr '\n' ' ' | sed 's/ *$//')
+# `|| exit 0` guards: under `set -euo pipefail`, any unexpected failure in the
+# pipeline or `jq -n` would propagate as exit 1, which for a PreToolUse hook is
+# unspecified and could block edits. Degrade gracefully to "allow" instead.
+unique=$(echo "$matched" | tr ' ' '\n' | awk 'NF && !seen[$0]++' | tr '\n' ' ' | sed 's/ *$//') || exit 0
 
 msg="[skill-trigger] About to modify \`$file_path\`. Per ~/.claude/rules/skill-triggers.md (File-pattern triggers), load before continuing if not already loaded: $unique"
 
@@ -43,5 +46,5 @@ jq -n --arg msg "$msg" '{
     hookEventName: "PreToolUse",
     additionalContext: $msg
   }
-}'
+}' || exit 0
 exit 0

--- a/claude/hooks/skill-trigger-reminder.sh
+++ b/claude/hooks/skill-trigger-reminder.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 
 command -v jq >/dev/null 2>&1 || exit 0
 
-input=$(cat)
+input=$(cat 2>/dev/null) || exit 0
 file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || exit 0
 [ -z "$file_path" ] && exit 0
 

--- a/claude/hooks/skill-trigger-reminder.sh
+++ b/claude/hooks/skill-trigger-reminder.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# PreToolUse hook for Edit/Write: emit a system reminder when the target path
+# PreToolUse hook on Edit/Write — emits a reminder when the target path
 # matches a file-pattern trigger in ~/.claude/rules/skill-triggers.md.
 #
 # Keep the pattern list in sync with the "File-pattern triggers" table in
@@ -34,5 +34,14 @@ matched=""
 
 unique=$(echo "$matched" | tr ' ' '\n' | awk 'NF && !seen[$0]++' | tr '\n' ' ' | sed 's/ *$//')
 
-echo "[skill-trigger] About to modify \`$file_path\`. Per ~/.claude/rules/skill-triggers.md (File-pattern triggers), load before continuing if not already loaded: $unique"
+msg="[skill-trigger] About to modify \`$file_path\`. Per ~/.claude/rules/skill-triggers.md (File-pattern triggers), load before continuing if not already loaded: $unique"
+
+# PreToolUse stdout is not injected into context — emit JSON with
+# hookSpecificOutput.additionalContext so the model actually sees the reminder.
+jq -n --arg msg "$msg" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    additionalContext: $msg
+  }
+}'
 exit 0

--- a/claude/hooks/skill-trigger-reminder.sh
+++ b/claude/hooks/skill-trigger-reminder.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Edit/Write: emit a system reminder when the target path
+# matches a file-pattern trigger in ~/.claude/rules/skill-triggers.md.
+#
+# Keep the pattern list in sync with the "File-pattern triggers" table in
+# skill-triggers.md.
+
+set -euo pipefail
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+input=$(cat)
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || exit 0
+[ -z "$file_path" ] && exit 0
+
+base=$(basename "$file_path")
+matched=""
+
+# Each rule below is independent — multiple skills can match a single path.
+[[ "$base" == "Justfile" || "$base" == "justfile" || "$base" == *.just ]] && matched+=" /just"
+[[ "$base" == "CLAUDE.md" ]] && matched+=" /claude-authoring"
+[[ "$base" == *.md ]] && matched+=" /markdown"
+[[ "$file_path" == */.claude/* || "$file_path" == */claude/* || "$file_path" == */memory/* ]] && matched+=" /claude-authoring"
+[[ "$file_path" == */docs/* ]] && matched+=" /documentation"
+[[ "$base" == "Cargo.toml" || "$base" == *.rs ]] && matched+=" /rust"
+[[ "$base" == *.tsx || "$base" == *.jsx ]] && matched+=" /react"
+[[ "$base" == "tsconfig.json" || "$base" == *.ts || "$base" == *.mts || "$base" == *.cts ]] && matched+=" /typescript"
+[[ "$base" == *.css || "$base" == tailwind.config.* ]] && matched+=" /css-responsive"
+[[ "$base" == *.ex || "$base" == *.exs ]] && matched+=" /phoenix"
+[[ "$base" == *.dart || "$base" == "pubspec.yaml" || "$base" == "pubspec.lock" ]] && matched+=" /flutter"
+[[ "$base" == "openapi.yaml" || "$base" == "openapi.yml" || "$base" == *.openapi.yaml || "$base" == *.openapi.yml ]] && matched+=" /api-design"
+
+[ -z "$matched" ] && exit 0
+
+unique=$(echo "$matched" | tr ' ' '\n' | awk 'NF && !seen[$0]++' | tr '\n' ' ' | sed 's/ *$//')
+
+echo "[skill-trigger] About to modify \`$file_path\`. Per ~/.claude/rules/skill-triggers.md (File-pattern triggers), load before continuing if not already loaded: $unique"
+exit 0

--- a/claude/rules/config-audit.md
+++ b/claude/rules/config-audit.md
@@ -8,7 +8,8 @@ When adding, removing, or modifying any file in `.claude/rules/`, `.claude/skill
 - [ ] **Bidirectional cross-references** — if file A references file B, file B references file A where relevant
 - [ ] **CLAUDE.md concern map updated** — correct typographic convention: *italic* for global rules (from dotfiles), `backtick` for project-local rules
 - [ ] **CLAUDE.md rules index updated** — new rules appear in the correct subsection (global vs path-scoped) with concern and description
-- [ ] **`skill-triggers.md` updated** — if adding a skill: task-triggered table entry + composite workflows row if applicable
+- [ ] **`skill-triggers.md` updated** — if adding a skill: task-triggered table entry; file-pattern row if relevant
+- [ ] **`skill-routing.md` updated** — if the new skill participates in composite workflows or disambiguation, add the row
 - [ ] **Path-scoped globs verified** — run `just claude-check-rule-scopes` (if the project provides it) to confirm globs match existing files
 - [ ] **`just check` passes** — escaping + cross-refs + lint + typecheck
 - [ ] **No orphaned cross-references** — if removing a rule or skill, grep for references to it and update or remove them

--- a/claude/rules/config-audit.md
+++ b/claude/rules/config-audit.md
@@ -8,7 +8,7 @@ When adding, removing, or modifying any file in `.claude/rules/`, `.claude/skill
 - [ ] **Bidirectional cross-references** — if file A references file B, file B references file A where relevant
 - [ ] **CLAUDE.md concern map updated** — correct typographic convention: *italic* for global rules (from dotfiles), `backtick` for project-local rules
 - [ ] **CLAUDE.md rules index updated** — new rules appear in the correct subsection (global vs path-scoped) with concern and description
-- [ ] **`skill-triggers.md` updated** — if adding a skill: task-triggered table entry; file-pattern row if relevant
+- [ ] **`skill-triggers.md` updated** — when adding a skill, route it where it belongs: task-triggered table if there's an intent-based signal, file-pattern row if it applies to a file type, or both. Some skills are file-pattern-only (e.g., `/markdown`, `/just`) and that's correct
 - [ ] **`skill-routing.md` updated** — if the new skill participates in composite workflows or disambiguation, add the row
 - [ ] **Path-scoped globs verified** — run `just claude-check-rule-scopes` (if the project provides it) to confirm globs match existing files
 - [ ] **`just check` passes** — escaping + cross-refs + lint + typecheck

--- a/claude/rules/findings-capture.md
+++ b/claude/rules/findings-capture.md
@@ -38,22 +38,6 @@ before moving on. The user shouldn't have to ask twice.
 4. **Memory** (`memory/*.md`) — last resort, only for project-specific
    context that doesn't generalize and isn't already in the code.
 
-## Verify claims before asserting them
-
-Numbers, sizes, version strings, "does X work?", "is Y under the limit?" —
-questions with a cheap deterministic check. The check is always cheaper than
-the rework after a wrong assertion.
-
-- **Line counts**: `wc -l <file>` before saying "this fits in the 80-line cap".
-- **Versions**: `cargo search <crate>` or read `Cargo.lock` before saying
-  "version X is the latest".
-- **Behavior**: run the actual command before saying "this errors with Z".
-- **Limits**: re-read the rule's text before saying "we're under the limit".
-
-If the check takes < 10 seconds, you have no excuse to skip it.
-Confident-but-unverified assertions force the user into a fact-checker role
-that defeats the whole point of having you here.
-
 ## Anti-patterns
 
 - "I'll remember this for next time" — you won't. Capture it now.

--- a/claude/rules/findings-capture.md
+++ b/claude/rules/findings-capture.md
@@ -1,0 +1,65 @@
+# Findings Capture
+
+When you learn something non-obvious during work — drift, quirk, working pattern,
+anti-pattern, or a contradiction with an existing skill or rule — persist it
+before moving on. The user shouldn't have to ask twice.
+
+## What counts as a finding
+
+- **Drift** — a crate API/feature/version that contradicts what you assumed
+  (e.g. `rand_core 0.10` dropped the `std` feature, `reqwest 0.13` renamed
+  `rustls-tls` → `rustls`).
+- **Undocumented quirk** — an API returns 404 where docs imply 200; a service
+  rate-limits below its published ceiling; a config requires `localhost` and
+  rejects `127.0.0.1`.
+- **Working pattern** — a non-obvious construction that turned out right
+  (e.g. "`std::sync::Mutex` for a sync trait method called from an async
+  context; `tokio::sync::Mutex` only when the guard crosses an `await`").
+- **Anti-pattern** — a thing you tried that failed for an instructive reason.
+- **Skill or rule inaccuracy** — a section of a global skill that doesn't
+  apply to the current context, or contradicts the actual API state.
+
+## When to capture
+
+- After a user correction (the classic trigger).
+- After any discovery during normal work, even unprompted.
+- Before declaring a non-trivial task done — ask: *did I learn anything a
+  future reader of the project docs and global skills wouldn't already know?*
+
+## Where to capture (first match wins)
+
+1. **Project docs** (`README.md`, `CLAUDE.md`, `docs/**`) — project-specific
+   facts: stack choices, verification recipes, known limitations.
+2. **Global skill** (`claude/skills/<name>/SKILL.md`) — cross-project
+   methodology and patterns. Update the skill *and* fix any inbound
+   cross-references that drift.
+3. **Global rule** (`claude/rules/*.md`) — constraints that must always hold
+   even without the user invoking a skill.
+4. **Memory** (`memory/*.md`) — last resort, only for project-specific
+   context that doesn't generalize and isn't already in the code.
+
+## Verify claims before asserting them
+
+Numbers, sizes, version strings, "does X work?", "is Y under the limit?" —
+questions with a cheap deterministic check. The check is always cheaper than
+the rework after a wrong assertion.
+
+- **Line counts**: `wc -l <file>` before saying "this fits in the 80-line cap".
+- **Versions**: `cargo search <crate>` or read `Cargo.lock` before saying
+  "version X is the latest".
+- **Behavior**: run the actual command before saying "this errors with Z".
+- **Limits**: re-read the rule's text before saying "we're under the limit".
+
+If the check takes < 10 seconds, you have no excuse to skip it.
+Confident-but-unverified assertions force the user into a fact-checker role
+that defeats the whole point of having you here.
+
+## Anti-patterns
+
+- "I'll remember this for next time" — you won't. Capture it now.
+- Writing memory when the fact generalizes (memory bloats; rules/skills
+  scale across sessions and projects).
+- Updating a skill but forgetting the inbound cross-reference in the project's
+  `CLAUDE.md`.
+- Capturing something that's already in the spec — read first, capture only
+  the delta.

--- a/claude/rules/quality-principles.md
+++ b/claude/rules/quality-principles.md
@@ -12,3 +12,9 @@ assess, research, plan, implement, verify, and review.
   to lower standards.
 - **No sunk-cost defense** — when questioned about code you wrote, run the
   coherence check (`claude/rules/coherence-check.md`) before answering.
+- **Verify claims before asserting them** — numbers, sizes, version strings,
+  "does X work?", "is Y under the limit?" are all questions with a cheap
+  deterministic check. Run `wc -l`, `cargo search`, the actual command.
+  If the check takes under 10 seconds you have no excuse to skip it.
+  Confident-but-unverified assertions force the user into a fact-checker
+  role that defeats the whole point of having you here.

--- a/claude/rules/quality-principles.md
+++ b/claude/rules/quality-principles.md
@@ -1,0 +1,14 @@
+# Quality Principles
+
+Always-on conduct, orthogonal to any specific task stage. These apply during
+assess, research, plan, implement, verify, and review.
+
+- **No laziness** — find root causes. No temporary fixes. Senior developer
+  standards.
+- **Never degrade quality incrementally** — every change must meet the same
+  standard as the codebase.
+- **Correctness over progress** — when uncertain, stop and ask the user.
+  Never improvise to keep moving. Stopping is a signal to think harder, not
+  to lower standards.
+- **No sunk-cost defense** — when questioned about code you wrote, run the
+  coherence check (`claude/rules/coherence-check.md`) before answering.

--- a/claude/rules/skill-routing.md
+++ b/claude/rules/skill-routing.md
@@ -25,7 +25,7 @@ Most real tasks need multiple skills. When a task matches a pattern below, load 
 | Full-stack feature with mobile | project feature skill | `/flutter`, `/rust`, `/api-design` | "add X to mobile", "new mobile screen", "API + mobile" |
 | Flutter feature with generated client | `/flutter` | `/api-design` | "new screen with API data", "Flutter + REST" |
 | Flutter design system | `/flutter` | `/ux-design` | "Flutter theming", "design tokens in Flutter" |
-| New project scaffold | `/code-planning` | language skill (`/rust`, `/typescript`, `/phoenix`, `/flutter`) | "new project", "scaffold X", "create X from scratch", "basic X app" |
+| New project scaffold | `/code-planning` | one language skill chosen from the language named in the request — `/rust`, `/typescript`, `/phoenix`, `/flutter` — or ask the user if none was named | "new project", "scaffold X", "create X from scratch", "basic X app" |
 
 For full-stack features: check the project's `CLAUDE.md` for an end-to-end feature skill (e.g., `/new-feature`) that orchestrates the pipeline order.
 

--- a/claude/rules/skill-routing.md
+++ b/claude/rules/skill-routing.md
@@ -1,0 +1,39 @@
+# Skill Routing
+
+How to combine skills for multi-skill tasks and how to disambiguate when intent could map to several. Companion to `claude/rules/skill-triggers.md`, which defines the base mappings; this rule defines how to compose them.
+
+## Composite workflows
+
+Most real tasks need multiple skills. When a task matches a pattern below, load all listed skills — primary first.
+
+| Task shape | Primary | Also load | Trigger signals |
+| --- | --- | --- | --- |
+| Full-stack feature (API + page) | project feature skill | `/rust`, `/api-design`, `/react-router`, `/react`, `/css-responsive` | "add X feature", "new endpoint with UI" |
+| API endpoint (no frontend) | `/rust` | `/api-design` | "add endpoint", "new handler" |
+| Frontend page with data | `/react-router` | `/react`, `/css-responsive` | "new page", "add a route with data", "new page with loader" |
+| Form mutation | `/react-router` | `/ux-design` | "form submission", "mutation", "add an action" |
+| Database/schema change | `/domain-design` | `/rust` | "add a migration", "new column", "change schema" |
+| Design system work | `/ux-design` | `/css-responsive` | "update tokens", "theme", "component variants" |
+| Dashboard or analytics | `/saas-product` | `/react`, `/css-responsive` | "build dashboard", "add charts", "KPI cards" |
+| Security hardening | `/web-security` | `/rust` or `/react` | "security audit", "pen test findings" |
+| Testing campaign | `/typescript` | `/react` or `/rust` | "add test coverage", "write E2E tests" |
+| Performance optimization | `/typescript` | `/css-responsive` | "bundle analysis", "lighthouse", "CLS" |
+| Pre-push workflow | `/roborev` | — | "push my changes", "ready to push" |
+| Complex domain feature | `/requirements` | `/domain-design`, `/code-planning` | "new entity", "new domain concept", "multi-entity feature" |
+| Full-stack Phoenix feature | `/phoenix` | `/api-design`, `/domain-design` | "add LiveView with Ecto", "new Phoenix feature", "LiveView + schema" |
+| Phoenix testing campaign | `/phoenix` | `/domain-design` | "write LiveView tests", "test Ecto queries" |
+| Full-stack feature with mobile | project feature skill | `/flutter`, `/rust`, `/api-design` | "add X to mobile", "new mobile screen", "API + mobile" |
+| Flutter feature with generated client | `/flutter` | `/api-design` | "new screen with API data", "Flutter + REST" |
+| Flutter design system | `/flutter` | `/ux-design` | "Flutter theming", "design tokens in Flutter" |
+| New project scaffold | `/code-planning` | language skill (`/rust`, `/typescript`, `/phoenix`, `/flutter`) | "new project", "scaffold X", "create X from scratch", "basic X app" |
+
+For full-stack features: check the project's `CLAUDE.md` for an end-to-end feature skill (e.g., `/new-feature`) that orchestrates the pipeline order.
+
+## Disambiguation
+
+When intent is ambiguous, prefer the more specific skill:
+
+- "Fix a bug" → investigate first, then load the skill matching the root cause layer
+- "Add validation" → `/rust` if server-side, `/ux-design` if form UX, `/react` if client logic
+- "Refactor" → load the skill matching the code layer being refactored
+- "Write tests" → `/typescript` (testing methodology), plus the layer-specific skill for context

--- a/claude/rules/skill-triggers.md
+++ b/claude/rules/skill-triggers.md
@@ -4,7 +4,7 @@ Routing table for skill selection. Always loaded — no path scoping, because in
 
 ## File-pattern triggers
 
-When editing files that match a pattern below, load the corresponding skill before making changes.
+When editing files that match a pattern below, load the corresponding skill before making changes. A `PreToolUse` hook (`claude/hooks/skill-trigger-reminder.sh`) injects a reminder into context on every `Edit`/`Write` whose path matches a row. Keep the hook's pattern list in sync with this table when adding rows.
 
 | File pattern | Skill | Why |
 | --- | --- | --- |
@@ -12,7 +12,13 @@ When editing files that match a pattern below, load the corresponding skill befo
 | `*.md` | `/markdown` | Consistent formatting across all Markdown files |
 | `docs/**` | `/documentation` | Doc structure, navigation, drift prevention |
 | `**/CLAUDE.md`, `.claude/**`, `claude/**`, `memory/**` | `/claude-authoring` | Config structure and authoring conventions |
+| `Cargo.toml`, `*.rs` | `/rust` | Rust conventions, error handling, testing discipline |
+| `*.tsx`, `*.jsx` | `/react` | React component patterns, hooks, composition |
+| `tsconfig.json`, `*.ts`, `*.mts`, `*.cts` | `/typescript` | Type safety, testing, build configuration |
+| `*.css`, `tailwind.config.*` | `/css-responsive` | Tailwind v4 conventions, responsive patterns |
+| `*.ex`, `*.exs` | `/phoenix` | Elixir/Phoenix conventions, Ecto, HEEx |
 | `*.dart`, `pubspec.yaml`, `pubspec.lock` | `/flutter` | Flutter architecture and widget patterns |
+| `openapi.yaml`, `openapi.yml`, `*.openapi.yaml`, `*.openapi.yml` | `/api-design` | HTTP semantics, error format, pagination |
 
 ## Task-triggered skills
 

--- a/claude/rules/skill-triggers.md
+++ b/claude/rules/skill-triggers.md
@@ -1,6 +1,6 @@
 # Skill Triggers
 
-Routing table for skill selection. Always loaded — no path scoping, because intent-based routing must be available regardless of which files are open.
+Routing tables for skill selection. Always loaded — no path scoping, because intent-based routing must be available regardless of which files are open. For composite workflows (combining skills) and disambiguation when intent maps to several skills, see `claude/rules/skill-routing.md`.
 
 ## File-pattern triggers
 
@@ -48,38 +48,4 @@ When the user's request matches an intent below, invoke the skill before startin
 | `/flutter` | Flutter widgets, state, navigation, theming | "add a screen", "new widget", "Riverpod provider", "Flutter navigation", "dart model" |
 | `/project-audit` | Comprehensive project health audit | "full audit", "audit the project", "check for drift", "are our rules still accurate" |
 
-## Composite workflows
-
-Most real tasks need multiple skills. When a task matches a pattern below, load all listed skills — primary first.
-
-| Task shape | Primary | Also load | Trigger signals |
-| --- | --- | --- | --- |
-| Full-stack feature (API + page) | project feature skill | `/rust`, `/api-design`, `/react-router`, `/react`, `/css-responsive` | "add X feature", "new endpoint with UI" |
-| API endpoint (no frontend) | `/rust` | `/api-design` | "add endpoint", "new handler" |
-| Frontend page with data | `/react-router` | `/react`, `/css-responsive` | "new page", "add a route with data", "new page with loader" |
-| Form mutation | `/react-router` | `/ux-design` | "form submission", "mutation", "add an action" |
-| Database/schema change | `/domain-design` | `/rust` | "add a migration", "new column", "change schema" |
-| Design system work | `/ux-design` | `/css-responsive` | "update tokens", "theme", "component variants" |
-| Dashboard or analytics | `/saas-product` | `/react`, `/css-responsive` | "build dashboard", "add charts", "KPI cards" |
-| Security hardening | `/web-security` | `/rust` or `/react` | "security audit", "pen test findings" |
-| Testing campaign | `/typescript` | `/react` or `/rust` | "add test coverage", "write E2E tests" |
-| Performance optimization | `/typescript` | `/css-responsive` | "bundle analysis", "lighthouse", "CLS" |
-| Pre-push workflow | `/roborev` | — | "push my changes", "ready to push" |
-| Complex domain feature | `/requirements` | `/domain-design`, `/code-planning` | "new entity", "new domain concept", "multi-entity feature" |
-| Full-stack Phoenix feature | `/phoenix` | `/api-design`, `/domain-design` | "add LiveView with Ecto", "new Phoenix feature", "LiveView + schema" |
-| Phoenix testing campaign | `/phoenix` | `/domain-design` | "write LiveView tests", "test Ecto queries" |
-| Full-stack feature with mobile | project feature skill | `/flutter`, `/rust`, `/api-design` | "add X to mobile", "new mobile screen", "API + mobile" |
-| Flutter feature with generated client | `/flutter` | `/api-design` | "new screen with API data", "Flutter + REST" |
-| Flutter design system | `/flutter` | `/ux-design` | "Flutter theming", "design tokens in Flutter" |
-| New project scaffold | `/code-planning` | language skill (`/rust`, `/typescript`, `/phoenix`, `/flutter`) | "new project", "scaffold X", "create X from scratch", "basic X app" |
-
-For full-stack features: check the project's `CLAUDE.md` for an end-to-end feature skill (e.g., `/new-feature`) that orchestrates the pipeline order.
-
-## Disambiguation
-
-When intent is ambiguous, prefer the more specific skill:
-
-- "Fix a bug" → investigate first, then load the skill matching the root cause layer
-- "Add validation" → `/rust` if server-side, `/ux-design` if form UX, `/react` if client logic
-- "Refactor" → load the skill matching the code layer being refactored
-- "Write tests" → `/typescript` (testing methodology), plus the layer-specific skill for context
+For composite workflows (multi-skill tasks) and ambiguity resolution, see `claude/rules/skill-routing.md`.

--- a/claude/rules/skill-triggers.md
+++ b/claude/rules/skill-triggers.md
@@ -29,7 +29,7 @@ When the user's request matches an intent below, invoke the skill before startin
 | `/code-planning` | Planning before implementation | "plan", "design the approach", "how should we" |
 | `/code-research` | Evaluating approaches or sources | "research", "compare options", "best practice" |
 | `/claude-authoring` | Writing or auditing Claude config | "audit rules", "write a rule", "config hygiene" |
-| `/rust` | Rust handlers, models, errors, config | "add a handler", "new model", "Rust error" |
+| `/rust` | Any Rust code — CLI, library, or service | "new rust project", "rust CLI", "cargo new", "add a handler", "new model", "Rust error" |
 | `/react` | React components, hooks, composition | "add a component", "write a hook", "extract component" |
 | `/react-router` | Route data loading, mutations, SSR | "new route with data", "form mutation", "loader", "action" |
 | `/typescript` | Type safety, testing, build tooling | "write a test", "fix type error", "bundle size" |
@@ -71,6 +71,7 @@ Most real tasks need multiple skills. When a task matches a pattern below, load 
 | Full-stack feature with mobile | project feature skill | `/flutter`, `/rust`, `/api-design` | "add X to mobile", "new mobile screen", "API + mobile" |
 | Flutter feature with generated client | `/flutter` | `/api-design` | "new screen with API data", "Flutter + REST" |
 | Flutter design system | `/flutter` | `/ux-design` | "Flutter theming", "design tokens in Flutter" |
+| New project scaffold | `/code-planning` | language skill (`/rust`, `/typescript`, `/phoenix`, `/flutter`) | "new project", "scaffold X", "create X from scratch", "basic X app" |
 
 For full-stack features: check the project's `CLAUDE.md` for an end-to-end feature skill (e.g., `/new-feature`) that orchestrates the pipeline order.
 

--- a/claude/rules/task-lifecycle.md
+++ b/claude/rules/task-lifecycle.md
@@ -54,18 +54,11 @@ For plan quality methodology → `/code-planning`.
 
 ## Quality principles
 
-- **No laziness** — find root causes. No temporary fixes. Senior developer standards
-- **Never degrade quality incrementally** — every change must meet the same standard as the codebase
-- **Correctness over progress** — when uncertain, stop and ask the user. Never improvise to keep moving. Stopping is a signal to think harder, not to lower standards
-- **No sunk-cost defense** — when questioned about code you wrote, run the coherence check (`claude/rules/coherence-check.md`) before answering
+See `claude/rules/quality-principles.md`.
 
 ## Self-improvement
 
-After ANY correction from the user:
-
-1. Identify the pattern (wrong assumption, missed convention, skipped verification)
-2. **Rule first, memory second** — if the mistake could recur across sessions, write or update a rule (enforced). Only use memory for project-specific context that doesn't generalize
-3. Check if an existing rule already covered this — if so, the problem is discipline, not missing rules. Add the specific anti-pattern to make it harder to ignore
+See `claude/rules/findings-capture.md` — fires on corrections and on non-correction discoveries.
 
 ## Anti-patterns
 

--- a/claude/skills/api-design/SKILL.md
+++ b/claude/skills/api-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: api-design
-description: |
+description: >
   Language-agnostic REST API design skill for production APIs.
   Covers: resource design, HTTP semantics, status codes, error format (RFC 9457),
   pagination, filtering, versioning, idempotency, authentication, authorization,

--- a/claude/skills/code-planning/SKILL.md
+++ b/claude/skills/code-planning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-planning
-description: |
+description: >
   Planning discipline skill for structuring implementation plans.
   Covers: trade-off evaluation, task decomposition, scope management, risk identification,
   complexity signals, plan structure, and planning anti-patterns.

--- a/claude/skills/code-research/SKILL.md
+++ b/claude/skills/code-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-research
-description: |
+description: >
   Source evaluation and research methodology skill for code and architecture decisions.
   Covers: source authority hierarchy, evaluating recency and context, conflict resolution,
   idiomatic code selection, research process, and reporting findings with attribution.

--- a/claude/skills/css-responsive/SKILL.md
+++ b/claude/skills/css-responsive/SKILL.md
@@ -1,21 +1,24 @@
 ---
 name: css-responsive
-description: |
-  Mobile-first CSS architecture and Tailwind CSS v4 strategy for responsive web applications.
-  Covers: breakpoint strategy, touch interaction, viewport handling, Tailwind v4 patterns,
+description: >
+  Mobile-first CSS and responsive layout skill for production web applications.
+  Covers: breakpoint strategy, touch interaction, viewport handling,
   responsive typography, container queries, layout patterns, navigation patterns, performance.
-  Use when: building responsive layouts, implementing mobile-first designs, configuring
-  Tailwind v4, or auditing responsive behavior across breakpoints.
-version: 1.0.0
-date: 2026-02-23
+  Tailwind CSS v4 is the default implementation; the architectural patterns apply to plain CSS, CSS-in-JS, or other utility frameworks.
+  Use when: building responsive layouts, implementing mobile-first designs,
+  configuring Tailwind v4, or auditing responsive behavior across breakpoints.
+  Not for: design tokens or visual hierarchy (use `/ux-design`),
+  React component composition (use `/react`).
+version: 1.1.0
+date: 2026-05-13
 user-invocable: true
 ---
 
 # CSS & Responsive Design
 
-Mobile-first CSS architecture for production web applications. Covers responsive strategy, Tailwind CSS v4 patterns, and performance optimization.
+Mobile-first CSS architecture for production web applications. Covers responsive strategy, performance, and layout patterns. Tailwind CSS v4 is the default implementation referenced in examples, but the architectural patterns apply to plain CSS, CSS-in-JS, or other utility frameworks.
 
-For design tokens and visual hierarchy, see `/ux-design`. For React component patterns, see `/react`. For project-specific breakpoints and Tailwind configuration, check the project's `CLAUDE.md`.
+> **Scope boundary:** Design tokens, visual hierarchy, and component design are in `/ux-design`. React component patterns are in `/react`. Project-specific breakpoints and Tailwind configuration belong in the project's `CLAUDE.md`.
 
 ---
 

--- a/claude/skills/domain-design/SKILL.md
+++ b/claude/skills/domain-design/SKILL.md
@@ -1,13 +1,16 @@
 ---
 name: domain-design
-description: |
+description: >
   Language-agnostic domain design skill for modeling business domains.
   Covers: bounded contexts, aggregates, entities, value objects, domain events,
   data modeling, schema evolution, system decomposition, and anti-patterns.
   Use when: designing new domain models, evaluating aggregate boundaries, planning
   schema changes, decomposing systems, or reviewing domain modeling decisions.
-version: 1.0.0
-date: 2026-02-22
+  Not for: pre-implementation requirements (use `/requirements`),
+  implementation in a specific language (use `/rust`, `/typescript`, or `/phoenix`),
+  HTTP resource design (use `/api-design`).
+version: 1.1.0
+date: 2026-05-13
 user-invocable: true
 ---
 

--- a/claude/skills/flutter/SKILL.md
+++ b/claude/skills/flutter/SKILL.md
@@ -1,21 +1,23 @@
 ---
 name: flutter
-description: |
-  Production Flutter development skill for native mobile applications.
+description: >
+  Production Flutter development skill for Flutter applications across mobile, web, and desktop targets.
   Covers: MVVM architecture, Riverpod state management, go_router navigation,
   Freezed models, widget composition, theming (Material 3), testing methodology,
   performance optimization, and platform channels.
   Use when: writing widgets, providers, screens, models, tests, or reviewing Flutter code quality.
-version: 1.0.0
-date: 2026-03-27
+  Not for: API contract design (use `/api-design`), domain modeling (use `/domain-design`),
+  design system and accessibility (use `/ux-design`), observability (use `/observability`).
+version: 1.1.0
+date: 2026-05-13
 user-invocable: true
 ---
 
 # Flutter Development
 
-Production guidance for Flutter native mobile applications. Based on the Flutter team's official architecture guide (2024), Riverpod documentation, Very Good Ventures patterns, and Andrea Bizzotto's architecture series.
+Production guidance for Flutter applications. Patterns target mobile first but apply equally to Flutter web and desktop builds; platform-specific deviations are called out where relevant. Based on the Flutter team's official architecture guide (2024), Riverpod documentation, Very Good Ventures patterns, and Andrea Bizzotto's architecture series.
 
-For API contract design and HTTP semantics, see `/api-design`. For domain modeling, see `/domain-design`. For design system and accessibility, see `/ux-design`. For observability, see `/observability`.
+> **Scope boundary:** For API contract design and HTTP semantics, see `/api-design`. For domain modeling, see `/domain-design`. For design system and accessibility, see `/ux-design`. For observability, see `/observability`.
 
 ---
 

--- a/claude/skills/just/SKILL.md
+++ b/claude/skills/just/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: just
-description: |
+description: >
   Justfile authoring skill for the just command runner.
   Covers: recipe design, dependency management, variables, shebang recipes, error handling,
   output control, modules, built-in functions, settings, and common patterns.

--- a/claude/skills/observability/SKILL.md
+++ b/claude/skills/observability/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: observability
-description: |
+description: >
   Language-agnostic observability skill covering traces, metrics, structured logging,
   health checks, frontend RUM, security, and configuration patterns.
   Covers: three pillars, span naming, metric naming, cardinality discipline, sampling,

--- a/claude/skills/phoenix/SKILL.md
+++ b/claude/skills/phoenix/SKILL.md
@@ -1,21 +1,26 @@
 ---
 name: phoenix
-description: |
-  Full-stack Elixir/Phoenix development skill for LiveView applications.
+description: >
+  Full-stack Elixir/Phoenix development skill for Phoenix applications.
   Covers: Elixir idioms, Mix workflow, Phoenix conventions, Ecto patterns,
   LiveView, HEEx templates, forms, testing, JS/CSS integration, and UI/UX.
-  Use when: writing LiveViews, Ecto schemas, migrations, Phoenix routes,
+  LiveView is the primary interactive UI layer covered; the same conventions
+  apply to traditional Phoenix controllers and JSON APIs.
+  Use when: writing LiveViews, controllers, Ecto schemas, migrations, Phoenix routes,
   HEEx templates, or reviewing Elixir code quality.
-version: 1.0.0
-date: 2026-03-01
+  Not for: API contract design (use `/api-design`), domain modeling (use `/domain-design`),
+  responsive CSS (use `/css-responsive`), design system and accessibility (use `/ux-design`),
+  observability (use `/observability`).
+version: 1.1.0
+date: 2026-05-13
 user-invocable: true
 ---
 
 # Phoenix Development
 
-Full-stack guidance for production Phoenix + LiveView applications. Covers the Elixir language layer, Phoenix framework conventions, Ecto data access, LiveView interactivity, HEEx templating, forms, and testing.
+Full-stack guidance for production Phoenix applications. Covers the Elixir language layer, Phoenix framework conventions, Ecto data access, LiveView interactivity, HEEx templating, forms, and testing. LiveView is the primary interactive UI layer documented here; the same conventions apply to traditional Phoenix controllers and JSON APIs.
 
-For API contract design and HTTP semantics, see `/api-design`. For domain modeling and schema evolution, see `/domain-design`. For responsive CSS and Tailwind v4, see `/css-responsive`. For design system and accessibility, see `/ux-design`. For observability, see `/observability`.
+> **Scope boundary:** For API contract design and HTTP semantics, see `/api-design`. For domain modeling and schema evolution, see `/domain-design`. For responsive CSS and Tailwind v4, see `/css-responsive`. For design system and accessibility, see `/ux-design`. For observability, see `/observability`.
 
 ---
 

--- a/claude/skills/project-audit/SKILL.md
+++ b/claude/skills/project-audit/SKILL.md
@@ -84,8 +84,8 @@ Broken links between config files that cause hallucinated guidance.
 **Method:** Automated checks handle existence verification. AI audit verifies semantic correctness — does the referenced section still say what the referencing file assumes it says?
 
 **Checklist:**
-- [ ] `skill-triggers.md` — all existing skills are routed (no orphaned skills)
-- [ ] `skill-triggers.md` — composite workflows reference valid combinations
+- [ ] `skill-triggers.md` — all existing skills appear in the task-triggered table (no orphaned skills)
+- [ ] `skill-routing.md` — composite workflows reference valid combinations
 - [ ] CLAUDE.md rules index — matches actual rule files and their scoping
 - [ ] Bidirectional cross-references — if A references B, B references A
 

--- a/claude/skills/project-audit/SKILL.md
+++ b/claude/skills/project-audit/SKILL.md
@@ -1,6 +1,16 @@
 ---
+name: project-audit
+description: >
+  Comprehensive project health audit methodology.
+  Covers: drift detection, tech currency, cross-reference integrity, codebase quality,
+  semantic checks that automation cannot perform.
+  Use when: running a quarterly audit, validating after major dependency upgrades,
+  checking cross-references after adding or removing rules/skills, or assessing
+  release readiness.
+  Not for: routine lint checks (run the project's `just check`/`just ci` recipe instead).
+version: 1.1.0
+date: 2026-05-13
 user-invocable: true
-description: Comprehensive project health audit — drift detection, tech currency, cross-reference integrity, and codebase quality
 ---
 
 # Project Audit

--- a/claude/skills/project-audit/SKILL.md
+++ b/claude/skills/project-audit/SKILL.md
@@ -84,7 +84,7 @@ Broken links between config files that cause hallucinated guidance.
 **Method:** Automated checks handle existence verification. AI audit verifies semantic correctness — does the referenced section still say what the referencing file assumes it says?
 
 **Checklist:**
-- [ ] `skill-triggers.md` — all existing skills appear in the task-triggered table (no orphaned skills)
+- [ ] `skill-triggers.md` — every existing skill is reachable via at least one routing entry (task-triggered intent, file-pattern, or both); no orphaned skills
 - [ ] `skill-routing.md` — composite workflows reference valid combinations
 - [ ] CLAUDE.md rules index — matches actual rule files and their scoping
 - [ ] Bidirectional cross-references — if A references B, B references A

--- a/claude/skills/project-management/SKILL.md
+++ b/claude/skills/project-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-management
-description: |
+description: >
   Tool-agnostic conventions for writing issues and PRs.
   Covers: issue structure, PR format, naming consistency, lifecycle.
   Use when: creating issues, writing PR descriptions, filing bugs, or planning work items.

--- a/claude/skills/react-router/SKILL.md
+++ b/claude/skills/react-router/SKILL.md
@@ -1,13 +1,16 @@
 ---
 name: react-router
-description: |
+description: >
   React Router v7 framework patterns for data loading, mutations, error handling, and routing.
   Covers: loaders, actions, data revalidation, Form patterns, route error boundaries,
   type-safe loader/action data, and progressive enhancement.
   Use when: building server-first applications, handling route-level data fetching,
   processing form mutations, managing URL state, or implementing error handling.
-version: 1.1.0
-date: 2026-03-25
+  Not for: component composition and hooks (use `/react`),
+  TypeScript build tooling (use `/typescript`),
+  component design and accessibility (use `/ux-design`).
+version: 1.2.0
+date: 2026-05-13
 user-invocable: true
 ---
 
@@ -15,7 +18,7 @@ user-invocable: true
 
 Server-first data and mutation patterns for React Router v7. React Router v7 combines client-side routing with server-side data loading and mutation handling — eliminating the need for SPA-era client-side data layers.
 
-For general React patterns (hooks, state, composition), see `/react`. For TypeScript language patterns and build tooling, see `/typescript`. For component design and accessibility, see `/ux-design`.
+> **Scope boundary:** For general React patterns (hooks, state, composition), see `/react`. For TypeScript language patterns and build tooling, see `/typescript`. For component design and accessibility, see `/ux-design`.
 
 ---
 

--- a/claude/skills/react/SKILL.md
+++ b/claude/skills/react/SKILL.md
@@ -1,13 +1,17 @@
 ---
 name: react
-description: |
+description: >
   React 19 development patterns for production web applications.
   Covers: React 19 features, hooks, component composition, state management,
   error handling, and testing methodology.
   Use when: writing React components, managing component state, handling errors,
   testing components, or designing component APIs.
-version: 2.1.0
-date: 2026-03-25
+  Not for: route data loading and mutations (use `/react-router`),
+  TypeScript build tooling and testing (use `/typescript`),
+  component design, form UX, and accessibility (use `/ux-design`),
+  responsive CSS (use `/css-responsive`).
+version: 2.2.0
+date: 2026-05-13
 user-invocable: true
 ---
 
@@ -15,7 +19,7 @@ user-invocable: true
 
 React 19 component patterns, hooks, and testing methodology for production applications. This covers the component and composition layer — component design, hooks, state management, error handling within components, and testing strategies.
 
-For React Router loaders, actions, mutations, and data patterns, see `/react-router`. For TypeScript strictness, testing, and build tooling, see `/typescript`. For component design, form UX, and accessibility, see `/ux-design`. For CSS and responsive patterns, see `/css-responsive`.
+> **Scope boundary:** For React Router loaders, actions, mutations, and data patterns, see `/react-router`. For TypeScript strictness, testing, and build tooling, see `/typescript`. For component design, form UX, and accessibility, see `/ux-design`. For CSS and responsive patterns, see `/css-responsive`.
 
 ---
 

--- a/claude/skills/requirements/SKILL.md
+++ b/claude/skills/requirements/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: requirements
-description: |
+description: >
   Pre-implementation requirements elicitation using EARS notation.
   Covers: acceptance criteria, edge cases, entity sketches, open questions.
   Use when: clarifying what to build before implementation on complex features

--- a/claude/skills/roborev/SKILL.md
+++ b/claude/skills/roborev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: roborev
-description: |
+description: >
   Automated code review management with roborev daemon and CLI.
   Covers: multi-agent reviews (claude, copilot, codex), review modes (interactive/auto),
   fixing findings, pre-push workflow, daemon management, per-project config.

--- a/claude/skills/rust/SKILL.md
+++ b/claude/skills/rust/SKILL.md
@@ -1,21 +1,26 @@
 ---
 name: rust
-description: |
-  Industrial-grade Rust development skill for Axum + Diesel + utoipa APIs.
-  Covers: naming conventions, handler design, error handling, validation, Diesel models & migrations,
-  Tower middleware, observability, testing, security, performance, API design, resilience,
-  transactions, and dependency management.
-  Use when: writing handlers, models, migrations, tests, or reviewing Rust code quality.
-version: 3.1.0
-date: 2026-03-05
+description: >
+  Rust development skill — conventions and quality discipline for any Rust code.
+  Universal sections apply to all Rust (CLI, library, service): crate-level safety,
+  naming, error handling, validation, domain types and newtypes, testing,
+  security and dependency hygiene, performance, clippy/lint discipline, pre-commit checklist.
+  HTTP-server sections apply to Axum + Diesel + utoipa APIs: handler design,
+  Diesel models and migrations, Tower middleware, server hardening, API patterns, resilience.
+  Use when: writing any Rust code — CLI, library, handlers, models, migrations, tests —
+  or reviewing Rust code quality.
+  Not for: HTTP contract design (use `/api-design`), domain modeling (use `/domain-design`),
+  cross-cutting web security (use `/web-security`).
+version: 3.2.0
+date: 2026-05-13
 user-invocable: true
 ---
 
 # Rust Development
 
-Implements the API Design skill conventions using Axum + Diesel + utoipa. See that skill for HTTP semantics, error format, status codes, pagination contracts, security patterns, and DX principles.
+Rust development conventions and quality discipline. Based on industry best practices from Cloudflare, Discord, AWS, and the broader Rust ecosystem.
 
-Comprehensive Rust guidance for building production-quality Axum + Diesel APIs. Based on industry best practices from Cloudflare, Discord, AWS, and the broader Rust ecosystem.
+> **Scope boundary:** Universal Rust guidance lives in §1, §2, §4, §7, §12, §13, §14, §17, §18 — applies to all Rust code (CLI, library, service). HTTP-server guidance lives in §3, §5, §6, §8–§11, §15, §16 — specific to Axum + Diesel + utoipa APIs. For HTTP contract decisions (status codes, pagination, error format) see `/api-design`. For domain modeling see `/domain-design`. For cross-cutting web security see `/web-security`.
 
 ---
 

--- a/claude/skills/rust/SKILL.md
+++ b/claude/skills/rust/SKILL.md
@@ -3,16 +3,18 @@ name: rust
 description: >
   Rust development skill — conventions and quality discipline for any Rust code.
   Universal sections apply to all Rust (CLI, library, service): crate-level safety,
-  naming, error handling, validation, domain types and newtypes, testing,
-  security and dependency hygiene, performance, clippy/lint discipline, pre-commit checklist.
+  naming, error handling, validation, domain types and newtypes,
+  Diesel models, transactions, and migrations (when using Diesel),
+  testing, security and dependency hygiene, performance,
+  clippy/lint discipline, pre-commit checklist.
   HTTP-server sections apply to Axum + Diesel + utoipa APIs: handler design,
-  Diesel models and migrations, Tower middleware, server hardening, API patterns, resilience.
+  input extractor patterns, Tower middleware, server hardening, API patterns, resilience.
   Use when: writing any Rust code — CLI, library, handlers, models, migrations, tests —
   or reviewing Rust code quality.
   Not for: HTTP contract design (use `/api-design`), domain modeling (use `/domain-design`),
   cross-cutting web security (use `/web-security`).
-version: 3.2.0
-date: 2026-05-13
+version: 3.3.0
+date: 2026-05-14
 user-invocable: true
 ---
 
@@ -20,7 +22,7 @@ user-invocable: true
 
 Rust development conventions and quality discipline. Based on industry best practices from Cloudflare, Discord, AWS, and the broader Rust ecosystem.
 
-> **Scope boundary:** Universal Rust guidance lives in §1, §2, §4, §7, §12, §13, §14, §17, §18 — applies to all Rust code (CLI, library, service). HTTP-server guidance lives in §3, §5, §6, §8–§11, §15, §16 — specific to Axum + Diesel + utoipa APIs. For HTTP contract decisions (status codes, pagination, error format) see `/api-design`. For domain modeling see `/domain-design`. For cross-cutting web security see `/web-security`.
+> **Scope boundary:** Universal Rust guidance lives in §1, §2, §4, §6, §7, §8, §9, §12, §13, §14, §17, §18 — applies to all Rust code (CLI, library, service). Diesel-specific sections (§6 models, §8 transactions, §9 migrations) apply to any project using Diesel, not just HTTP services. HTTP-server guidance lives in §3, §5, §10, §11, §15, §16 — specific to Axum + Diesel + utoipa APIs. For HTTP contract decisions (status codes, pagination, error format) see `/api-design`. For domain modeling see `/domain-design`. For cross-cutting web security see `/web-security`.
 
 ---
 

--- a/claude/skills/saas-product/SKILL.md
+++ b/claude/skills/saas-product/SKILL.md
@@ -1,13 +1,16 @@
 ---
 name: saas-product
-description: |
+description: >
   SaaS product design methodology for building user-facing application features.
   Covers: onboarding, empty states, billing UX, feature gating, dashboard design,
   notification patterns, settings/admin UX, audit trails, loading states, multi-tenancy.
   Use when: designing new SaaS features, creating dashboards, planning onboarding flows,
   or reviewing product-level UX decisions.
-version: 1.0.0
-date: 2026-02-28
+  Not for: design tokens and accessibility (use `/ux-design`),
+  React component patterns (use `/react`), API contracts behind features (use `/api-design`),
+  domain modeling (use `/domain-design`).
+version: 1.1.0
+date: 2026-05-13
 user-invocable: true
 ---
 
@@ -15,7 +18,7 @@ user-invocable: true
 
 Methodology for building production SaaS features that drive user adoption and retention. Focused on patterns that reduce time-to-value and handle the complexity of multi-tenant, subscription-based applications.
 
-For design system tokens and accessibility, see `/ux-design`. For React component patterns, see `/react`. For API contracts behind features, see `/api-design`. For domain modeling, see `/domain-design`.
+> **Scope boundary:** For design system tokens and accessibility, see `/ux-design`. For React component patterns, see `/react`. For API contracts behind features, see `/api-design`. For domain modeling, see `/domain-design`.
 
 ---
 

--- a/claude/skills/typescript/SKILL.md
+++ b/claude/skills/typescript/SKILL.md
@@ -1,19 +1,23 @@
 ---
 name: typescript
-description: |
+description: >
   TypeScript language patterns, testing methodology, and build tooling for production applications.
   Covers: type safety, testing (Vitest/Playwright), performance optimization,
   security practices, linting, module patterns, and build configuration.
   Use when: configuring TypeScript strictness, writing tests, optimizing bundles,
   reviewing security, or setting up build tooling.
-version: 2.0.0
-date: 2026-02-28
+  Not for: React component patterns (use `/react`), route data loading (use `/react-router`),
+  component design and accessibility (use `/ux-design`), responsive CSS (use `/css-responsive`).
+version: 2.1.0
+date: 2026-05-13
 user-invocable: true
 ---
 
 # TypeScript Language & Build Tooling
 
-For React-specific patterns (hooks, state, composition), see the React skill (`/react`). For React Router loaders, actions, and data patterns, see the React Router skill (`/react-router`). For component design, form UX, and accessibility, see the UX Design skill (`/ux-design`). For CSS and responsive patterns, see the CSS & Responsive skill (`/css-responsive`).
+TypeScript language patterns, testing methodology, and build tooling for production applications.
+
+> **Scope boundary:** For React-specific patterns (hooks, state, composition), see `/react`. For React Router loaders, actions, and data patterns, see `/react-router`. For component design, form UX, and accessibility, see `/ux-design`. For CSS and responsive patterns, see `/css-responsive`.
 
 ---
 

--- a/claude/skills/ux-design/SKILL.md
+++ b/claude/skills/ux-design/SKILL.md
@@ -1,14 +1,17 @@
 ---
 name: ux-design
-description: |
+description: >
   Design system methodology and UX engineering for production applications.
   Covers: design token architecture, visual hierarchy, component API design,
   form UX depth, ARIA widget patterns, motion/animation, dark mode strategy,
   theming, icon systems, and data visualization UX.
   Use when: building design systems, implementing complex form flows,
   adding animation, designing data visualizations, or auditing accessibility.
-version: 1.0.0
-date: 2026-02-28
+  Not for: responsive layout and breakpoints (use `/css-responsive`),
+  product-level patterns like onboarding or billing (use `/saas-product`),
+  React hooks and state (use `/react`).
+version: 1.1.0
+date: 2026-05-13
 user-invocable: true
 ---
 
@@ -16,7 +19,7 @@ user-invocable: true
 
 Canonical reference for design system engineering, accessibility, and UX patterns. This skill absorbs and expands component design, form handling, and accessibility guidance — these topics live here, not in language-specific skills.
 
-For responsive CSS and Tailwind patterns, see `/css-responsive`. For SaaS-specific product patterns, see `/saas-product`. For React hooks and state, see `/react`.
+> **Scope boundary:** For responsive CSS and Tailwind patterns, see `/css-responsive`. For SaaS-specific product patterns, see `/saas-product`. For React hooks and state, see `/react`.
 
 ---
 

--- a/claude/skills/web-security/SKILL.md
+++ b/claude/skills/web-security/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: web-security
-description: |
+description: >
   Browser-facing and cross-cutting web security skill for production applications.
   Covers: CSRF, XSS, CSP, cookie security, CORS, session management, authentication,
   JWT security, OAuth 2.1, SSRF, security headers, input validation, dependency scanning,

--- a/rcrc
+++ b/rcrc
@@ -1,2 +1,3 @@
 EXCLUDES="README.md .githooks"
 DOTFILES_DIRS="${HOME}/Workspace/tgautier/dotfiles ${HOME}/Workspace/tgautier/dotfiles-private"
+SYMLINK_DIRS="claude/skills claude/rules claude/hooks"


### PR DESCRIPTION
## Summary

Strengthens the Claude config system in five concerns:

- **Sync hygiene** (#163) — `rcrc` `SYMLINK_DIRS` so `claude/{skills,rules,hooks}` are linked as whole directories, eliminating per-file drift. Recovered `roborev-review-reminder.sh` which lived only in runtime.
- **Skill-triggers enforcement** (#164) — new `PreToolUse` hook (`skill-trigger-reminder.sh`) injects a routing reminder into context on every `Edit`/`Write` whose path matches a row in the triggers table. Routing went from advisory to enforced. File-pattern table extended with rows for Rust, React, TypeScript, CSS, Phoenix, OpenAPI.
- **Skill scope audit** (#165) — rewrote descriptions across all 20 global skills to remove self-narrowing (most importantly `/rust`, which appeared not to apply to non-HTTP code), added explicit "Not for:" boundaries, standardized YAML block scalars on `>` (folded), filled missing `/project-audit` frontmatter.
- **Rules split** (#166) — `task-lifecycle.md` (87 lines, over cap) split into `task-lifecycle.md` + new `findings-capture.md` + new `quality-principles.md`. `skill-triggers.md` (85 lines, over cap) split into `skill-triggers.md` (routing tables) + new `skill-routing.md` (composite workflows + disambiguation). All resulting rule files under the 80-line cap.
- **Hook input contract** (#167) — both existing roborev hooks (`roborev-gate.sh`, `roborev-review-reminder.sh`) read from `${TOOL_INPUT:-}` env var, which Claude Code never sets. Empirical diagnostic (logged on this branch) confirmed input arrives via stdin. Both hooks fixed to read stdin and parse `.tool_input.command`. `roborev-gate.sh`, which had been silently allowing every push, now actually gates. `roborev-review-reminder.sh` output also switched to `hookSpecificOutput.additionalContext` JSON.

Verified end-to-end: the skill-trigger hook fired and emitted reminders on every `claude/**` edit across this PR's history. The roborev gate now blocks pushes when reviews are missing (tested with a synthesized payload for a fake branch) and allows pushes when all 3 agents have done reviews.

## Test plan

- [x] `just ci` passes (shellcheck, markdownlint, ruby, mise)
- [x] Skill-trigger hook fires on `.rs`, `.tsx`, `.md`, `.css`, file edits — verified `[skill-trigger]` system reminders throughout this PR's session
- [x] `roborev-gate.sh` blocks a push when the branch has no reviews — verified via synthesized stdin payload with a fake branch name
- [x] `roborev-gate.sh` allows a push when all 3 agents have done reviews — verified via the actual push of this branch
- [x] `roborev-review-reminder.sh` produces valid JSON output for `roborev show` commands — verified via pipe-test
- [x] All rule files under 80-line cap — `wc -l claude/rules/*.md`
- [x] Skill listing reflects updated descriptions — verified via the listing emitted on every Edit
- [x] Multi-agent reviews (copilot, claude-code, codex) ran 4 rounds; two agents clean at convergence

## Deferred findings

- CLAUDE.md double-triggers `/claude-authoring` and `/markdown` — tracked in #168. Behavior is defensible (CLAUDE.md is markdown); whether to suppress one of the triggers or amend the table is a focused decision for its own PR.

## Dismissed findings

- codex × 3 rounds: "hooks should use `$TOOL_INPUT`" — see [rationale](https://github.com/tgautier/dotfiles/pull/169#issuecomment-4445737336). Verified-wrong via direct measurement (`TOOL_INPUT env: [<unset>]`, stdin populated).
- codex: hook globs miss repo-root-relative paths — see [rationale](https://github.com/tgautier/dotfiles/pull/169#issuecomment-4445738661). Doesn't apply in practice; Claude Code consistently passes absolute paths.
- copilot: `SYMLINK_DIRS` could shadow `dotfiles-private` files — see [rationale](https://github.com/tgautier/dotfiles/pull/169#issuecomment-4445739682). Verified inapplicable; `dotfiles-private` has no `claude/` directory.

Fixes #163
Fixes #164
Fixes #165
Fixes #166
Fixes #167
Addresses #168