### PR TITLE
chore(mise): bump deno, elixir/erlang (OTP 29), go, yarn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ grouped by **date** rather than by semantic version. Newest first.
 
 - LM Studio CLI (`lms`) PATH: reverted the installer-written `zshrc` block
   (hardcoded home path) in favor of a guarded, portable line in `zprofile`.
+- Bump mise tool versions: deno 2.8.2, elixir 1.20.0-otp-29 + erlang 29.0
+  (OTP 28 → 29, bumped as a pair), go 1.26.4, yarn 4.16.0.
 
 ## [2026-06-01]
 

--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -4,17 +4,16 @@ trusted_config_paths = ["~/Workspace/tgautier"]
 
 [tools]
 dart = { version = "3.12.1", url = "https://storage.googleapis.com/dart-archive/channels/stable/release/{{ version }}/sdk/dartsdk-{{ os() }}-{{ arch() }}-release.zip", version_list_url = "https://storage.googleapis.com/storage/v1/b/dart-archive/o?prefix=channels/stable/release/&delimiter=/", version_regex = 'channels/stable/release/(\d+\.\d+\.\d+)/' }
-deno = "2.8.1"
-# elixir's -otp-N suffix must match erlang's OTP major. 1.19.x has no -otp-29
-# build (only 1.20.0-rc), so erlang stays on 28.x until a stable elixir-otp-29
-# ships. Bump these two as a pair, never independently.
-elixir = "1.19.5-otp-28"
-erlang = "28.5"
+deno = "2.8.2"
+# elixir's -otp-N suffix must match erlang's OTP major. Bump these two as a
+# pair, never independently.
+elixir = "1.20.0-otp-29"
+erlang = "29.0"
 "vfox:mise-plugins/vfox-flutter" = "3.44.1"
-go = "1.26.3"
+go = "1.26.4"
 helm = "4.2.0"
 node = "26"
 python = "3.14.5"
 ruby = "4.0.5"
-yarn = "4.15.0"
+yarn = "4.16.0"
 yq = "4.53.2"


### PR DESCRIPTION
## Summary

- deno 2.8.1 → 2.8.2
- elixir 1.19.5-otp-28 → 1.20.0-otp-29 + erlang 28.5 → 29.0 (paired bump; elixir 1.20 stable now ships an `-otp-29` build, so the stale "stay on OTP 28" comment rationale is trimmed while keeping the pairing rule)
- go 1.26.3 → 1.26.4
- yarn 4.15.0 → 4.16.0

Fixes #178

## Test plan

- [x] `just ci` green (includes `mise config ls` validation)
- [x] `mise ls-remote elixir` confirms `1.20.0-otp-29` is a stable release
- [x] `mise install` + `mise current` on this machine: deno 2.8.2, elixir 1.20.0-otp-29, erlang 29.0, go 1.26.4, yarn 4.16.0 all installed and active

## Review

1 roborev round (claude-code) on the branch: clean, no findings.
