### PR TITLE
feat(setup): trust declared taps before brew bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Fixed
 
+- `just setup` now trusts the Brewfile's own declared taps (`brew trust`,
+  guarded on Homebrew 6+) before `brew bundle`, so the trusted-taps gate
+  ($HOMEBREW_REQUIRE_TAP_TRUST) no longer aborts a fresh-machine bootstrap with
+  "Refusing to load formula … from untrusted tap". A no-op on older Homebrew.
 - `just set-default-editor` no longer hijacks the macOS web-browser role. Web
   content types (`html`/`htm`/`xhtml`/`svg`) and the root `public.data` UTI are
   now excluded — registering VS Code as their handler cascaded into the browser

--- a/Justfile
+++ b/Justfile
@@ -20,7 +20,23 @@ setup: _ensure-profile
     # this repo (+ dotfiles-private if used), run `brew bundle` once to get `just`.
     cd "{{dotfiles_dir}}"
 
-    # 1. Packages for this machine's profile (install only; `just update` upgrades).
+    # 1. Packages for this machine's profile (install only; `just update`
+    #    upgrades). First trust the repo's own declared taps so Homebrew's
+    #    trusted-taps gate ($HOMEBREW_REQUIRE_TAP_TRUST, Homebrew 6+) doesn't
+    #    refuse to load their formulae mid-bundle. `brew trust` only records the
+    #    tap name in trust.json (no clone needed), so it's safe before the tap
+    #    is added; guarded on the subcommand, so it's a no-op on older Homebrew.
+    #    Verified against Homebrew 6.0.2 (`brew trust --help`); the gate is the
+    #    exact one that fails a fresh bootstrap ("Refusing to load formula …
+    #    from untrusted tap. Run `brew trust …`").
+    #    Scans only the base brewfile: per-machine overlays carry no `tap` lines
+    #    by convention (Applications/Mas only, per .claude/rules/brewfile.md).
+    #    A failed trust is non-fatal (`|| true`) — it just degrades to the gate
+    #    `brew bundle` would have hit anyway, never aborts the bootstrap.
+    if brew trust --help >/dev/null 2>&1; then
+        taps="$(grep -E '^tap "' "{{brewfile}}" | sed -E 's/^tap "([^"]+)".*/\1/' || true)"
+        for tap in $taps; do brew trust "$tap" || true; done
+    fi
     brew bundle install --file="{{brewfile}}"
 
     # 2. Symlink dotfiles. RCRC points rcm at the repo config so a fresh machine


### PR DESCRIPTION
## Summary

`just setup` now runs `brew trust` on each tap declared in the active Brewfile **before** `brew bundle`, so Homebrew 6's trusted-taps gate (`$HOMEBREW_REQUIRE_TAP_TRUST`) no longer aborts a fresh-machine bootstrap with *"Refusing to load formula … from untrusted tap"* (the failure hit live on a `work` Mac).

- `brew trust` only records the tap name in `trust.json` — no clone needed — so it's safe to run before the tap is added by `brew bundle`.
- Guarded on `brew help trust` existing -> a true no-op on older Homebrew without the gate.
- Non-fatal (`|| true`) -> a failed trust degrades to the exact gate `brew bundle` would have hit anyway, never aborts the bootstrap.
- Scans only the base Brewfile (overlays carry no `tap` lines by convention, per `.claude/rules/brewfile.md`).
- Verified against Homebrew 6.0.2.

## Test plan

- [x] `just ci` passes (recipe parses; shell/markdown/brewfile/mise lints green)
- [x] Verified the gate + command exist on Homebrew 6.0.2 (`brew trust --help`); the gate is the exact one that failed the live bootstrap
- [x] roborev clean
