### PR TITLE
fix(just): exclude web content from set-default-editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Fixed
 
+- `just set-default-editor` no longer hijacks the macOS web-browser role. Web
+  content types (`html`/`htm`/`xhtml`/`svg`) and the root `public.data` UTI are
+  now excluded — registering VS Code as their handler cascaded into the browser
+  role and the `http`/`https` URL schemes, sending web links to VS Code instead
+  of the browser.
 - `rcup` / `just setup` no longer hang for minutes with no output. rcm was
   descending into a large non-dotfile project directory (managed only via
   `dotfiles-private`) and symlinking its tens of thousands of build

--- a/Justfile
+++ b/Justfile
@@ -226,7 +226,10 @@ update-rust:
     rustup update
 
 # Register VS Code as default opener for text/code/data files (macOS only).
-# Word and Pages documents are deliberately excluded.
+# Word and Pages documents are deliberately excluded. Web-content types
+# (html/htm/xhtml/svg) and the root public.data UTI are ALSO excluded: making
+# VS Code the default HTML handler cascades into the macOS web-browser role and
+# the http/https URL schemes, hijacking web links away from the browser.
 set-default-editor:
     #!/usr/bin/env zsh
     if [[ "$(uname -s)" != "Darwin" ]]; then
@@ -255,13 +258,13 @@ set-default-editor:
         public.comma-separated-values-text
         public.tab-separated-values-text
         public.log
-        public.data
     )
     for uti in "${utis[@]}"; do
         duti -s "$bundle" "$uti" all 2>/dev/null || true
     done
     # Extension-level associations (catches files without a registered UTI).
-    # Excludes Word (.doc, .docx) and Pages (.pages) by design.
+    # Excludes Word (.doc, .docx), Pages (.pages), and web content
+    # (.html/.htm/.xhtml/.svg) by design — see the recipe header above.
     exts=(
         txt md markdown rst adoc org tex log csv tsv
         json yaml yml toml xml ini conf cfg env properties plist
@@ -273,7 +276,7 @@ set-default-editor:
         cs fs fsx vb
         ex exs erl hrl hs lhs ml mli ocaml
         sol move
-        css scss sass less styl html htm xhtml svg
+        css scss sass less styl
         sql graphql gql proto thrift avsc
         dart
         tf hcl tfvars
@@ -285,7 +288,8 @@ set-default-editor:
         duti -s "$bundle" ".$ext" all 2>/dev/null || true
     done
     echo "VS Code registered as default for text/code/data files."
-    echo "Word (.doc/.docx) and Pages (.pages) intentionally left untouched."
+    echo "Word (.doc/.docx), Pages (.pages), and web content (.html/.svg)"
+    echo "intentionally left untouched so the browser keeps http/https links."
 
 # Remove stale symlinks in $HOME that point into dotfiles dirs
 cleanup-symlinks:


### PR DESCRIPTION
## Summary

- `just set-default-editor`: exclude web-content types (`html`/`htm`/`xhtml`/`svg`) and the root `public.data` UTI from the VS Code default-handler registration.
- Registering VS Code for `public.html` / `public.data` cascaded into the macOS web-browser role and the `http`/`https` URL schemes, sending web links to VS Code instead of the browser. Word and Pages remain excluded as before.
- Update the recipe header comment, the inline exclusion comment, the final echo, and add a `CHANGELOG.md` entry.

Fixes #190

## Test plan

- [x] `just ci` passes (shell + markdown + Brewfile + mise lints)
- [ ] On macOS, `just set-default-editor` leaves `http`/`https` and `.html` bound to the browser (manual — requires running the recipe on a Mac)
