### PR TITLE
fix(rcm): stop rcup/just setup hanging on non-dotfile project dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,21 @@ grouped by **date** rather than by semantic version. Newest first.
   then installs packages, links dotfiles, installs mise runtimes, and enables
   git hooks and tools — so a fresh machine is one command after `brew install just`.
 
+### Fixed
+
+- `rcup` / `just setup` no longer hang for minutes with no output. rcm was
+  descending into a large non-dotfile project directory (managed only via
+  `dotfiles-private`) and symlinking its tens of thousands of build
+  artifacts one by one. That directory is now excluded via a new
+  `dotfiles-private/rcm-excludes` list, sourced by `rcrc` at link time so its
+  name stays out of this public repo (works for bare `rcup` and `just setup`).
+- Exclude the repo `Justfile` and `CHANGELOG.md` from rcm symlinking — they are
+  run/used in-repo, not home dotfiles. Excluding `Justfile` also fixes a
+  collision with the private repo's `justfile` → `~/.justfile` on
+  case-insensitive filesystems (macOS) that made every `rcup` prompt
+  `overwrite ~/.Justfile?` (a silent hang when stdin is not a TTY). Brewfiles
+  stay linked (`zshenv` exports `HOMEBREW_BUNDLE_FILE=~/.Brewfile[.linux]`).
+
 ## [2026-06-01]
 
 ### Changed

--- a/rcrc
+++ b/rcrc
@@ -1,3 +1,18 @@
-EXCLUDES="README.md .githooks"
-DOTFILES_DIRS="${HOME}/Workspace/tgautier/dotfiles ${HOME}/Workspace/tgautier/dotfiles-private"
+# Private repo path, used by both EXCLUDES and DOTFILES_DIRS below. Single
+# source of truth: if it drifts, the exclude-sourcing would silently no-op
+# (2>/dev/null) and rcup would resume hanging on the excluded directory.
+PRIVATE_DIR="${HOME}/Workspace/tgautier/dotfiles-private"
+
+# Base excludes plus any private-only exclude patterns appended from
+# ${PRIVATE_DIR}/rcm-excludes. Sourced here (rcm reads rcrc as shell) so
+# bare `rcup` and `just setup` both honor them; an absent private repo is a
+# no-op. Keeps project/dir names we don't publish out of this public file.
+# Justfile and CHANGELOG.md are run/used in-repo, not home dotfiles, so they
+# are excluded. Excluding Justfile also avoids colliding with the private
+# repo's `justfile` -> ~/.justfile on case-insensitive filesystems (macOS).
+# NB: Brewfile / Brewfile.linux must stay linked — zshenv exports
+# HOMEBREW_BUNDLE_FILE=~/.Brewfile[.linux], so excluding them breaks bare
+# `brew bundle`.
+EXCLUDES="README.md .githooks Justfile CHANGELOG.md rcm-excludes $( { grep -hvE '^[[:space:]]*(#|$)' "${PRIVATE_DIR}/rcm-excludes" 2>/dev/null || true; } | tr '\n' ' ')"
+DOTFILES_DIRS="${HOME}/Workspace/tgautier/dotfiles ${PRIVATE_DIR}"
 SYMLINK_DIRS="claude/skills claude/rules claude/hooks"


### PR DESCRIPTION
## Summary

`just setup` / bare `rcup` hung for minutes with no output. rcm was descending into a large **non-dotfile project directory** (managed only via `dotfiles-private`) whose home target already existed as a real dir, symlinking its tens of thousands of build artifacts one by one.

- **Source extra rcm `EXCLUDES` from `dotfiles-private/rcm-excludes`** at link time (`rcrc` is sourced as shell). Private-only directory names stay out of this public repo, and both bare `rcup` and `just setup` honor them; an absent private repo is a no-op. The private path is now a single `PRIVATE_DIR` var shared by `EXCLUDES` and `DOTFILES_DIRS` (drift would silently re-introduce the hang).
- **Exclude in-repo tooling `Justfile` and `CHANGELOG.md`** from rcm symlinking. Excluding `Justfile` also fixes a collision with the private repo's `justfile` → `~/.justfile` on case-insensitive filesystems (macOS) that made every `rcup` prompt `overwrite ~/.Justfile?` (a silent hang off-TTY).
- **Brewfiles stay linked** — `zshenv` exports `HOMEBREW_BUNDLE_FILE=~/.Brewfile[.linux]`, so excluding them would break bare `brew bundle` (caught in review).

Depends on a companion `rcm-excludes` file landing in `dotfiles-private` (tracked separately).

Fixes #188

## Test plan

- [x] `rcup` completes (`EXIT=0`) instead of hanging; no descent into the excluded project dir
- [x] `~/.Justfile` collision prompt no longer occurs; private `justfile` → `~/.justfile` intact
- [x] `~/.Brewfile` / `~/.Brewfile.linux` still linked (`HOMEBREW_BUNDLE_FILE` target exists)
- [x] `just ci` passes (shell, markdown, Brewfile merge, mise, lint-public-no-arr)
- [x] Public repo clean of arr/NAS tokens (`lint-public-no-arr` ✓)
- [x] roborev: 2 consecutive rounds, zero P0 (HIGH Brewfile regression caught and fixed mid-review)