### PR TITLE
chore(mise): bump tool versions + cross-platform dart backend

### DIFF
--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -3,15 +3,18 @@ not_found_auto_install = true
 trusted_config_paths = ["~/Workspace/tgautier"]
 
 [tools]
-dart = "3.11.6"
-deno = "2.7.14"
+dart = { version = "3.12.1", url = "https://storage.googleapis.com/dart-archive/channels/stable/release/{{ version }}/sdk/dartsdk-{{ os() }}-{{ arch() }}-release.zip", version_list_url = "https://storage.googleapis.com/storage/v1/b/dart-archive/o?prefix=channels/stable/release/&delimiter=/", version_regex = 'channels/stable/release/(\d+\.\d+\.\d+)/' }
+deno = "2.8.1"
+# elixir's -otp-N suffix must match erlang's OTP major. 1.19.x has no -otp-29
+# build (only 1.20.0-rc), so erlang stays on 28.x until a stable elixir-otp-29
+# ships. Bump these two as a pair, never independently.
 elixir = "1.19.5-otp-28"
 erlang = "28.5"
-"vfox:mise-plugins/vfox-flutter" = "3.41.9"
+"vfox:mise-plugins/vfox-flutter" = "3.44.0"
 go = "1.26.3"
-helm = "4.1.4"
+helm = "4.2.0"
 node = "26"
 python = "3.14.5"
-ruby = "4.0.3"
-yarn = "4.14.1"
+ruby = "4.0.5"
+yarn = "4.15.0"
 yq = "4.53.2"


### PR DESCRIPTION
## Summary

Routine mise tool version bumps from `mise upgrade --bump`, split out of the linux-deps-parity work (#173) as a separate concern so the parity PR stayed focused:

- deno 2.7.14 → 2.8.1
- vfox-flutter 3.41.9 → 3.44.0
- helm 4.1.4 → 4.2.0
- ruby 4.0.3 → 4.0.5
- yarn 4.14.1 → 4.15.0
- **dart** 3.11.6 → 3.12.1, switched to an explicit cross-platform archive URL backend (`{{ os() }}`/`{{ arch() }}` templating + `version_list_url` + `version_regex`) so versions resolve from the dart-archive index directly.

**Erlang held at 28.5** (the `--bump` had moved it to 29.0): elixir is pinned to an `-otp-28` build and 1.19.x has no `-otp-29` release (only `1.20.0-rc`), so OTP 29 would break the Elixir runtime. An inline comment now guards the pairing.

## Test plan

- [x] `just ci` passes (shell, markdown, Brewfile, mise lints)
- [x] dart backend verified: `mise ls-remote dart` lists 3.12.1 (173 versions); `mise install dart@3.12.1` resolves the templated URL, downloads, extracts, and runs (`Dart SDK 3.12.1 on linux_x64`)
- [x] erlang/elixir OTP pairing confirmed against `mise ls-remote` (no stable `1.19.x-otp-29` exists)
- [x] dart backend valid on all target platforms — HEAD-checked the templated archive URL for macos-arm64, macos-x64, linux-x64, linux-arm64 (all HTTP 200); mise normalizes os/arch identically to the linux path proven above, so `mise install dart@3.12.1` resolves on each
