### PR TITLE
feat(brew): work/personal Brewfile profiles + setup bootstrap

### DIFF
--- a/.claude/rules/brewfile.md
+++ b/.claude/rules/brewfile.md
@@ -1,23 +1,35 @@
 ---
 paths:
   - Brewfile
+  - Brewfile.work
+  - Brewfile.personal
   - Brewfile.linux
   - Justfile
 ---
 
 # Brewfile Conventions
 
-Both Brewfiles must stay in sync and sorted. Tools enter a machine through exactly one of two channels: a `brew` entry, or the native-installer pattern below — never both.
+The Brewfiles must stay in sync and sorted. Tools enter a machine through exactly one of two channels: a `brew` entry, or the native-installer pattern below — never both.
+
+## Files
+
+- `Brewfile` — macOS **shared base**: every package common to all Macs, plus a profile-overlay tail that merges the machine-specific overlay via `instance_eval`
+- `Brewfile.work` / `Brewfile.personal` — macOS **per-machine overlays**: casks/mas/brew that belong on only that profile. Each Mac picks one via the marker at `~/.config/dotfiles/profile` (set with `just set-profile work|personal`; absent ⇒ `work`)
+- `Brewfile.linux` — Linux base (no casks/mas)
+
+Because the overlay is merged into the same `brew bundle` evaluation, both `brew bundle install` and `brew bundle cleanup` operate on the full per-machine set — cleanup never uninstalls a sibling profile's apps on that machine.
 
 ## Rules
 
