### PR TITLE
fix(setup): make brew bundle install-only in just setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,11 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Fixed
 
+- `just setup` now runs `brew bundle install --no-upgrade`, matching its
+  documented "install only" contract (`just update` owns upgrades). Previously
+  `brew bundle` upgraded every outdated cask/formula, so a single failing
+  upgrade (e.g. `google-chrome` with a stale Caskroom app) aborted the whole
+  bootstrap.
 - `just setup` now trusts the Brewfile's own declared taps (`brew trust`,
   guarded on Homebrew 6+) before `brew bundle`, so the trusted-taps gate
   ($HOMEBREW_REQUIRE_TAP_TRUST) no longer aborts a fresh-machine bootstrap with

--- a/Justfile
+++ b/Justfile
@@ -37,7 +37,13 @@ setup: _ensure-profile
         taps="$(grep -E '^tap "' "{{brewfile}}" | sed -E 's/^tap "([^"]+)".*/\1/' || true)"
         for tap in $taps; do brew trust "$tap" || true; done
     fi
-    brew bundle install --file="{{brewfile}}"
+    #    `--no-upgrade` keeps this install-only: bootstrap should not try to
+    #    upgrade already-installed packages (`just update` owns upgrades). Without
+    #    it, `brew bundle install` upgrades every outdated cask/formula, so a
+    #    single failing upgrade (e.g. a cask with a stale Caskroom app) aborts the
+    #    whole bootstrap — a fresh-machine step must not depend on every existing
+    #    package upgrading cleanly.
+    brew bundle install --no-upgrade --file="{{brewfile}}"
 
     # 2. Symlink dotfiles. RCRC points rcm at the repo config so a fresh machine
     #    (no ~/.rcrc yet) links every DOTFILES_DIRS entry; a missing private repo


### PR DESCRIPTION
## Summary

- `just setup` is documented as install-only (*"install only; \`just update\` upgrades"*), but `brew bundle install` upgrades outdated casks/formulae by default.
- On a machine with a stale Caskroom app (`google-chrome` 148 → 150), that default upgrade failed, and `set -euo pipefail` aborted the entire bootstrap at step 1 — symlinks, mise runtimes, and git hooks never ran.
- Fix: add `--no-upgrade` so `setup` only installs missing packages. Upgrades stay the job of `just update-brew`.

A fresh-machine bootstrap must not depend on every already-installed package upgrading cleanly.

## Test plan

- [x] `just setup` completes end-to-end (EXIT=0); brew step shows 0 upgrades, `google-chrome` left as `Using`
- [x] `just ci` passes (shell, markdown, Brewfile, mise, private lint)
- [x] roborev branch review clean (no issues)
- [x] `CHANGELOG.md` entry added under `[Unreleased] → Fixed`

## Notes

The underlying stale-Caskroom-app conflict on `google-chrome` will still surface under `just update` — that's a separate concern, out of scope here.