### PR TITLE
fix(update): trust declared taps before brew bundle in update-brew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Changed
 
+- Bump mise deno 2.9.2 → 2.9.3
+  ([#198](https://github.com/tgautier/dotfiles/pull/198)).
 - Bump mise tool versions: deno 2.9.2, elixir 1.20.2-otp-29, Flutter
   (`vfox-flutter`) 3.44.6, go 1.26.5, helm 4.2.3, ruby 4.0.6, yarn 4.17.1.
 - Rename the roborev Homebrew tap `roborev-dev/tap` → `kenn-io/tap` in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,11 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Fixed
 
+- `just update` now trusts the Brewfile's declared taps before `brew bundle`,
+  the same fix `just setup` received: Homebrew 6's trusted-taps gate aborted
+  `update-brew` with "Refusing to load formula kenn-io/tap/roborev from
+  untrusted tap". The trust logic moved from the `setup` recipe body into a
+  shared `_trust-taps` recipe that both `setup` and `update-brew` run.
 - `just setup` now runs `brew bundle install --no-upgrade`, matching its
   documented "install only" contract (`just update` owns upgrades). Previously
   `brew bundle` upgraded every outdated cask/formula, so a single failing

--- a/Justfile
+++ b/Justfile
@@ -22,21 +22,9 @@ setup: _ensure-profile
 
     # 1. Packages for this machine's profile (install only; `just update`
     #    upgrades). First trust the repo's own declared taps so Homebrew's
-    #    trusted-taps gate ($HOMEBREW_REQUIRE_TAP_TRUST, Homebrew 6+) doesn't
-    #    refuse to load their formulae mid-bundle. `brew trust` only records the
-    #    tap name in trust.json (no clone needed), so it's safe before the tap
-    #    is added; guarded on the subcommand, so it's a no-op on older Homebrew.
-    #    Verified against Homebrew 6.0.2 (`brew trust --help`); the gate is the
-    #    exact one that fails a fresh bootstrap ("Refusing to load formula …
-    #    from untrusted tap. Run `brew trust …`").
-    #    Scans only the base brewfile: per-machine overlays carry no `tap` lines
-    #    by convention (Applications/Mas only, per .claude/rules/brewfile.md).
-    #    A failed trust is non-fatal (`|| true`) — it just degrades to the gate
-    #    `brew bundle` would have hit anyway, never aborts the bootstrap.
-    if brew trust --help >/dev/null 2>&1; then
-        taps="$(grep -E '^tap "' "{{brewfile}}" | sed -E 's/^tap "([^"]+)".*/\1/' || true)"
-        for tap in $taps; do brew trust "$tap" || true; done
-    fi
+    #    trusted-taps gate doesn't refuse to load their formulae mid-bundle —
+    #    see _trust-taps for the full rationale.
+    just _trust-taps
     #    `--no-upgrade` keeps this install-only: bootstrap should not try to
     #    upgrade already-installed packages (`just update` owns upgrades). Without
     #    it, `brew bundle install` upgrades every outdated cask/formula, so a
@@ -257,8 +245,26 @@ dotfiles_dir := parent_directory(canonicalize(justfile()))
 # Platform-specific Brewfile
 brewfile := dotfiles_dir / if os() == "macos" { "Brewfile" } else { "Brewfile.linux" }
 
+# Trust the base Brewfile's declared taps so Homebrew's trusted-taps gate
+# ($HOMEBREW_REQUIRE_TAP_TRUST, Homebrew 6+) doesn't refuse to load their
+# formulae mid-bundle ("Refusing to load formula … from untrusted tap. Run
+# `brew trust …`"). `brew trust` only records the tap name in trust.json (no
+# clone needed), so it's safe before the tap is added; guarded on the
+# subcommand, so it's a no-op on older Homebrew (verified against 6.0.2).
+# Scans only the base brewfile: per-machine overlays carry no `tap` lines by
+# convention (Applications/Mas only, per .claude/rules/brewfile.md). A failed
+# trust is non-fatal (`|| true`) — it just degrades to the gate `brew bundle`
+# would have hit anyway, never aborts the caller.
+_trust-taps:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if brew trust --help >/dev/null 2>&1; then
+        taps="$(grep -E '^tap "' "{{brewfile}}" | sed -E 's/^tap "([^"]+)".*/\1/' || true)"
+        for tap in $taps; do brew trust "$tap" || true; done
+    fi
+
 # Update Homebrew packages and clean up
-update-brew:
+update-brew: _trust-taps
     brew update
     brew bundle install --file={{brewfile}}
     brew upgrade

--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -4,7 +4,7 @@ trusted_config_paths = ["~/Workspace/tgautier"]
 
 [tools]
 dart = { version = "3.12.2", url = "https://storage.googleapis.com/dart-archive/channels/stable/release/{{ version }}/sdk/dartsdk-{{ os() }}-{{ arch() }}-release.zip", version_list_url = "https://storage.googleapis.com/storage/v1/b/dart-archive/o?prefix=channels/stable/release/&delimiter=/", version_regex = 'channels/stable/release/(\d+\.\d+\.\d+)/' }
-deno = "2.9.2"
+deno = "2.9.3"
 # elixir's -otp-N suffix must match erlang's OTP major. Bump these two as a
 # pair, never independently.
 elixir = "1.20.2-otp-29"


### PR DESCRIPTION
## Summary

- `just update` hit the same Homebrew 6 trusted-taps gate that `just setup` was fixed for in #195: `update-brew` aborted with "Refusing to load formula kenn-io/tap/roborev from untrusted tap"
- Extract the tap-trust logic from the `setup` recipe body into a shared `_trust-taps` recipe; `setup` calls it and `update-brew` depends on it
- Bump deno 2.9.2 -> 2.9.3 in `config/mise/config.toml`, with its own CHANGELOG entry (review finding)
- CHANGELOG entries added under `[Unreleased]`

Addresses the follow-up to #195/#196.

## Test plan

- [x] `just ci` passes (shell + markdown + Brewfile + mise lints) — runs as pre-commit hook on every commit
- [x] The untrusted-tap refusal reproduces and the fix clears it: with no `trust.json` and `HOMEBREW_REQUIRE_TAP_TRUST=1`, `brew bundle check --file=Brewfile` fails on both taps (exit 1); after `just _trust-taps` (both taps recorded in `trust.json`) the same command exits 0
- [x] `just -n update-brew` shows `_trust-taps` running before `brew update` / `brew bundle install`
- [x] `just _trust-taps` is idempotent ("Already trusted tap: …", exit 0 on second run)
- [x] `just setup` still trusts taps before `brew bundle` — it calls the same `_trust-taps` recipe verified above
- [x] deno 2.9.3 active via mise (`deno --version` → 2.9.3)