### PR TITLE
feat(claude): add versioning rule (SemVer policy + release procedure)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ Global rules (`claude/rules/`) are symlinked from this repo to all projects:
 | `ci-integrity.md` | CI must reflect reality — no silencing failures |
 | `secrets.md` | Never commit credentials outside dotfiles-private |
 | `shell.md` | zsh `!` corruption, jq compatibility |
+| `versioning.md` | SemVer policy, changelog format, release procedure |
 
 Skills (`claude/skills/`) provide on-demand methodology invoked via `/skill-name`. Routing is defined in `skill-triggers.md` and `skill-routing.md`.
 

--- a/claude/rules/git-conventions.md
+++ b/claude/rules/git-conventions.md
@@ -17,6 +17,7 @@
 - Never add "Generated with Claude Code" or similar footers to PRs
 - Use conventional commit format: `type(scope): description`
   - `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `ci`, `perf`
+- A trailing `!` (`feat!:`) or a `BREAKING CHANGE:` line marks a breaking change; commit types drive version bumps per `claude/rules/versioning.md`
 - Keep the first line under 72 characters
 - Only commit when explicitly asked
 

--- a/claude/rules/quality-principles.md
+++ b/claude/rules/quality-principles.md
@@ -18,3 +18,10 @@ assess, research, plan, implement, verify, and review.
   If the check takes under 10 seconds you have no excuse to skip it.
   Confident-but-unverified assertions force the user into a fact-checker
   role that defeats the whole point of having you here.
+- **Docs reflect reality** — any change that alters behavior, stack, status,
+  scope, or version invalidates docs. Grep the repo (`README.md`, `CLAUDE.md`,
+  `docs/**`, `CHANGELOG.md`) for the affected concept and update every hit
+  in the *same* PR. Stale docs are worse than absent docs: they mislead the
+  reader with confidence. If you pivoted (TS → Rust, single → workspace, v1
+  → v1.x), assume the original docs are now wrong somewhere and audit them
+  end-to-end before declaring the task done.

--- a/claude/rules/task-lifecycle.md
+++ b/claude/rules/task-lifecycle.md
@@ -45,7 +45,7 @@ For plan quality methodology → `/code-planning`.
 - **Staff engineer bar** — "Would a staff engineer approve this?"
 - **Demand elegance** — "Is there a more elegant way?" If yes, propose it to the user — don't refactor without approval
 - **Diff against intent** — does the change do exactly what was asked? No more, no less?
-- **CLAUDE.md drift check** — if the PR adds new files/config/rules, verify CLAUDE.md still reflects reality
+- **Doc drift check** — verify every doc that the change touches still matches reality: `README.md`, `CLAUDE.md`, `docs/**`, `CHANGELOG.md`. Grep for the affected concept; update every hit in the same PR. See the "Docs reflect reality" principle in `claude/rules/quality-principles.md`.
 
 ### Failing tests are blockers
 

--- a/claude/rules/versioning.md
+++ b/claude/rules/versioning.md
@@ -1,0 +1,60 @@
+# Versioning
+
+All releasable artifacts follow [Semantic Versioning 2.0.0](https://semver.org). The version lives in a single canonical location per project (Cargo workspace `[workspace.package].version`, `package.json`, `pubspec.yaml`, `mix.exs`, etc.) and propagates from there.
+
+## Format
+
+`MAJOR.MINOR.PATCH[-PRERELEASE]`.
+
+| Bump | When (≥ 1.0.0) | When (0.x.y, pre-1.0) |
+| --- | --- | --- |
+| MAJOR | Breaking change to public API, CLI flags, on-disk format, schema, wire protocol | n/a — stay 0.x |
+| MINOR | Backwards-compatible feature | Any user-visible change, including breaking ones (pre-1.0 caveat) |
+| PATCH | Bug fix, internal refactor, no surface change | Bug fix, internal refactor |
+
+**Pre-1.0 is unstable by definition.** Breaking changes are allowed at any minor bump. The project's `README.md` / `CHANGELOG.md` must call out breaking changes explicitly so users notice without reading the diff.
+
+## Commit type → version bump
+
+Conventional commits map to bumps (consistent with the `git-conventions` rule):
+
+- `fix:` / `perf:` → PATCH
+- `feat:` → MINOR
+- `feat!:` or any commit with `BREAKING CHANGE:` in the body → MAJOR (pre-1.0: still MINOR; document in `CHANGELOG.md`)
+- `docs:` / `chore:` / `test:` / `refactor:` (no behavior change) → no bump on their own; ride the next release
+
+Multiple commits between releases collapse to the highest bump implied by any of them.
+
+## Changelog
+
+Every project keeps a `CHANGELOG.md` at the root, in [Keep a Changelog](https://keepachangelog.com) format:
+
+- `## [Unreleased]` at the top accumulates entries as work lands.
+- On release: rename `[Unreleased]` → `[X.Y.Z] - YYYY-MM-DD`, create a new empty `[Unreleased]` above it.
+- Group entries under `### Added`, `### Changed`, `### Deprecated`, `### Removed`, `### Fixed`, `### Security`.
+- Reference issues/PRs inline.
+
+## Release procedure
+
+1. **Bump the version** in the canonical location, no other places — derive everywhere else.
+2. **Update `CHANGELOG.md`**: move `[Unreleased]` content under the new version heading; date it.
+3. **Commit** with `chore(release): vX.Y.Z`.
+4. **Tag** with `git tag vX.Y.Z` (annotated, signed if signing is configured). Tag and crate/package versions must agree.
+5. **Push** the tag (`git push origin vX.Y.Z`) and the commit. The tag is the immutable artifact.
+6. **GitHub release** (`gh release create vX.Y.Z --notes-from-tag` or with `--notes-file CHANGELOG.md` excerpt). Releases attach binaries / artifacts if the project ships them.
+
+Never reuse a tag. If a release is broken, ship `vX.Y.Z+1` (PATCH bump) — never `git tag -f`.
+
+## Workspace projects
+
+Cargo / pnpm / Pub workspaces have a choice: single workspace-wide version vs per-package independent versions. Default to **single workspace version** — simpler bookkeeping, one tag per release. Switch to per-package only when one of the crates is published independently and needs its own cadence; document the switch in the project's `CLAUDE.md`.
+
+## Anti-patterns
+
+- Bumping the version in `Cargo.toml` without a corresponding `CHANGELOG.md` entry.
+- Releasing without tagging — leaves no immutable reference for rollback or downstream pinning.
+- Tagging without pushing — local-only tags are lost on machine swap.
+- Force-pushing a tag (`git tag -f`) or moving an existing tag.
+- Treating `0.x.y` as stable — pre-1.0 versions exist precisely so the API can churn.
+- Bumping MAJOR for refactors that don't change the public surface.
+- Skipping versions ("we went 0.3 → 0.5 to match the issue tracker"). Versions are not labels.

--- a/claude/rules/versioning.md
+++ b/claude/rules/versioning.md
@@ -39,7 +39,7 @@ Every project keeps a `CHANGELOG.md` at the root, in [Keep a Changelog](https://
 1. **Bump the version** in the canonical location, no other places — derive everywhere else.
 2. **Update `CHANGELOG.md`**: move `[Unreleased]` content under the new version heading; date it.
 3. **Commit** with `chore(release): vX.Y.Z`.
-4. **Tag** with `git tag vX.Y.Z` (annotated, signed if signing is configured). Tag and crate/package versions must agree.
+4. **Tag** with `git tag -a vX.Y.Z -m "vX.Y.Z"` (annotated) — or `git tag -s vX.Y.Z -m "vX.Y.Z"` if commit signing is configured. Plain `git tag vX.Y.Z` is lightweight (no tagger / timestamp / message) and breaks signed-tag verification — don't use it. Tag and crate/package versions must agree.
 5. **Push** the tag (`git push origin vX.Y.Z`) and the commit. The tag is the immutable artifact.
 6. **GitHub release** (`gh release create vX.Y.Z --notes-from-tag` or with `--notes-file CHANGELOG.md` excerpt). Releases attach binaries / artifacts if the project ships them.
 


### PR DESCRIPTION
## Summary

Two related global-rule additions, pulled out during the v1 release of `tgautier/playlist-sync` so the conventions are owned centrally instead of being duplicated in each project.

### `claude/rules/versioning.md` (new — 60 lines, under the 80-line cap)

SemVer 2.0 reference, pre-1.0 caveat matrix, conventional-commit → bump mapping, CHANGELOG.md (Keep a Changelog) discipline, full release procedure with annotated/signed tags (`git tag -a -m`), workspace defaults, anti-patterns. One-line cross-reference added to `claude/rules/git-conventions.md` covering `feat!:` / `BREAKING CHANGE:` semantics.

### `claude/rules/quality-principles.md` + `task-lifecycle.md` (modified)

New always-on principle: **Docs reflect reality**. Any change that alters behavior, stack, status, scope, or version invalidates docs — grep the repo for the affected concept and update every hit in the same PR. Calls out pivots (TS → Rust, dropped milestones) as audit triggers. Driven by repeated doc-drift incidents during the playlist-sync v1 release session.

`task-lifecycle.md`'s Verify-stage `CLAUDE.md drift check` broadened to a `Doc drift check` covering `README.md`, `CLAUDE.md`, `docs/**`, `CHANGELOG.md`, with a cross-reference to the new principle so the always-on duty and the per-task verification step stay coherent.

### `CLAUDE.md`

Rules index gets a `versioning.md` row.

## Test plan

- [x] `just lint-markdown` clean
- [x] All modified rules under the 80-line cap (`versioning.md` 60, `quality-principles.md` 27, `task-lifecycle.md` 80)
- [x] Bidirectional cross-references: `versioning.md` ↔ `git-conventions.md`; `quality-principles.md` ↔ `task-lifecycle.md`; both indexed in `CLAUDE.md`
- [x] Roborev clean across all agents (copilot, claude-code, codex) on the final branch head
- [x] CI `Lint` passes

## Origin

The first consumer is `tgautier/playlist-sync` PR #9 (v0.1.0), which adds a `CHANGELOG.md` + `just release X.Y.Z` recipe pointing at the versioning rule, and applies the doc-sync principle across its own README / CLAUDE.md / docs tree.