-- When adding or removing a package, apply the change to **both** `Brewfile` and `Brewfile.linux` unless the package is platform-specific (casks, Mac App Store apps, or Linux-only tools)
-- Casks (`cask`) and Mac App Store (`mas`) entries only exist in `Brewfile` — they are not available on Linux
-- The macOS `Brewfile` is organized into comment-delimited blocks: `# CLI Tools & Development`, `# Applications`, `# Fonts`, `# Mac App Store Applications`
-- The `Brewfile.linux` is organized into a `# CLI Tools & Development` block (casks and Mac App Store apps are not supported on Linux)
-- Within each block in each Brewfile, entries are sorted alphabetically (a-z) by the package name
+- A package shared by **all** machines goes in the base (`Brewfile` for macOS, and also `Brewfile.linux` unless it's a cask/mas or platform-specific tool)
+- A package for **one Mac profile only** goes in `Brewfile.work` or `Brewfile.personal` — never in the shared `Brewfile` base
+- Casks (`cask`) and Mac App Store (`mas`) entries never appear in `Brewfile.linux` — they are not available on Linux
+- The macOS `Brewfile` base is organized into comment-delimited blocks: `# CLI Tools & Development`, `# Applications`, `# Fonts`, `# Mac App Store Applications`. The overlays use `# Applications` and `# Mac App Store Applications` blocks
+- `Brewfile.linux` is organized into a `# CLI Tools & Development` block
+- Within each block in each file, entries are sorted alphabetically (a-z) by package name
 - Tap entries (`tap`) come before all blocks
 - For tap-prefixed formulae (e.g., `brew "terror/tap/just-lsp"`), sort by the full string including the tap prefix
+- Keep `lint-brewfile` in the `Justfile` in sync with this file set — every Brewfile gets a `ruby -c` check
 
 ## Native-installer tools
 

--- a/.claude/rules/brewfile.md
+++ b/.claude/rules/brewfile.md
@@ -14,7 +14,7 @@ The Brewfiles must stay in sync and sorted. Tools enter a machine through exactl
 ## Files
 
 - `Brewfile` — macOS **shared base**: every package common to all Macs, plus a profile-overlay tail that merges the machine-specific overlay via `instance_eval`
-- `Brewfile.work` / `Brewfile.personal` — macOS **per-machine overlays**: casks/mas/brew that belong on only that profile. Each Mac picks one via the marker at `~/.config/dotfiles/profile` (set with `just set-profile work|personal`; `just setup` writes it on first run, defaulting to `work`). An absent/empty/unknown marker makes `brew bundle` fail loud — never silently merge the wrong overlay, since `brew bundle cleanup --force` would then uninstall every overlay app
+- `Brewfile.work` / `Brewfile.personal` — macOS **per-machine overlays**: casks/mas/brew that belong on only that profile. Each Mac picks one via the marker at `~/.config/dotfiles/profile` (set with `just set-profile work|personal`; interactive `just setup` prompts on first run, default `work` — non-interactive runs fail instead of guessing). An absent/empty/unknown marker makes `brew bundle` fail loud — never silently merge the wrong overlay, since `brew bundle cleanup --force` would then uninstall every overlay app
 - `Brewfile.linux` — Linux base (no casks/mas)
 
 Because the overlay is merged into the same `brew bundle` evaluation, both `brew bundle install` and `brew bundle cleanup` operate on the full per-machine set — cleanup never uninstalls a sibling profile's apps on that machine.

--- a/.claude/rules/brewfile.md
+++ b/.claude/rules/brewfile.md
@@ -14,7 +14,7 @@ The Brewfiles must stay in sync and sorted. Tools enter a machine through exactl
 ## Files
 
 - `Brewfile` — macOS **shared base**: every package common to all Macs, plus a profile-overlay tail that merges the machine-specific overlay via `instance_eval`
-- `Brewfile.work` / `Brewfile.personal` — macOS **per-machine overlays**: casks/mas/brew that belong on only that profile. Each Mac picks one via the marker at `~/.config/dotfiles/profile` (set with `just set-profile work|personal`; absent ⇒ `work`)
+- `Brewfile.work` / `Brewfile.personal` — macOS **per-machine overlays**: casks/mas/brew that belong on only that profile. Each Mac picks one via the marker at `~/.config/dotfiles/profile` (set with `just set-profile work|personal`; `just setup` writes it on first run, defaulting to `work`). An absent/empty/unknown marker makes `brew bundle` fail loud — never silently merge the wrong overlay, since `brew bundle cleanup --force` would then uninstall every overlay app
 - `Brewfile.linux` — Linux base (no casks/mas)
 
 Because the overlay is merged into the same `brew bundle` evaluation, both `brew bundle install` and `brew bundle cleanup` operate on the full per-machine set — cleanup never uninstalls a sibling profile's apps on that machine.
@@ -29,7 +29,7 @@ Because the overlay is merged into the same `brew bundle` evaluation, both `brew
 - Within each block in each file, entries are sorted alphabetically (a-z) by package name
 - Tap entries (`tap`) come before all blocks
 - For tap-prefixed formulae (e.g., `brew "terror/tap/just-lsp"`), sort by the full string including the tap prefix
-- Keep `lint-brewfile` in the `Justfile` in sync with this file set — every Brewfile gets a `ruby -c` check
+- Keep `lint-brewfile` in the `Justfile` in sync with this file set — every Brewfile gets a `ruby -c` check, and the overlay-merge harness must keep evaluating every profile plus the absent-marker failure
 
 ## Native-installer tools
 

--- a/Brewfile
+++ b/Brewfile
@@ -111,41 +111,25 @@ brew "zsh-completions"
 # Applications
 cask "1password"
 cask "1password-cli"
-cask "adobe-creative-cloud"
 cask "android-studio"
-cask "audacity"
 cask "claude"
 ## claude-code: native installer via `just setup` (auto-updates, no deps)
 cask "codex"
 cask "codex-app"
 cask "copilot-cli"
-cask "discord"
 cask "docker-desktop"
-cask "figma"
 cask "firefox"
 cask "gcloud-cli"
 cask "ghostty"
 cask "google-chrome"
 cask "iterm2"
-cask "ledger-wallet"
-cask "linear-linear"
 cask "lm-studio"
-cask "microsoft-auto-update"
-cask "microsoft-office"
-cask "notion"
 cask "obsidian"
 cask "parsec"
 cask "postman"
-cask "proton-mail"
-cask "proton-mail-bridge"
-cask "rectangle"
-cask "rode-central"
-cask "setapp"
 cask "signal"
 cask "slack"
 cask "spotify"
-cask "synology-drive"
-cask "tailscale-app"
 cask "visual-studio-code"
 cask "vlc"
 cask "whatsapp"
@@ -156,10 +140,26 @@ cask "font-source-code-pro"
 
 # Mac App Store Applications
 mas "1Password for Safari", id: 1569813296
-mas "Infuse", id: 1136220934
 mas "Keynote", id: 361285480
-mas "Notion Web Clipper", id: 1559269364
 mas "Numbers", id: 361304891
 mas "Pages", id: 361309726
-mas "Reeder 5", id: 1529448980
 mas "Xcode", id: 497799835
+
+# Profile overlay
+# Everything above is shared by every macOS machine. Machine-specific entries
+# live in Brewfile.work / Brewfile.personal and are merged in here so that
+# `brew bundle` AND `brew bundle cleanup` operate on the full per-machine set.
+# The profile is read from ~/.config/dotfiles/profile (set it with
+# `just set-profile work|personal`); it defaults to "work" when absent, so a
+# fresh machine never installs personal apps by accident.
+profile_path = File.expand_path("~/.config/dotfiles/profile")
+profile = File.exist?(profile_path) ? File.read(profile_path).strip : ""
+profile = "work" if profile.empty?
+# Fail loud on an unknown profile or missing overlay: silently skipping the
+# overlay would let `brew bundle cleanup --force` uninstall every overlay app.
+unless %w[work personal].include?(profile)
+  raise "Unknown profile #{profile.inspect} in #{profile_path} — expected 'work' or 'personal' (just set-profile)"
+end
+overlay = File.expand_path("Brewfile.#{profile}", __dir__)
+raise "Missing overlay #{overlay}" unless File.exist?(overlay)
+instance_eval(File.read(overlay), overlay)

--- a/Brewfile
+++ b/Brewfile
@@ -150,15 +150,15 @@ mas "Xcode", id: 497799835
 # live in Brewfile.work / Brewfile.personal and are merged in here so that
 # `brew bundle` AND `brew bundle cleanup` operate on the full per-machine set.
 # The profile is read from ~/.config/dotfiles/profile (set it with
-# `just set-profile work|personal`); it defaults to "work" when absent, so a
-# fresh machine never installs personal apps by accident.
+# `just set-profile work|personal`; `just setup` writes it on first run,
+# defaulting to "work" so a fresh machine never installs personal apps by
+# accident). An absent, empty, or unknown marker fails loud: silently merging
+# the wrong overlay would let `brew bundle cleanup --force` (in `just
+# update-brew`) uninstall every overlay app on the machine.
 profile_path = File.expand_path("~/.config/dotfiles/profile")
 profile = File.exist?(profile_path) ? File.read(profile_path).strip : ""
-profile = "work" if profile.empty?
-# Fail loud on an unknown profile or missing overlay: silently skipping the
-# overlay would let `brew bundle cleanup --force` uninstall every overlay app.
 unless %w[work personal].include?(profile)
-  raise "Unknown profile #{profile.inspect} in #{profile_path} — expected 'work' or 'personal' (just set-profile)"
+  raise "No valid machine profile in #{profile_path} (got #{profile.inspect}) — run 'just set-profile work|personal'"
 end
 overlay = File.expand_path("Brewfile.#{profile}", __dir__)
 raise "Missing overlay #{overlay}" unless File.exist?(overlay)

--- a/Brewfile
+++ b/Brewfile
@@ -150,9 +150,10 @@ mas "Xcode", id: 497799835
 # live in Brewfile.work / Brewfile.personal and are merged in here so that
 # `brew bundle` AND `brew bundle cleanup` operate on the full per-machine set.
 # The profile is read from ~/.config/dotfiles/profile (set it with
-# `just set-profile work|personal`; `just setup` writes it on first run,
-# defaulting to "work" so a fresh machine never installs personal apps by
-# accident). An absent, empty, or unknown marker fails loud: silently merging
+# `just set-profile work|personal`; interactive `just setup` prompts for it
+# on first run, defaulting the answer to "work" so a fresh machine never
+# installs personal apps by accident — non-interactive runs fail instead of
+# guessing). An absent, empty, or unknown marker fails loud: silently merging
 # the wrong overlay would let `brew bundle cleanup --force` (in `just
 # update-brew`) uninstall every overlay app on the machine.
 profile_path = File.expand_path("~/.config/dotfiles/profile")

--- a/Brewfile.personal
+++ b/Brewfile.personal
@@ -1,0 +1,29 @@
+# Personal-only macOS overlay — merged into Brewfile when the machine profile
+# is "personal" (see the profile-overlay block in Brewfile). Add casks/mas/brew
+# here that belong ONLY on the personal laptop. Shared apps stay in Brewfile.
+#
+# Keep entries sorted alphabetically within each block, per
+# .claude/rules/brewfile.md.
+
+# Applications
+cask "adobe-creative-cloud"
+cask "audacity"
+cask "discord"
+cask "figma"
+cask "ledger-wallet"
+cask "linear-linear"
+cask "microsoft-auto-update"
+cask "microsoft-office"
+cask "notion"
+cask "proton-mail"
+cask "proton-mail-bridge"
+cask "rectangle"
+cask "rode-central"
+cask "setapp"
+cask "synology-drive"
+cask "tailscale-app"
+
+# Mac App Store Applications
+mas "Infuse", id: 1136220934
+mas "Notion Web Clipper", id: 1559269364
+mas "Reeder 5", id: 1529448980

--- a/Brewfile.work
+++ b/Brewfile.work
@@ -1,0 +1,10 @@
+# Work-only macOS overlay — merged into Brewfile when the machine profile is
+# "work" (see the profile-overlay block in Brewfile). Add casks/mas/brew here
+# that belong ONLY on the work laptop. Shared apps stay in Brewfile.
+#
+# Keep entries sorted alphabetically within each block, per
+# .claude/rules/brewfile.md.
+
+# Applications
+
+# Mac App Store Applications

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@ grouped by **date** rather than by semantic version. Newest first.
 - `uv` in `Brewfile` and `Brewfile.linux`.
 - `codex-app` and `lm-studio` casks in `Brewfile` (macOS).
 - Per-machine macOS Brewfile profiles: `Brewfile.work` and `Brewfile.personal`
-  overlays merged into `Brewfile` based on `~/.config/dotfiles/profile` (absent
-  defaults to `work`). Set it with `just set-profile work|personal`.
+  overlays merged into `Brewfile` based on `~/.config/dotfiles/profile`. Set it
+  with `just set-profile work|personal` (`just setup` writes it on first run,
+  defaulting to `work`); `brew bundle` fails loud when the marker is absent or
+  invalid so a forced cleanup can never uninstall the overlay apps.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ grouped by **date** rather than by semantic version. Newest first.
   in the `setup` recipe) in `.claude/rules/brewfile.md`.
 - `uv` in `Brewfile` and `Brewfile.linux`.
 - `codex-app` and `lm-studio` casks in `Brewfile` (macOS).
