### PR TITLE
feat(brew): detect duplicate entries in lint-brewfile

### DIFF
--- a/.claude/rules/brewfile.md
+++ b/.claude/rules/brewfile.md
@@ -21,7 +21,7 @@ Because the overlay is merged into the same `brew bundle` evaluation, both `brew
 
 ## Rules
 
-- Before adding an entry to **any** Brewfile, grep all four (`grep -n "<name>" Brewfile Brewfile.work Brewfile.personal Brewfile.linux`) for an existing entry — the package may already live in an overlay. Promoting an overlay package to the base means **removing** the overlay entry in the same change; `lint-brewfile` does not catch duplicates (the merge harness stubs the DSL), so a stale overlay entry stays green in CI while duplicating the merged bundle
+- Before adding an entry to **any** Brewfile, grep all four (`grep -n "<name>" Brewfile Brewfile.work Brewfile.personal Brewfile.linux`) for an existing entry — the package may already live in an overlay. Promoting an overlay package to the base means **removing** the overlay entry in the same change. `lint-brewfile` now catches a duplicate `brew`/`cask`/`mas` name across the merged base + overlay set (its harness records entry names during the eval), but grep first — a clear diff beats a CI failure
 - A package shared by **all** machines goes in the base (`Brewfile` for macOS, and also `Brewfile.linux` unless it's a cask/mas or platform-specific tool)
 - A package for **one Mac profile only** goes in `Brewfile.work` or `Brewfile.personal` — never in the shared `Brewfile` base
 - Casks (`cask`) and Mac App Store (`mas`) entries never appear in `Brewfile.linux` — they are not available on Linux
@@ -30,7 +30,7 @@ Because the overlay is merged into the same `brew bundle` evaluation, both `brew
 - Within each block in each file, entries are sorted alphabetically (a-z) by package name
 - Tap entries (`tap`) come before all blocks
 - For tap-prefixed formulae (e.g., `brew "terror/tap/just-lsp"`), sort by the full string including the tap prefix
-- Keep `lint-brewfile` in the `Justfile` in sync with this file set — every Brewfile gets a `ruby -c` check, and the overlay-merge harness must keep evaluating every profile plus the absent-marker failure
+- Keep `lint-brewfile` in the `Justfile` in sync with this file set — every Brewfile gets a `ruby -c` check, and the overlay-merge harness must keep evaluating every profile plus the absent-marker failure and the duplicate-entry guard (with its negative fixture test)
 
 ## Native-installer tools
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,11 @@ grouped by **date** rather than by semantic version. Newest first.
   before `just` itself exists.
 - `.claude/rules/brewfile.md`: grep all four Brewfiles before adding an entry —
   promoting an overlay package to the base must remove the overlay entry in the
-  same change; `lint-brewfile` can't catch duplicates
-  ([#192](https://github.com/tgautier/dotfiles/issues/192) tracks lint support).
+  same change.
+- `lint-brewfile` now detects duplicate `brew`/`cask`/`mas` names across the
+  merged base + overlay set: the eval harness records entry names and fails on
+  a repeat, with a negative fixture test asserting the guard fires
+  ([#192](https://github.com/tgautier/dotfiles/issues/192)).
 - LM Studio CLI (`lms`) PATH: reverted the installer-written `zshrc` block
   (hardcoded home path) in favor of a guarded, portable line in `zprofile`.
 - Bump mise tool versions: deno 2.8.2, elixir 1.20.0-otp-29 + erlang 29.0

--- a/Justfile
+++ b/Justfile
@@ -160,12 +160,29 @@ lint-brewfile:
     ruby -c Brewfile.linux
     # Evaluate the merged Brewfile for each profile from a non-repo cwd with
     # stubbed DSL methods — catches overlay-resolution and fail-loud regressions
-    # that `ruby -c` (syntax only) cannot see.
+    # that `ruby -c` (syntax only) cannot see. The stubs also record each
+    # brew/cask/mas entry name so a package present in BOTH the base and an
+    # overlay (a duplicate in the merged bundle, which `ruby -c` cannot see and
+    # `brew bundle` may error on) fails the lint — issue #192.
     brewfile="$PWD/Brewfile"
     harness='
+      seen = Hash.new(0)
+      dups = []
       dsl = Object.new
-      %i[tap brew cask mas].each { |m| dsl.define_singleton_method(m) { |*a, **k| } }
+      %i[brew cask mas].each do |m|
+        dsl.define_singleton_method(m) do |name, *a, **k|
+          key = [m, name]
+          seen[key] += 1
+          dups << key if seen[key] == 2
+        end
+      end
+      dsl.define_singleton_method(:tap) { |*a, **k| }
       dsl.instance_eval(File.read(ARGV[0]), ARGV[0])
+      unless dups.empty?
+        STDERR.puts "DUPLICATE Brewfile entries in merged bundle:"
+        dups.each { |m, n| STDERR.puts %(  #{m} "#{n}") }
+        exit 1
+      end
     '
     tmp_root="$(mktemp -d)"
     trap 'rm -rf "$tmp_root"' EXIT
@@ -189,6 +206,21 @@ lint-brewfile:
         exit 1
     fi
     echo "Brewfile absent-marker raise OK"
+    # A duplicate brew/cask/mas name (here within one file; the same guard
+    # catches a base+overlay duplicate) must fail loud — assert the dup guard
+    # fires on a known duplicate, not just any error.
+    dup_brewfile="$tmp_root/dup-Brewfile"
+    printf 'cask "vlc"\ncask "vlc"\n' > "$dup_brewfile"
+    if dout="$(cd /tmp && ruby -e "$harness" "$dup_brewfile" 2>&1)"; then
+        echo "ERROR: duplicate detection did not fire on a known duplicate" >&2
+        exit 1
+    fi
+    if ! grep -q 'DUPLICATE' <<<"$dout"; then
+        echo "ERROR: duplicate-case failure did not come from the dup guard:" >&2
+        echo "$dout" >&2
+        exit 1
+    fi
+    echo "Brewfile duplicate-detection OK"
 
 # Validate mise config
 lint-mise:


### PR DESCRIPTION
## Summary

Implements the lint follow-up tracked in #192. The `lint-brewfile` merge harness now records each `brew`/`cask`/`mas` entry name during the stubbed profile eval and fails when a name repeats across the merged **base + overlay** bundle — the duplicate class roborev caught by hand on #183 (`ruby -c` can't see it, and `brew bundle` may error or double-process on it).

- Harness stubs accumulate `(type, name)` keys in one `seen` hash per eval; base + overlay duplicates land in the same hash (single-process `instance_eval`), each reported once.
- Adds a **negative fixture test**: a known-duplicate Brewfile must fail with the `DUPLICATE` guard message (per the guard-script positive/negative-fixture discipline).
- Updates `.claude/rules/brewfile.md` ("lint now catches duplicates") and `CHANGELOG.md`.

## Test plan

- [x] `just lint-brewfile` passes (current Brewfiles have no duplicates) and prints `Brewfile duplicate-detection OK`
- [x] `just ci` passes
- [x] Negative test confirmed: the guard fires on a planted `cask "vlc"` x2
- [x] roborev clean (job 53, no issues)

Fixes #192
