### PR TITLE
feat(brew): add antigravity-cli and antigravity-ide casks

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -113,6 +113,8 @@ cask "1password"
 cask "1password-cli"
 cask "android-studio"
 cask "antigravity"
+cask "antigravity-cli"
+cask "antigravity-ide"
 cask "claude"
 ## claude-code: native installer via `just setup` (auto-updates, no deps)
 cask "codex"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ grouped by **date** rather than by semantic version. Newest first.
 ### Added
 
 - `antigravity` and `cursor` casks in `Brewfile` (macOS, all profiles).
+- `antigravity-cli` and `antigravity-ide` casks in `Brewfile` (macOS, all
+  profiles).
 - `protonvpn` cask in the `Brewfile.personal` overlay (macOS).
 - `hermes-agent` via native installer in `just setup`, with cross-references in
   both Brewfiles; document the native-installer pattern (single source of truth


### PR DESCRIPTION
## Summary

Add the `antigravity-cli` and `antigravity-ide` casks to the shared macOS `Brewfile` `# Applications` block, alongside the existing `antigravity` cask (all profiles).

These edits originated as in-flight working-tree changes that got accidentally swept into an unrelated branch by a `git add -A`; this PR is their proper, isolated home.

## Test plan

- [x] Both casks verified present in `homebrew/cask` (`brew info --cask antigravity-cli antigravity-ide`)
- [x] `just lint-brewfile` passes — including the new duplicate-entry guard (the three `antigravity*` names are distinct, not duplicates)
- [x] roborev clean (job 61, no issues)