+- Per-machine macOS Brewfile profiles: `Brewfile.work` and `Brewfile.personal`
+  overlays merged into `Brewfile` based on `~/.config/dotfiles/profile` (absent
+  defaults to `work`). Set it with `just set-profile work|personal`.
 
 ### Changed
 
@@ -22,6 +25,9 @@ grouped by **date** rather than by semantic version. Newest first.
   (hardcoded home path) in favor of a guarded, portable line in `zprofile`.
 - Bump mise tool versions: deno 2.8.2, elixir 1.20.0-otp-29 + erlang 29.0
   (OTP 28 → 29, bumped as a pair), go 1.26.4, yarn 4.16.0.
+- `just setup` is now a full idempotent bootstrap — selects the machine profile,
+  then installs packages, links dotfiles, installs mise runtimes, and enables
+  git hooks and tools — so a fresh machine is one command after `brew install just`.
 
 ## [2026-06-01]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@ grouped by **date** rather than by semantic version. Newest first.
 - `codex-app` and `lm-studio` casks in `Brewfile` (macOS).
 - Per-machine macOS Brewfile profiles: `Brewfile.work` and `Brewfile.personal`
   overlays merged into `Brewfile` based on `~/.config/dotfiles/profile`. Set it
-  with `just set-profile work|personal` (`just setup` writes it on first run,
-  defaulting to `work`); `brew bundle` fails loud when the marker is absent or
-  invalid so a forced cleanup can never uninstall the overlay apps.
+  with `just set-profile work|personal` (interactive `just setup` prompts on
+  first run, default `work`; non-interactive runs fail instead of guessing);
+  `brew bundle` fails loud when the marker is absent or invalid so a forced
+  cleanup can never uninstall the overlay apps.
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,8 @@ rcup
 # Install macOS packages (auto-selects the work/personal overlay)
 brew bundle --file=~/Workspace/tgautier/dotfiles/Brewfile
 
