### PR TITLE
chore(mise): bump deno, elixir, flutter, go, helm, ruby, yarn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Changed
 
+- Bump mise tool versions: deno 2.9.2, elixir 1.20.2-otp-29, Flutter
+  (`vfox-flutter`) 3.44.6, go 1.26.5, helm 4.2.3, ruby 4.0.6, yarn 4.17.1.
 - Rename the roborev Homebrew tap `roborev-dev/tap` → `kenn-io/tap` in
   `Brewfile` and `Brewfile.linux` (upstream GitHub org rename; the old name
   now redirects). Stops the "Redirected tap … Not trusted tap" warning on

--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -4,16 +4,16 @@ trusted_config_paths = ["~/Workspace/tgautier"]
 
 [tools]
 dart = { version = "3.12.2", url = "https://storage.googleapis.com/dart-archive/channels/stable/release/{{ version }}/sdk/dartsdk-{{ os() }}-{{ arch() }}-release.zip", version_list_url = "https://storage.googleapis.com/storage/v1/b/dart-archive/o?prefix=channels/stable/release/&delimiter=/", version_regex = 'channels/stable/release/(\d+\.\d+\.\d+)/' }
-deno = "2.8.3"
+deno = "2.9.2"
 # elixir's -otp-N suffix must match erlang's OTP major. Bump these two as a
 # pair, never independently.
-elixir = "1.20.1-otp-29"
+elixir = "1.20.2-otp-29"
 erlang = "29.0"
-"vfox:mise-plugins/vfox-flutter" = "3.44.2"
-go = "1.26.4"
-helm = "4.2.1"
+"vfox:mise-plugins/vfox-flutter" = "3.44.6"
+go = "1.26.5"
+helm = "4.2.3"
 node = "26"
 python = "3.14.6"
-ruby = "4.0.5"
-yarn = "4.17.0"
+ruby = "4.0.6"
+yarn = "4.17.1"
 yq = "4.53.3"


### PR DESCRIPTION
## Summary

- Bump mise-managed tool versions from the latest update cycle:
  - deno 2.8.3 → 2.9.2
  - elixir 1.20.1-otp-29 → 1.20.2-otp-29 (erlang stays 29.0; OTP suffix still matches the pinned pair)
  - Flutter (`vfox-flutter`) 3.44.2 → 3.44.6
  - go 1.26.4 → 1.26.5
  - helm 4.2.1 → 4.2.3
  - ruby 4.0.5 → 4.0.6
  - yarn 4.17.0 → 4.17.1
- Add the matching `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan

- [x] `just ci` passes locally (shellcheck, markdownlint, Brewfile lints, mise config load)
- [x] `mise config ls` loads the updated config without errors
- [x] roborev reviews (claude-code + copilot): no issues found