### PR TITLE
chore: bump flutter to 3.44.1 + introduce changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this dotfiles repo are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This is a rolling configuration repo with no tagged releases, so entries are
+grouped by **date** rather than by semantic version. Newest first.
+
+## [Unreleased]
+
+## [2026-06-01]
+
+### Changed
+
+- Bump Flutter (`vfox-flutter`) to 3.44.1 ([#175](https://github.com/tgautier/dotfiles/pull/175)).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,16 @@ The `Justfile` defines local CI targets mirroring the GitHub Actions workflow:
 
 Global Claude Code rules and skills (commit conventions, task lifecycle, code-planning, language-specific patterns, etc.) live in `dotfiles-private/claude/` and auto-load via the rcm symlinks at `~/.claude/`. Edit them there.
 
+## Changelog
+
+`CHANGELOG.md` tracks notable changes. This is a rolling repo with no tagged
+releases, so entries are **date-based** (`## [YYYY-MM-DD]`), newest first, in
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. Any
+user-visible change (new tool, version bump, config behavior, removed feature)
+adds an entry under the current date — group it by `Added` / `Changed` /
+`Removed` / `Fixed` and reference the PR. The `[Unreleased]` section holds
+entries not yet dated.
+
 ## Documentation
 
 Detailed guides live in `docs/`:

--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -10,7 +10,7 @@ deno = "2.8.1"
 # ships. Bump these two as a pair, never independently.
 elixir = "1.19.5-otp-28"
 erlang = "28.5"
-"vfox:mise-plugins/vfox-flutter" = "3.44.0"
+"vfox:mise-plugins/vfox-flutter" = "3.44.1"
 go = "1.26.3"
 helm = "4.2.0"
 node = "26"


### PR DESCRIPTION
## Summary

- Bump `vfox-flutter` plugin from `3.44.0` → `3.44.1` (patch).
- Introduce a date-based `CHANGELOG.md` (Keep a Changelog format, no tagged releases) and document the convention in `CLAUDE.md`.

The working tree also carried an `erlang 28.5 → 29.0` bump, which was **dropped**: it would have broken the documented elixir/erlang OTP-pairing invariant (the `-otp-N` suffix must match erlang's OTP major). No stable `elixir-otp-29` exists yet — only `1.20.0-rc.*-otp-29` pre-releases — so erlang stays on `28.5` alongside `elixir 1.19.5-otp-28`.

## Test plan

- [x] `git diff` shows only the flutter line changed in mise config
- [x] `mise install` resolves the flutter plugin at 3.44.1
- [x] `just ci` passes (markdownlint clean on CHANGELOG.md + CLAUDE.md)