-# Declare this Mac's profile (work|personal); absent defaults to work
+# Declare this Mac's profile (work|personal) — required before brew bundle;
+# `just setup` writes it on first run (default: work)
 just set-profile personal
 
 # Install Linux packages

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,11 @@ Cross-platform personal dotfiles for macOS and Linux/WSL2, managed with **rcm** 
 # Link/update dotfiles after changes (uses DOTFILES_DIRS from rcrc)
 rcup
 
-# Install macOS packages
+# Install macOS packages (auto-selects the work/personal overlay)
 brew bundle --file=~/Workspace/tgautier/dotfiles/Brewfile
+
+# Declare this Mac's profile (work|personal); absent defaults to work
+just set-profile personal
 
 # Install Linux packages
 brew bundle --file=~/Workspace/tgautier/dotfiles/Brewfile.linux
@@ -34,7 +37,7 @@ just ci
 # Update everything (brew, mas, mise, rust)
 just update
 
-# Enable pre-commit hook and install native tools
+# Bootstrap a machine: profile, packages, symlinks, runtimes, hooks, tools
 just setup
 ```
 
@@ -43,7 +46,7 @@ just setup
 This repo targets **three platforms**: macOS, Linux, and WSL2. Every change must consider all three:
 
 - Shell config: guard platform-specific code with `$PLATFORM` checks (set in `zshenv`)
-- Brewfiles: edit **both** `Brewfile` and `Brewfile.linux` for CLI tools (see `.claude/rules/brewfile.md`)
+- Brewfiles: shared CLI tools go in **both** `Brewfile` and `Brewfile.linux`; macOS apps that belong to only one Mac go in `Brewfile.work` / `Brewfile.personal` (see `.claude/rules/brewfile.md`)
 - tmux: use `if-shell` platform detection for OS-specific commands (clipboard, terminfo)
 - Never assume macOS-only tools exist (`pbcopy`, `open`) — provide WSL (`clip.exe`) and Linux (`xclip`) alternatives
 
@@ -73,7 +76,7 @@ The `Justfile` defines local CI targets mirroring the GitHub Actions workflow:
 
 - `just ci` — runs all checks (shell, markdown, Brewfile, mise)
 - `just lint-shell` — shellcheck on `bin/*` and zsh files
-- `just setup` — enables `.githooks/pre-commit` and installs native tools
+- `just setup` — full machine bootstrap (profile, packages, symlinks, runtimes, hooks, tools)
 
 ### tmux
 
@@ -91,7 +94,7 @@ The `Justfile` defines local CI targets mirroring the GitHub Actions workflow:
 
 | Rule | Scope | Purpose |
 | --- | --- | --- |
-| `brewfile.md` | `Brewfile`, `Brewfile.linux`, `Justfile` | Dual-Brewfile sync, alphabetical sorting, native-installer pattern (`just setup` as single source of truth) |
+| `brewfile.md` | `Brewfile`, `Brewfile.work`, `Brewfile.personal`, `Brewfile.linux`, `Justfile` | Brewfile sync, work/personal overlays, alphabetical sorting, native-installer pattern (`just setup` as single source of truth) |
 
 Global Claude Code rules and skills (commit conventions, task lifecycle, code-planning, language-specific patterns, etc.) live in `dotfiles-private/claude/` and auto-load via the rcm symlinks at `~/.claude/`. Edit them there.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ rcup
 brew bundle --file=~/Workspace/tgautier/dotfiles/Brewfile
 
 # Declare this Mac's profile (work|personal) — required before brew bundle;
-# `just setup` writes it on first run (default: work)
+# interactive `just setup` prompts for it on first run (default: work)
 just set-profile personal
 
 # Install Linux packages

--- a/Justfile
+++ b/Justfile
@@ -153,22 +153,27 @@ lint-brewfile:
       %i[tap brew cask mas].each { |m| dsl.define_singleton_method(m) { |*a, **k| } }
       dsl.instance_eval(File.read(ARGV[0]), ARGV[0])
     '
+    tmp_root="$(mktemp -d)"
+    trap 'rm -rf "$tmp_root"' EXIT
     for profile in work personal; do
-        tmp_home="$(mktemp -d)"
-        mkdir -p "$tmp_home/.config/dotfiles"
-        printf '%s\n' "$profile" > "$tmp_home/.config/dotfiles/profile"
-        (cd /tmp && HOME="$tmp_home" ruby -e "$harness" "$brewfile")
-        rm -rf "$tmp_home"
+        home_dir="$tmp_root/$profile"
+        mkdir -p "$home_dir/.config/dotfiles"
+        printf '%s\n' "$profile" > "$home_dir/.config/dotfiles/profile"
+        (cd /tmp && HOME="$home_dir" ruby -e "$harness" "$brewfile")
         echo "Brewfile merge OK: $profile"
     done
-    # An absent marker must fail loud, never silently bundle the base-only set.
-    tmp_home="$(mktemp -d)"
-    if (cd /tmp && HOME="$tmp_home" ruby -e "$harness" "$brewfile" 2>/dev/null); then
+    # An absent marker must trip the marker guard, never silently bundle the
+    # base-only set — assert the guard's own message, not just any failure.
+    mkdir -p "$tmp_root/absent"
+    if out="$(cd /tmp && HOME="$tmp_root/absent" ruby -e "$harness" "$brewfile" 2>&1)"; then
         echo "ERROR: Brewfile must raise when the profile marker is absent" >&2
-        rm -rf "$tmp_home"
         exit 1
     fi
-    rm -rf "$tmp_home"
+    if ! grep -q 'No valid machine profile' <<<"$out"; then
+        echo "ERROR: absent-marker failure did not come from the marker guard:" >&2
+        echo "$out" >&2
+        exit 1
+    fi
     echo "Brewfile absent-marker raise OK"
 
 # Validate mise config

--- a/Justfile
+++ b/Justfile
@@ -35,7 +35,12 @@ setup: _ensure-profile
     fi
     mise_bin="$(command -v mise || true)"
     [ -z "$mise_bin" ] && [ -x "${HOME}/.local/bin/mise" ] && mise_bin="${HOME}/.local/bin/mise"
-    if [ -n "$mise_bin" ]; then "$mise_bin" install; fi
+    if [ -n "$mise_bin" ]; then
+        "$mise_bin" install
+    else
+        echo "mise not found on PATH or at ~/.local/bin/mise after the install attempt — aborting." >&2
+        exit 1
+    fi
 
     # 4. Git hooks + review tooling.
     git config --local core.hooksPath .githooks
@@ -88,8 +93,12 @@ _link-libsqlite3:
     echo "linked $src -> $HOME/.local/lib/flutter-ffi/libsqlite3.so"
 
 # Ensure a valid Brewfile profile marker exists (macOS only — Brewfile.linux
-# never reads it); prompt on first interactive setup, default to work when
-# non-interactive. No-op when the marker already holds a valid profile.
+# never reads it); prompt on first interactive setup (default: work). A
+# non-interactive run fails instead of defaulting: silently minting a
+# valid-but-wrong marker on an unmigrated personal Mac would let
+# `brew bundle cleanup --force` uninstall every personal app — the exact
+# disaster the Brewfile marker guard exists to prevent.
+# No-op when the marker already holds a valid profile.
 _ensure-profile:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -98,18 +107,19 @@ _ensure-profile:
     fi
     marker="${HOME}/.config/dotfiles/profile"
     current=""
-    [[ -f "$marker" ]] && current="$(tr -d '[:space:]' < "$marker")"
+    # Trim-only (ends), mirroring the Brewfile's String#strip on the same file.
+    [[ -f "$marker" ]] && current="$(sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' "$marker")"
     if [[ "$current" == "work" || "$current" == "personal" ]]; then
         echo "Machine profile already set: $current"
         exit 0
     fi
-    if [[ -t 0 ]]; then
-        printf 'Select machine profile [work/personal] (default: work): '
-        read -r reply
-    else
-        reply=""
-        echo "Non-interactive shell; defaulting machine profile to 'work'."
+    if [[ ! -t 0 ]]; then
+        echo "No machine profile set and stdin is not a terminal." >&2
+        echo "Run 'just set-profile work|personal' first, then re-run 'just setup'." >&2
+        exit 1
     fi
+    printf 'Select machine profile [work/personal] (default: work): '
+    read -r reply
     just set-profile "${reply:-work}"
 
 # Lint shell scripts with ShellCheck
@@ -123,17 +133,21 @@ lint-markdown:
 
 # Set this machine's Brewfile profile (work|personal). Writes the marker the
 # Brewfile reads to pick Brewfile.work / Brewfile.personal — the Brewfile
-# fails loud when the marker is absent; `just setup` defaults it to work.
+# fails loud when the marker is absent; interactive `just setup` prompts
+# for it (default: work).
 set-profile profile:
     #!/usr/bin/env bash
     set -euo pipefail
-    if [[ "{{profile}}" != "work" && "{{profile}}" != "personal" ]]; then
-        echo "Error: profile must be 'work' or 'personal', got '{{profile}}'" >&2
+    # quote() interpolates once as a shell-safe literal; metacharacters in the
+    # argument (e.g. typed at the _ensure-profile prompt) stay inert data.
+    profile={{quote(profile)}}
+    if [[ "$profile" != "work" && "$profile" != "personal" ]]; then
+        echo "Error: profile must be 'work' or 'personal', got '$profile'" >&2
         exit 1
     fi
     mkdir -p "${HOME}/.config/dotfiles"
-    printf '%s\n' "{{profile}}" > "${HOME}/.config/dotfiles/profile"
-    echo "Machine profile set to '{{profile}}' (${HOME}/.config/dotfiles/profile)."
+    printf '%s\n' "$profile" > "${HOME}/.config/dotfiles/profile"
+    echo "Machine profile set to '$profile' (${HOME}/.config/dotfiles/profile)."
     echo "Run 'just update-brew' to sync packages for this profile."
 
 # Check Brewfile Ruby syntax + evaluate the profile-overlay merge logic

--- a/Justfile
+++ b/Justfile
@@ -12,12 +12,43 @@ lint-via-private:
         just -f ~/Workspace/tgautier/dotfiles-private/justfile lint-public-no-arr; \
     fi
 
-# Enable the pre-commit hook and install native tools
-setup:
+# Bootstrap this machine: profile, packages, symlinks, runtimes, hooks, tools (idempotent)
+setup: _ensure-profile
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Prerequisites (just does not exist before them): install Homebrew, clone
+    # this repo (+ dotfiles-private if used), run `brew bundle` once to get `just`.
+    cd "{{dotfiles_dir}}"
+
+    # 1. Packages for this machine's profile (install only; `just update` upgrades).
+    brew bundle install --file="{{brewfile}}"
+
+    # 2. Symlink dotfiles. RCRC points rcm at the repo config so a fresh machine
+    #    (no ~/.rcrc yet) links every DOTFILES_DIRS entry; a missing private repo
+    #    is skipped, not fatal.
+    RCRC="{{dotfiles_dir}}/rcrc" rcup
+
+    # 3. Language runtimes from the pinned mise config. Install mise first if the
+    #    machine doesn't have it yet (matches the README curl bootstrap).
+    if ! command -v mise >/dev/null 2>&1 && [ ! -x "${HOME}/.local/bin/mise" ]; then
+        curl https://mise.run | sh
+    fi
+    mise_bin="$(command -v mise || true)"
+    [ -z "$mise_bin" ] && [ -x "${HOME}/.local/bin/mise" ] && mise_bin="${HOME}/.local/bin/mise"
+    if [ -n "$mise_bin" ]; then "$mise_bin" install; fi
+
+    # 4. Git hooks + review tooling.
     git config --local core.hooksPath .githooks
     if command -v roborev >/dev/null 2>&1; then roborev install-hook; fi
+
+    # 5. Native-installer tools (self-update through their own channels).
     command -v claude >/dev/null 2>&1 || curl -fsSL https://claude.ai/install.sh | bash
     command -v hermes >/dev/null 2>&1 || curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+
+    # 6. Default editor associations (macOS only; no-ops elsewhere).
+    just set-default-editor
+
+    # 7. Linux/WSL: symlink libsqlite3 for Dart/Flutter FFI (no-op on macOS).
     {{ if os() == "macos" { "true" } else { "just _link-libsqlite3" } }}
 
 # Symlink the system libsqlite3 into a dedicated ~/.local/lib/flutter-ffi dir for
@@ -56,6 +87,25 @@ _link-libsqlite3:
     ln -sf "$src" "$HOME/.local/lib/flutter-ffi/libsqlite3.so"
     echo "linked $src -> $HOME/.local/lib/flutter-ffi/libsqlite3.so"
 
+# Ensure a Brewfile profile marker exists; prompt on first interactive setup,
+# default to work when non-interactive. No-op when the marker is already set.
+_ensure-profile:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    marker="${HOME}/.config/dotfiles/profile"
+    if [[ -s "$marker" ]]; then
+        echo "Machine profile already set: $(cat "$marker")"
+        exit 0
+    fi
+    if [[ -t 0 ]]; then
+        printf 'Select machine profile [work/personal] (default: work): '
+        read -r reply
+    else
+        reply=""
+        echo "Non-interactive shell; defaulting machine profile to 'work'."
+    fi
+    just set-profile "${reply:-work}"
+
 # Lint shell scripts with ShellCheck
 lint-shell:
     shellcheck --severity=warning bin/op-ssh-sign bin/kshow bin/kseal
@@ -65,9 +115,25 @@ lint-shell:
 lint-markdown:
     markdownlint-cli2
 
+# Set this machine's Brewfile profile (work|personal). Writes the marker the
+# Brewfile reads to pick Brewfile.work / Brewfile.personal. Absent = work.
+set-profile profile:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ "{{profile}}" != "work" && "{{profile}}" != "personal" ]]; then
+        echo "Error: profile must be 'work' or 'personal', got '{{profile}}'" >&2
+        exit 1
+    fi
+    mkdir -p "${HOME}/.config/dotfiles"
+    printf '%s\n' "{{profile}}" > "${HOME}/.config/dotfiles/profile"
+    echo "Machine profile set to '{{profile}}' (${HOME}/.config/dotfiles/profile)."
+    echo "Run 'just update-brew' to sync packages for this profile."
+
 # Check Brewfile Ruby syntax
 lint-brewfile:
     ruby -c Brewfile
+    ruby -c Brewfile.work
+    ruby -c Brewfile.personal
     ruby -c Brewfile.linux
 
 # Validate mise config

--- a/Justfile
+++ b/Justfile
@@ -31,7 +31,7 @@ setup: _ensure-profile
     # 3. Language runtimes from the pinned mise config. Install mise first if the
     #    machine doesn't have it yet (matches the README curl bootstrap).
     if ! command -v mise >/dev/null 2>&1 && [ ! -x "${HOME}/.local/bin/mise" ]; then
-        curl https://mise.run | sh
+        curl -fsSL https://mise.run | sh
     fi
     mise_bin="$(command -v mise || true)"
     [ -z "$mise_bin" ] && [ -x "${HOME}/.local/bin/mise" ] && mise_bin="${HOME}/.local/bin/mise"
@@ -87,14 +87,20 @@ _link-libsqlite3:
     ln -sf "$src" "$HOME/.local/lib/flutter-ffi/libsqlite3.so"
     echo "linked $src -> $HOME/.local/lib/flutter-ffi/libsqlite3.so"
 
-# Ensure a Brewfile profile marker exists; prompt on first interactive setup,
-# default to work when non-interactive. No-op when the marker is already set.
+# Ensure a valid Brewfile profile marker exists (macOS only — Brewfile.linux
+# never reads it); prompt on first interactive setup, default to work when
+# non-interactive. No-op when the marker already holds a valid profile.
 _ensure-profile:
     #!/usr/bin/env bash
     set -euo pipefail
+    if [[ "$(uname -s)" != "Darwin" ]]; then
+        exit 0
+    fi
     marker="${HOME}/.config/dotfiles/profile"
-    if [[ -s "$marker" ]]; then
-        echo "Machine profile already set: $(cat "$marker")"
+    current=""
+    [[ -f "$marker" ]] && current="$(tr -d '[:space:]' < "$marker")"
+    if [[ "$current" == "work" || "$current" == "personal" ]]; then
+        echo "Machine profile already set: $current"
         exit 0
     fi
     if [[ -t 0 ]]; then
@@ -116,7 +122,8 @@ lint-markdown:
     markdownlint-cli2
 
 # Set this machine's Brewfile profile (work|personal). Writes the marker the
-# Brewfile reads to pick Brewfile.work / Brewfile.personal. Absent = work.
+# Brewfile reads to pick Brewfile.work / Brewfile.personal — the Brewfile
+# fails loud when the marker is absent; `just setup` defaults it to work.
 set-profile profile:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -129,12 +136,40 @@ set-profile profile:
     echo "Machine profile set to '{{profile}}' (${HOME}/.config/dotfiles/profile)."
     echo "Run 'just update-brew' to sync packages for this profile."
 
-# Check Brewfile Ruby syntax
+# Check Brewfile Ruby syntax + evaluate the profile-overlay merge logic
 lint-brewfile:
+    #!/usr/bin/env bash
+    set -euo pipefail
     ruby -c Brewfile
     ruby -c Brewfile.work
     ruby -c Brewfile.personal
     ruby -c Brewfile.linux
+    # Evaluate the merged Brewfile for each profile from a non-repo cwd with
+    # stubbed DSL methods — catches overlay-resolution and fail-loud regressions
+    # that `ruby -c` (syntax only) cannot see.
+    brewfile="$PWD/Brewfile"
+    harness='
+      dsl = Object.new
+      %i[tap brew cask mas].each { |m| dsl.define_singleton_method(m) { |*a, **k| } }
+      dsl.instance_eval(File.read(ARGV[0]), ARGV[0])
+    '
+    for profile in work personal; do
+        tmp_home="$(mktemp -d)"
+        mkdir -p "$tmp_home/.config/dotfiles"
+        printf '%s\n' "$profile" > "$tmp_home/.config/dotfiles/profile"
+        (cd /tmp && HOME="$tmp_home" ruby -e "$harness" "$brewfile")
+        rm -rf "$tmp_home"
+        echo "Brewfile merge OK: $profile"
+    done
+    # An absent marker must fail loud, never silently bundle the base-only set.
+    tmp_home="$(mktemp -d)"
+    if (cd /tmp && HOME="$tmp_home" ruby -e "$harness" "$brewfile" 2>/dev/null); then
+        echo "ERROR: Brewfile must raise when the profile marker is absent" >&2
+        rm -rf "$tmp_home"
+        exit 1
+    fi
+    rm -rf "$tmp_home"
+    echo "Brewfile absent-marker raise OK"
 
 # Validate mise config
 lint-mise:

--- a/README.md
+++ b/README.md
@@ -29,38 +29,34 @@ Cross-platform dotfiles for macOS and Linux/WSL2 Ubuntu, managed with
    ```sh
    mkdir -p ~/Workspace/tgautier
    git clone https://github.com/tgautier/dotfiles.git ~/Workspace/tgautier/dotfiles
+   # Optional: clone the private companion repo alongside it (merged via
+   # DOTFILES_DIRS). If absent, setup links the public repo only.
    ```
 
-3. **Install packages from Brewfile** (includes rcm, just, rustup, 1Password, and everything else):
+3. **Bootstrap and run setup:**
 
    ```sh
-   brew bundle --file=~/Workspace/tgautier/dotfiles/Brewfile
+   brew install just                       # the only package needed by hand
+   cd ~/Workspace/tgautier/dotfiles
+   just setup
    ```
 
-4. **Link dotfiles** (rcm was installed in step 3):
+   `just setup` prompts for the machine profile (work/personal) on first run,
+   then installs all packages for that profile, links every dotfiles repo,
+   installs mise and the pinned runtimes, and enables git hooks and tools.
+   It is idempotent — re-run it anytime.
 
-   ```sh
-   rcup -d ~/Workspace/tgautier/dotfiles
-   ```
-
-5. **Set up 1Password SSH agent:**
+4. **Set up 1Password SSH agent:**
    Open 1Password, sign in, and enable the SSH agent under
    Settings > Developer > SSH Agent.
 
-6. **Switch git remote to SSH** (now that 1Password SSH is configured):
+5. **Switch git remote to SSH** (now that 1Password SSH is configured):
 
    ```sh
    git -C ~/Workspace/tgautier/dotfiles remote set-url origin git@github.com:tgautier/dotfiles.git
    ```
 
-7. **Install mise:**
-
-   ```sh
-   curl https://mise.run | sh
-   mise install
-   ```
-
-8. **Update everything:**
+6. **Keep everything current** (later, for maintenance):
 
    ```sh
    just update
@@ -120,21 +116,23 @@ Cross-platform dotfiles for macOS and Linux/WSL2 Ubuntu, managed with
    ```sh
    mkdir -p ~/Workspace/tgautier
    git clone https://github.com/tgautier/dotfiles.git ~/Workspace/tgautier/dotfiles
+   # Optional: clone the private companion repo alongside it (merged via
+   # DOTFILES_DIRS). If absent, setup links the public repo only.
    ```
 
-6. **Install packages from Brewfile** (includes rcm, just, rustup, and other tools):
+6. **Bootstrap and run setup** (uses `Brewfile.linux` automatically):
 
    ```sh
-   brew bundle --file=~/Workspace/tgautier/dotfiles/Brewfile.linux
+   brew install just                       # the only package needed by hand
+   cd ~/Workspace/tgautier/dotfiles
+   just setup
    ```
 
-7. **Link dotfiles** (rcm was installed in step 6):
+   `just setup` prompts for the machine profile on first run, then installs all
+   packages, links every dotfiles repo, installs mise and the pinned runtimes,
+   and enables git hooks and tools. It is idempotent — re-run it anytime.
 
-   ```sh
-   rcup -d ~/Workspace/tgautier/dotfiles
-   ```
-
-8. **Change shell to zsh:**
+7. **Change shell to zsh:**
 
    ```sh
    chsh -s $(which zsh)
@@ -142,24 +140,17 @@ Cross-platform dotfiles for macOS and Linux/WSL2 Ubuntu, managed with
 
    Log out and log back in for the shell change to take effect.
 
-9. **Switch git remote to SSH** (1Password SSH agent was set up on the Windows side):
+8. **Switch git remote to SSH** (1Password SSH agent was set up on the Windows side):
 
    ```sh
    git -C ~/Workspace/tgautier/dotfiles remote set-url origin git@github.com:tgautier/dotfiles.git
    ```
 
-10. **Install mise:**
+9. **Keep everything current** (later, for maintenance):
 
-    ```sh
-    curl https://mise.run | sh
-    mise install
-    ```
-
-11. **Update everything:**
-
-    ```sh
-    just update
-    ```
+   ```sh
+   just update
+   ```
 
 ## Day-to-Day Updates
 
@@ -241,7 +232,7 @@ Individual targets:
 | `just lint-brewfile`   | Ruby syntax check on Brewfiles                       |
 | `just lint-mise`       | Validate mise config                                 |
 
-Enable the pre-commit hook:
+The pre-commit hook is enabled by the bootstrap (idempotent — safe to re-run):
 
 ```sh
 just setup

--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ Cross-platform dotfiles for macOS and Linux/WSL2 Ubuntu, managed with
    # DOTFILES_DIRS). If absent, setup links the public repo only.
    ```
 
-3. **Bootstrap and run setup:**
+3. **Sign in to the App Store** (the Brewfile's `mas` entries fail without
+   it, which aborts the bootstrap — `just setup` is rerunnable after signing
+   in).
+
+4. **Bootstrap and run setup:**
 
    ```sh
    brew install just                       # the only package needed by hand
@@ -46,17 +50,17 @@ Cross-platform dotfiles for macOS and Linux/WSL2 Ubuntu, managed with
    installs mise and the pinned runtimes, and enables git hooks and tools.
    It is idempotent — re-run it anytime.
 
-4. **Set up 1Password SSH agent:**
+5. **Set up 1Password SSH agent:**
    Open 1Password, sign in, and enable the SSH agent under
    Settings > Developer > SSH Agent.
 
-5. **Switch git remote to SSH** (now that 1Password SSH is configured):
+6. **Switch git remote to SSH** (now that 1Password SSH is configured):
 
    ```sh
    git -C ~/Workspace/tgautier/dotfiles remote set-url origin git@github.com:tgautier/dotfiles.git
    ```
 
-6. **Keep everything current** (later, for maintenance):
+7. **Keep everything current** (later, for maintenance):
 
    ```sh
    just update
@@ -128,9 +132,10 @@ Cross-platform dotfiles for macOS and Linux/WSL2 Ubuntu, managed with
    just setup
    ```
 
-   `just setup` prompts for the machine profile on first run, then installs all
-   packages, links every dotfiles repo, installs mise and the pinned runtimes,
-   and enables git hooks and tools. It is idempotent — re-run it anytime.
+   `just setup` installs all packages, links every dotfiles repo, installs
+   mise and the pinned runtimes, and enables git hooks and tools (the
+   work/personal machine profile is macOS-only — Linux has no overlay).
+   It is idempotent — re-run it anytime.
 
 7. **Change shell to zsh:**
 


### PR DESCRIPTION
## Summary

- Split the macOS `Brewfile` into a shared base plus `Brewfile.work` / `Brewfile.personal` overlays, merged via `instance_eval` so `brew bundle install` AND `brew bundle cleanup` operate on the full per-machine set
- Profile selected by `~/.config/dotfiles/profile` (`just set-profile work|personal`); an absent/empty/unknown marker fails loud so `brew bundle cleanup --force` can never silently uninstall overlay apps
- Make `just setup` a full idempotent bootstrap: profile prompt (macOS only), packages, rcm symlinks, mise + pinned runtimes, git hooks, native installers, default-editor associations — one command after `brew install just`
- `lint-brewfile` now evaluates the merged Brewfile for both profiles from a non-repo cwd (stubbed DSL) and asserts the absent-marker guard raises
- README install flows rewritten around the bootstrap (incl. App Store sign-in prerequisite for `mas`); brewfile rule, CLAUDE.md, and CHANGELOG updated

Fixes #177

## Test plan

- [x] `just ci` green (shellcheck, markdownlint, Brewfile syntax + merge harness, mise config)
- [x] `lint-brewfile` harness: merge OK for work + personal, absent-marker raise asserted on the guard message
- [x] `instance_eval` path resolution verified from a non-repo cwd (`__dir__` resolves to the Brewfile dir)
- [x] `just setup` end-to-end on the work Mac (profile marker honored, 136 brew deps, mise pins, hooks, claude/hermes installers, duti associations — exit 0, idempotent re-run, no rc-file mutations)

## Review

3 roborev rounds (claude-code): R1 surfaced the absent-marker/cleanup-force hazard (fixed: fail-loud guard), R2 hardened the lint harness, R3 clean.

## Dismissed findings

- `__dir__` returns nil inside `instance_eval` (R1, MED) — refuted by evidence — see [rationale](https://github.com/tgautier/dotfiles/pull/179#issuecomment-4679285712).

