### PR TITLE
fix(linux): brew vendored ruby, dangling completion symlinks, zcompdump race

### DIFF
--- a/Brewfile.linux
+++ b/Brewfile.linux
@@ -96,5 +96,5 @@ brew "zsh-completions"
 # - gemini-cli: npm install -g @google/gemini-cli (Homebrew formula deprecated
 #   upstream; the brew replacement, antigravity-cli, is a macOS-only cask)
 # - Ghostty: https://ghostty.org/docs/install/binary
-# - VS Code: https://code.visualstudio.com/docs/setup/linux
 # - telnet: apt install telnet (Homebrew formula is source-only / Tier 3 on Linux)
+# - VS Code: https://code.visualstudio.com/docs/setup/linux

--- a/Brewfile.linux
+++ b/Brewfile.linux
@@ -74,7 +74,6 @@ brew "sqlite"
 brew "step"
 brew "stern"
 brew "svn"
-brew "telnet"
 brew "terror/tap/just-lsp", trusted: true
 brew "tmux"
 brew "tree"
@@ -94,7 +93,8 @@ brew "zsh-completions"
 # - 1Password: https://1password.com/downloads/linux/
 # - Docker: apt install docker.io
 # - gcloud CLI: https://cloud.google.com/sdk/docs/install#linux
-# - Gemini CLI: no Linux brew replacement (the antigravity-cli cask is
-#   macOS-only) — install via Google's official channel if needed
+# - gemini-cli: npm install -g @google/gemini-cli (Homebrew formula deprecated
+#   upstream; the brew replacement, antigravity-cli, is a macOS-only cask)
 # - Ghostty: https://ghostty.org/docs/install/binary
 # - VS Code: https://code.visualstudio.com/docs/setup/linux
+# - telnet: apt install telnet (Homebrew formula is source-only / Tier 3 on Linux)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ grouped by **date** rather than by semantic version. Newest first.
   `brew bundle install` applies the declared trust before fetching, so fresh
   bootstraps need no separate trust step either
   ([#199](https://github.com/tgautier/dotfiles/pull/199)).
+- Bump mise deno 2.9.3 → 2.9.4 and Flutter (`vfox-flutter`) 3.44.6 → 3.44.7.
 - Bump mise deno 2.9.2 → 2.9.3
   ([#198](https://github.com/tgautier/dotfiles/pull/198)).
 - Bump mise tool versions: deno 2.9.2, elixir 1.20.2-otp-29, Flutter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,18 +104,24 @@ grouped by **date** rather than by semantic version. Newest first.
   the loser reopened the winner's fresh read-only file and aborted. The
   precompile now takes a non-blocking `zsystem flock` before compiling, so
   exactly one shell writes the `.zwc`; the lock auto-releases on process exit.
-  Where `zsh/system` isn't built, the precompile still runs — unserialized,
-  with `zcompile`'s stderr dropped — rather than being skipped entirely.
+  Where `zsh/system` isn't built, the precompile still runs unserialized rather
+  than being skipped entirely. Either way `zcompile`'s stderr is dropped —
+  precompilation is best-effort and the block is a disowned background job, so
+  a failure would otherwise surface asynchronously in an unrelated prompt.
 - `compinit` no longer prints `no such file or directory:
   /usr/share/zsh/vendor-completions/_docker` on WSL when Docker Desktop is
   stopped. Docker Desktop's integration leaves a root-owned symlink into its
   cli-tools mount, which dangles while it's off. `zprofile` now shadows the
   dangling symlink with an empty file earlier in `fpath` so `compinit` skips
   it, keyed on each completion's *first* `fpath` occurrence to match
-  `compinit`'s own earliest-wins dedupe. The shadow stops being created on the
-  next login once the real target returns, but the completion itself only
-  comes back when the dump is rebuilt (`compinit -C` reuses the cached dump for
-  the rest of the day) — `rm ~/.zcompdump` forces it back immediately.
+  `compinit`'s own earliest-wins dedupe. Shadows live in a per-shell
+  `~/.cache/zsh/compinit-shadows.<pid>`, pruned when the owning shell is gone
+  or the directory is over a day old; a single shared directory would let one
+  login wipe it while another was mid-`compinit`. The shadow stops being
+  created on the next login once the real target returns, but the completion
+  itself only comes back when the dump is rebuilt (`compinit -C` reuses the
+  cached dump for the rest of the day) — start a fresh login shell to get it
+  back immediately.
 - `just update` (and any `brew` command) no longer fails on Linux/WSL with
   `libcrypto.so.3: version OPENSSL_3.4.0 not found`. Homebrew was adopting
   mise's PATH-resident ruby, whose `openssl.so` links a newer OpenSSL than the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,13 +104,18 @@ grouped by **date** rather than by semantic version. Newest first.
   the loser reopened the winner's fresh read-only file and aborted. The
   precompile now takes a non-blocking `zsystem flock` before compiling, so
   exactly one shell writes the `.zwc`; the lock auto-releases on process exit.
+  Where `zsh/system` isn't built, the precompile still runs — unserialized,
+  with `zcompile`'s stderr dropped — rather than being skipped entirely.
 - `compinit` no longer prints `no such file or directory:
   /usr/share/zsh/vendor-completions/_docker` on WSL when Docker Desktop is
   stopped. Docker Desktop's integration leaves a root-owned symlink into its
-  cli-tools mount, which dangles while it's off. `zprofile` now shadows any
-  dangling completion symlink with an empty file earlier in `fpath` (rebuilt
-  each login) so `compinit` skips the broken one; the shadow disappears once
-  the real target returns.
+  cli-tools mount, which dangles while it's off. `zprofile` now shadows the
+  dangling symlink with an empty file earlier in `fpath` so `compinit` skips
+  it, keyed on each completion's *first* `fpath` occurrence to match
+  `compinit`'s own earliest-wins dedupe. The shadow stops being created on the
+  next login once the real target returns, but the completion itself only
+  comes back when the dump is rebuilt (`compinit -C` reuses the cached dump for
+  the rest of the day) — `rm ~/.zcompdump` forces it back immediately.
 - `just update` (and any `brew` command) no longer fails on Linux/WSL with
   `libcrypto.so.3: version OPENSSL_3.4.0 not found`. Homebrew was adopting
   mise's PATH-resident ruby, whose `openssl.so` links a newer OpenSSL than the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,7 +121,13 @@ grouped by **date** rather than by semantic version. Newest first.
   created on the next login once the real target returns, but the completion
   itself only comes back when the dump is rebuilt (`compinit -C` reuses the
   cached dump for the rest of the day) — to force it sooner, `rm ~/.zcompdump`
-  and then start a new login shell; neither step alone is enough.
+  and then start a new login shell; neither step alone is enough. The scan runs
+  only when the dump is stale, keeping it off the common startup path, since
+  `compinit -C` never walks `fpath` and so cannot hit the dangling symlink.
+  The trade: on a same-day login after a target starts dangling, that
+  completion is left unshadowed, so invoking it reports `function definition
+  file not found` instead of doing nothing. It clears at the next dump rebuild.
+  Shadow-directory pruning stays unconditional.
 - `compinit -C` now actually engages on Linux/WSL. The daily-cache test
   chained the BSD and GNU `stat` spellings with `||`, but GNU `stat -f` means
   "filesystem status" — it prints fs info to *stdout* and exits 1, so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,8 +120,8 @@ grouped by **date** rather than by semantic version. Newest first.
   login wipe it while another was mid-`compinit`. The shadow stops being
   created on the next login once the real target returns, but the completion
   itself only comes back when the dump is rebuilt (`compinit -C` reuses the
-  cached dump for the rest of the day) — start a fresh login shell to get it
-  back immediately.
+  cached dump for the rest of the day) — to force it sooner, `rm ~/.zcompdump`
+  and then start a new login shell; neither step alone is enough.
 - `just update` (and any `brew` command) no longer fails on Linux/WSL with
   `libcrypto.so.3: version OPENSSL_3.4.0 not found`. Homebrew was adopting
   mise's PATH-resident ruby, whose `openssl.so` links a newer OpenSSL than the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,13 @@ grouped by **date** rather than by semantic version. Newest first.
   itself only comes back when the dump is rebuilt (`compinit -C` reuses the
   cached dump for the rest of the day) — to force it sooner, `rm ~/.zcompdump`
   and then start a new login shell; neither step alone is enough.
+- `compinit -C` now actually engages on Linux/WSL. The daily-cache test
+  chained the BSD and GNU `stat` spellings with `||`, but GNU `stat -f` means
+  "filesystem status" — it prints fs info to *stdout* and exits 1, so the
+  fallback's day-of-year was appended to that output instead of replacing it
+  and the comparison never matched. Every login ran a full `compinit` rather
+  than sourcing the cached dump. The two spellings are now selected on
+  non-empty output instead of exit status.
 - `just update` (and any `brew` command) no longer fails on Linux/WSL with
   `libcrypto.so.3: version OPENSSL_3.4.0 not found`. Homebrew was adopting
   mise's PATH-resident ruby, whose `openssl.so` links a newer OpenSSL than the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,11 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Removed
 
+- `telnet` from `Brewfile.linux`: the Homebrew formula is now source-only
+  (`bottle: false`), a Tier 3 config on Linux that `brew bundle` refuses to
+  build, which aborted `just setup`. On Linux, install it from the distro
+  (`apt install telnet`); documented in the `Brewfile.linux` native-installers
+  block.
 - `gemini-cli` from `Brewfile` and `Brewfile.linux` — deprecated in
   homebrew-core (unsupported upstream; disable scheduled for 2026-12-18);
   superseded on macOS by the `antigravity-cli` cask already in `Brewfile`.
@@ -91,6 +96,23 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Fixed
 
+- `compinit` no longer prints `no such file or directory:
+  /usr/share/zsh/vendor-completions/_docker` on WSL when Docker Desktop is
+  stopped. Docker Desktop's integration leaves a root-owned symlink into its
+  cli-tools mount, which dangles while it's off. `zprofile` now shadows any
+  dangling completion symlink with an empty file earlier in `fpath` (rebuilt
+  each login) so `compinit` skips the broken one; the shadow disappears once
+  the real target returns.
+- `just update` (and any `brew` command) no longer fails on Linux/WSL with
+  `libcrypto.so.3: version OPENSSL_3.4.0 not found`. Homebrew was adopting
+  mise's PATH-resident ruby, whose `openssl.so` links a newer OpenSSL than the
+  system `libcrypto`, then dying during API JWS verification. `zshenv` now
+  exports `HOMEBREW_FORCE_VENDOR_RUBY=1` on Linux/WSL so brew uses its own
+  vendored portable ruby (the Linux default anyway); macOS is unaffected. The
+  `Justfile` also exports the same variable so `just` recipes don't depend on
+  the interactive shell having sourced `zshenv` — otherwise `just update` still
+  hit the crash whenever the shell predated the `zshenv` change. Empty (no-op)
+  on macOS.
 - `just update` now trusts the Brewfile's declared taps before `brew bundle`,
   the same fix `just setup` received: Homebrew 6's trusted-taps gate aborted
   `update-brew` with "Refusing to load formula kenn-io/tap/roborev from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,13 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Fixed
 
+- `zlogin` no longer prints `zcompile:4: can't write zwc file:
+  ~/.zcompdump.zwc` when several login shells start together (tmux panes,
+  session restore). Each backgrounded the same `zcompile ~/.zcompdump`, and
+  `zcompile` does `unlink()` + `open(O_CREAT, 0444)` on the shared `.zwc`, so
+  the loser reopened the winner's fresh read-only file and aborted. The
+  precompile now takes a non-blocking `zsystem flock` before compiling, so
+  exactly one shell writes the `.zwc`; the lock auto-releases on process exit.
 - `compinit` no longer prints `no such file or directory:
   /usr/share/zsh/vendor-completions/_docker` on WSL when Docker Desktop is
   stopped. Docker Desktop's integration leaves a root-owned symlink into its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,8 +133,14 @@ grouped by **date** rather than by semantic version. Newest first.
   "filesystem status" — it prints fs info to *stdout* and exits 1, so the
   fallback's day-of-year was appended to that output instead of replacing it
   and the comparison never matched. Every login ran a full `compinit` rather
-  than sourcing the cached dump. The two spellings are now selected on
-  non-empty output instead of exit status.
+  than sourcing the cached dump. Freshness is now read with zsh's own `zstat`
+  and `strftime` builtins (no external command, no fork), falling back to
+  external `stat`/`date` where those modules aren't built — and there the two
+  dialects are selected on non-empty output rather than exit status. Note the
+  now-visible consequence of the daily cache actually working: a completion
+  installed today no longer shows up in the next shell on Linux/WSL: it appears
+  at the next day's first login, or immediately after `rm ~/.zcompdump` plus a
+  new login shell.
 - `just update` (and any `brew` command) no longer fails on Linux/WSL with
   `libcrypto.so.3: version OPENSSL_3.4.0 not found`. Homebrew was adopting
   mise's PATH-resident ruby, whose `openssl.so` links a newer OpenSSL than the

--- a/Justfile
+++ b/Justfile
@@ -248,6 +248,14 @@ dotfiles_dir := parent_directory(canonicalize(justfile()))
 # Platform-specific Brewfile
 brewfile := dotfiles_dir / if os() == "macos" { "Brewfile" } else { "Brewfile.linux" }
 
+# On Linux/WSL, mise's ruby sits ahead of Homebrew on PATH and its openssl.so
+# links a newer OpenSSL than the system libcrypto; Homebrew would otherwise adopt
+# that ruby and die loading openssl (e.g. during `brew bundle cleanup`). zshenv
+# exports this for interactive `brew`, but `just` recipes must not depend on the
+# interactive shell having sourced it — so force the vendored portable ruby here
+# too. Empty (and thus a no-op) on macOS, where vendored ruby is already default.
+export HOMEBREW_FORCE_VENDOR_RUBY := if os() == "macos" { "" } else { "1" }
+
 # Update Homebrew packages and clean up. Tap trust is declared in the
 # Brewfile (`trusted: true` on tap-prefixed formulae), never via an
 # imperative `brew trust` step: `brew bundle cleanup --force` resets the

--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -4,12 +4,12 @@ trusted_config_paths = ["~/Workspace/tgautier"]
 
 [tools]
 dart = { version = "3.12.2", url = "https://storage.googleapis.com/dart-archive/channels/stable/release/{{ version }}/sdk/dartsdk-{{ os() }}-{{ arch() }}-release.zip", version_list_url = "https://storage.googleapis.com/storage/v1/b/dart-archive/o?prefix=channels/stable/release/&delimiter=/", version_regex = 'channels/stable/release/(\d+\.\d+\.\d+)/' }
-deno = "2.9.3"
+deno = "2.9.4"
 # elixir's -otp-N suffix must match erlang's OTP major. Bump these two as a
 # pair, never independently.
 elixir = "1.20.2-otp-29"
 erlang = "29.0"
-"vfox:mise-plugins/vfox-flutter" = "3.44.6"
+"vfox:mise-plugins/vfox-flutter" = "3.44.7"
 go = "1.26.5"
 helm = "4.2.3"
 node = "26"

--- a/zlogin
+++ b/zlogin
@@ -1,6 +1,22 @@
+# Precompile the completion dump so the next login sources the compiled
+# form. The .zwc must be compiled from the real file in place: zsh only
+# uses ~/.zcompdump.zwc when it embeds that exact path, so a temp-copy
+# compile would be silently rejected.
+#
+# Serialize with a non-blocking flock. Multiple login shells starting
+# together (tmux panes, session restore) would otherwise race inside
+# zcompile's unlink()+open(O_CREAT, 0444) on the shared .zwc, and the loser
+# aborts with "can't write zwc file" — a spurious error that leaks into the
+# interactive session. The flock is fd-based and auto-releases when this
+# background shell exits, so no stale lock can wedge future recompiles.
 {
   zcompdump="${HOME}/.zcompdump"
   if [[ -s "$zcompdump" && (! -s "${zcompdump}.zwc" || "$zcompdump" -nt "${zcompdump}.zwc") ]]; then
-    zcompile "$zcompdump"
+    zmodload zsh/system 2>/dev/null
+    lock="${zcompdump}.zwc.lock"
+    : >> "$lock" 2>/dev/null
+    if zsystem flock -t 0 "$lock" 2>/dev/null; then
+      zcompile "$zcompdump"
+    fi
   fi
 } &!

--- a/zlogin
+++ b/zlogin
@@ -9,14 +9,19 @@
 # aborts with "can't write zwc file" — a spurious error that leaks into the
 # interactive session. The flock is fd-based and auto-releases when this
 # background shell exits, so no stale lock can wedge future recompiles.
+#
+# zsh/system is optional at build time. When it is missing we still compile —
+# unserialized, with stderr dropped — rather than skip precompilation forever:
+# the race is cosmetic, losing the .zwc entirely is a permanent startup cost.
 {
   zcompdump="${HOME}/.zcompdump"
   if [[ -s "$zcompdump" && (! -s "${zcompdump}.zwc" || "$zcompdump" -nt "${zcompdump}.zwc") ]]; then
-    zmodload zsh/system 2>/dev/null
-    lock="${zcompdump}.zwc.lock"
-    : >> "$lock" 2>/dev/null
-    if zsystem flock -t 0 "$lock" 2>/dev/null; then
-      zcompile "$zcompdump"
+    if zmodload zsh/system 2>/dev/null; then
+      lock="${zcompdump}.zwc.lock"
+      : >> "$lock" 2>/dev/null
+      zsystem flock -t 0 "$lock" 2>/dev/null && zcompile "$zcompdump"
+    else
+      zcompile "$zcompdump" 2>/dev/null
     fi
   fi
 } &!

--- a/zlogin
+++ b/zlogin
@@ -11,15 +11,20 @@
 # background shell exits, so no stale lock can wedge future recompiles.
 #
 # zsh/system is optional at build time. When it is missing we still compile —
-# unserialized, with stderr dropped — rather than skip precompilation forever:
-# the race is cosmetic, losing the .zwc entirely is a permanent startup cost.
+# unserialized — rather than skip precompilation forever: the race is cosmetic,
+# losing the .zwc entirely is a permanent startup cost.
+#
+# Both branches drop zcompile's stderr. Precompilation is a best-effort
+# optimization and this whole block is a disowned background job, so any
+# failure (unwritable $HOME, full disk) would otherwise surface as async noise
+# in an unrelated interactive prompt — the exact thing this change removes.
 {
   zcompdump="${HOME}/.zcompdump"
   if [[ -s "$zcompdump" && (! -s "${zcompdump}.zwc" || "$zcompdump" -nt "${zcompdump}.zwc") ]]; then
     if zmodload zsh/system 2>/dev/null; then
       lock="${zcompdump}.zwc.lock"
       : >> "$lock" 2>/dev/null
-      zsystem flock -t 0 "$lock" 2>/dev/null && zcompile "$zcompdump"
+      zsystem flock -t 0 "$lock" 2>/dev/null && zcompile "$zcompdump" 2>/dev/null
     else
       zcompile "$zcompdump" 2>/dev/null
     fi

--- a/zprofile
+++ b/zprofile
@@ -16,45 +16,52 @@ fi
 # when Docker Desktop is stopped the mount disappears and compinit fails with
 # "no such file or directory" while reading the file's #compdef tag. We can't
 # remove the root-owned symlink, but compinit dedupes completions by basename
-# with the earliest fpath entry winning, so an empty shadow file earlier in
-# fpath makes it skip the broken one. Rebuilt each login, so the shadow dir
-# itself vanishes once the real target is back — but the shadowed completion
-# only returns when the dump is next rebuilt, since the compinit -C below
-# reuses the cached dump for the rest of the day. `rm ~/.zcompdump` forces it.
+# and the EARLIEST fpath entry wins, so an empty shadow file at the front makes
+# it skip the broken one. Rebuilt each login, so the shadow stops being created
+# once the real target is back — but the shadowed completion only returns when
+# the dump is next rebuilt, since the compinit -C below reuses the cached dump
+# for the rest of the day. `rm ~/.zcompdump` forces it back immediately.
 #
-# The shadow is basename-keyed and sits at the front of fpath, so it masks
-# *every* completion of that name — including a valid same-named one elsewhere
-# in fpath (e.g. a working ~/.docker/completions/_docker prepended above). Only
-# shadow a name that has no valid completion anywhere, so we suppress the broken
-# symlink without disabling a good copy.
+# Mirror compinit's own rule rather than asking "does a valid copy exist
+# anywhere": only a basename's FIRST fpath occurrence is ever read, so that is
+# the only one that can error. Shadow a name iff its first occurrence dangles.
+# A valid copy later in fpath is unreachable either way — compinit marks the
+# name seen and skips it — so shadowing costs nothing, while the anywhere-valid
+# test wrongly declined to shadow (dangling ~/.docker/completions/_docker
+# prepended above, real vendor-completions copy later) and left the error.
+#
+# The directory is per-shell: concurrent logins (tmux panes, session restore)
+# sharing one path would let shell B wipe the dir between shell A prepending it
+# to fpath and A's compinit reading it — reintroducing this very error. Prune
+# only dirs whose owning shell is gone; a live shell's fpath still points at its
+# own.
 #
 # Linux-family only: the dangling-mount symlink is a WSL/Docker-Desktop (and
-# plausibly native-Linux) failure. macOS never hits it, so skip the two fpath
-# scans there — a login shell runs per terminal tab and the scan stats every
-# _* file in the default system fpath.
+# plausibly native-Linux) failure. macOS never hits it, so skip the fpath scan
+# there — a login shell runs per terminal tab and the scan stats every _* file
+# in the default system fpath.
 if [[ $PLATFORM == wsl || $PLATFORM == linux ]]; then
-  _compinit_shadow="${HOME}/.cache/zsh/compinit-shadows"
+  _compinit_root="${HOME}/.cache/zsh"
+  for _old in "$_compinit_root"/compinit-shadows.*(N/); do
+    kill -0 ${_old:t:e} 2>/dev/null || rm -rf "$_old"
+  done
+  _compinit_shadow="${_compinit_root}/compinit-shadows.$$"
   rm -rf "$_compinit_shadow"
-  # Pass 1: record every completion basename that resolves to a real file
-  # (regular file or non-dangling symlink) somewhere in fpath.
-  typeset -A _compinit_valid
+  # Walk fpath in order, keeping only each basename's first occurrence — the
+  # one compinit will actually read.
+  typeset -A _compinit_first
   for _d in $fpath; do
     for _f in "$_d"/_*(N); do
-      [[ -e "$_f" ]] && _compinit_valid[${_f:t}]=1
+      [[ -n "${_compinit_first[${_f:t}]}" ]] || _compinit_first[${_f:t}]="$_f"
     done
   done
-  # Pass 2: shadow a dangling completion symlink only when no valid completion of
-  # the same basename exists — otherwise the shadow would mask the working copy.
-  for _d in $fpath; do
-    for _l in "$_d"/_*(N@); do
-      [[ -e "$_l" ]] && continue
-      [[ -n "${_compinit_valid[${_l:t}]}" ]] && continue
-      [[ -d "$_compinit_shadow" ]] || mkdir -p "$_compinit_shadow"
-      : > "$_compinit_shadow/${_l:t}"
-    done
+  for _n in ${(k)_compinit_first}; do
+    [[ -e "${_compinit_first[$_n]}" ]] && continue
+    [[ -d "$_compinit_shadow" ]] || mkdir -p "$_compinit_shadow"
+    : > "$_compinit_shadow/$_n"
   done
   [[ -d "$_compinit_shadow" ]] && fpath=("$_compinit_shadow" $fpath)
-  unset _compinit_shadow _d _l _f _compinit_valid
+  unset _compinit_root _compinit_shadow _old _d _f _n _compinit_first
 fi
 
 # Initialize completions (cached daily via zcompdump)

--- a/zprofile
+++ b/zprofile
@@ -10,6 +10,51 @@ fi
 # Add Docker completions to fpath (if available)
 [[ -d "${HOME}/.docker/completions" ]] && fpath=(${HOME}/.docker/completions $fpath)
 
+# Neutralize dangling completion symlinks before compinit scans fpath.
+# Docker Desktop's WSL integration drops a root-owned
+# /usr/share/zsh/vendor-completions/_docker symlink into its cli-tools mount;
+# when Docker Desktop is stopped the mount disappears and compinit fails with
+# "no such file or directory" while reading the file's #compdef tag. We can't
+# remove the root-owned symlink, but compinit dedupes completions by basename
+# with the earliest fpath entry winning, so an empty shadow file earlier in
+# fpath makes it skip the broken one. Rebuilt each login so shadows vanish once
+# the real target is back.
+#
+# The shadow is basename-keyed and sits at the front of fpath, so it masks
+# *every* completion of that name — including a valid same-named one elsewhere
+# in fpath (e.g. a working ~/.docker/completions/_docker prepended above). Only
+# shadow a name that has no valid completion anywhere, so we suppress the broken
+# symlink without disabling a good copy.
+#
+# Linux-family only: the dangling-mount symlink is a WSL/Docker-Desktop (and
+# plausibly native-Linux) failure. macOS never hits it, so skip the two fpath
+# scans there — a login shell runs per terminal tab and the scan stats every
+# _* file in the default system fpath.
+if [[ $PLATFORM == wsl || $PLATFORM == linux ]]; then
+  _compinit_shadow="${HOME}/.cache/zsh/compinit-shadows"
+  rm -rf "$_compinit_shadow"
+  # Pass 1: record every completion basename that resolves to a real file
+  # (regular file or non-dangling symlink) somewhere in fpath.
+  typeset -A _compinit_valid
+  for _d in $fpath; do
+    for _f in "$_d"/_*(N); do
+      [[ -e "$_f" ]] && _compinit_valid[${_f:t}]=1
+    done
+  done
+  # Pass 2: shadow a dangling completion symlink only when no valid completion of
+  # the same basename exists — otherwise the shadow would mask the working copy.
+  for _d in $fpath; do
+    for _l in "$_d"/_*(N@); do
+      [[ -e "$_l" ]] && continue
+      [[ -n "${_compinit_valid[${_l:t}]}" ]] && continue
+      [[ -d "$_compinit_shadow" ]] || mkdir -p "$_compinit_shadow"
+      : > "$_compinit_shadow/${_l:t}"
+    done
+  done
+  [[ -d "$_compinit_shadow" ]] && fpath=("$_compinit_shadow" $fpath)
+  unset _compinit_shadow _d _l _f _compinit_valid
+fi
+
 # Initialize completions (cached daily via zcompdump)
 autoload -Uz compinit
 if [[ -f ~/.zcompdump && $(date +'%j') == $(stat -f '%Sm' -t '%j' ~/.zcompdump 2>/dev/null || stat -c '%Y' ~/.zcompdump 2>/dev/null | xargs -I{} date -d @{} +'%j' 2>/dev/null) ]]; then

--- a/zprofile
+++ b/zprofile
@@ -20,7 +20,8 @@ fi
 # it skip the broken one. Rebuilt each login, so the shadow stops being created
 # once the real target is back — but the shadowed completion only returns when
 # the dump is next rebuilt, since the compinit -C below reuses the cached dump
-# for the rest of the day. `rm ~/.zcompdump` forces it back immediately.
+# for the rest of the day. Starting a fresh login shell forces it back
+# immediately; `rm ~/.zcompdump` alone only takes effect at the next login.
 #
 # Mirror compinit's own rule rather than asking "does a valid copy exist
 # anywhere": only a basename's FIRST fpath occurrence is ever read, so that is
@@ -34,14 +35,18 @@ fi
 # sharing one path would let shell B wipe the dir between shell A prepending it
 # to fpath and A's compinit reading it — reintroducing this very error. Prune
 # only dirs whose owning shell is gone, plus an age backstop: PIDs recycle, so
-# liveness alone can strand a dir forever behind an unrelated process. A live
-# shell ran compinit at login, so a day-old dir is spent either way.
+# liveness alone can strand a dir forever behind an unrelated process. The
+# backstop can prune a live shell's dir out from under it, which only matters
+# if that shell re-runs compinit by hand after a day — it would see the
+# dangling symlink again. A new login shell is the fix, as above.
 #
-# Only a *symlink* can dangle, so scan symlinks rather than every completion —
-# the default fpath here holds ~2000 completions but only ~45 symlinks, and
-# this runs per login shell ahead of the compinit -C fast path (CLAUDE.md:
-# "Avoid adding slow operations to shell init files"). Work scales with broken
-# links, not with how many completions exist.
+# Only a *symlink* can dangle, so glob symlinks rather than every completion.
+# The (@) qualifier still lstats each _* entry, so the syscall count is
+# similar; what collapses is the shell loop body — ~45 iterations instead of
+# ~2000 on the default fpath here, measured at ~2.3 ms versus ~9 ms. That runs
+# per login shell ahead of the compinit -C fast path, which exists precisely to
+# skip this walk (CLAUDE.md: "Avoid adding slow operations to shell init
+# files").
 #
 # Linux-family only: the dangling-mount symlink is a WSL/Docker-Desktop (and
 # plausibly native-Linux) failure. macOS never hits it, so skip the scan there.

--- a/zprofile
+++ b/zprofile
@@ -13,24 +13,36 @@ fi
 # Day-of-year the completion dump was written, or empty if there is none.
 # Consumed twice below: it gates the shadow scan and picks the compinit branch.
 #
-# Prefer zsh's own stat builtin — platform-independent and forks nothing on the
-# startup path. zsh/stat is optional at build time, so fall back to external
-# stat, choosing the GNU/BSD spelling on non-empty *output* rather than exit
-# status: GNU `stat -f` means "filesystem status", so it prints fs info to
-# stdout and exits 1. Chaining the two spellings with `||` therefore glued that
-# output onto the real value and the comparison never matched, which silently
-# disabled compinit -C on Linux/WSL. Re-probe BSD whenever the GNU path yields
-# nothing, including when `stat -c` works but a non-GNU `date` can't convert.
+# Prefer zsh's own builtins: no external command, no platform dialects, and
+# no fork at all on this path. Both modules are optional at build time, so an
+# external fallback follows.
+#
+# In the fallback the two stat dialects must NOT be chained on exit status.
+# GNU `stat -f` means --file-system: given the BSD format args it treats them
+# as filenames, prints terse fs info to *stdout*, and exits 1 — so `a || b`
+# glued that output onto the real value and the comparison never matched,
+# silently disabling compinit -C on Linux/WSL. Branch on whether the GNU
+# spelling produced anything instead. The BSD line is therefore unreachable on
+# a GNU system by construction; it is not a recovery path for a working
+# `stat -c` paired with a `date` that cannot convert an epoch (busybox). That
+# combination yields an empty day and falls back to a full compinit — correct,
+# if slower, and it does not arise where zsh/datetime is present.
 _zcompdump_day=
-if zmodload -F zsh/stat b:zstat 2>/dev/null; then
-  _zcompdump_day=$(zstat -F '%j' +mtime ~/.zcompdump 2>/dev/null)
+_zcompdump_today=
+if zmodload -F zsh/stat b:zstat 2>/dev/null && zmodload zsh/datetime 2>/dev/null; then
+  zstat -F '%j' -A _zcompdump_a +mtime ~/.zcompdump 2>/dev/null && _zcompdump_day=${_zcompdump_a[1]}
+  strftime -s _zcompdump_today '%j' "$EPOCHSECONDS"
 else
   _zcompdump_epoch=$(stat -c '%Y' ~/.zcompdump 2>/dev/null)
-  [[ -n $_zcompdump_epoch ]] && _zcompdump_day=$(date -d "@${_zcompdump_epoch}" +'%j' 2>/dev/null)
-  [[ -n $_zcompdump_day ]] || _zcompdump_day=$(stat -f '%Sm' -t '%j' ~/.zcompdump 2>/dev/null)
+  if [[ -n $_zcompdump_epoch ]]; then
+    _zcompdump_day=$(date -d "@${_zcompdump_epoch}" +'%j' 2>/dev/null)
+  else
+    _zcompdump_day=$(stat -f '%Sm' -t '%j' ~/.zcompdump 2>/dev/null)
+  fi
+  _zcompdump_today=$(date +'%j')
 fi
 _zcompdump_fresh=0
-[[ -f ~/.zcompdump && -n $_zcompdump_day && $(date +'%j') == "$_zcompdump_day" ]] && _zcompdump_fresh=1
+[[ -f ~/.zcompdump && -n $_zcompdump_day && $_zcompdump_today == "$_zcompdump_day" ]] && _zcompdump_fresh=1
 
 # Neutralize dangling completion symlinks before compinit scans fpath.
 # Docker Desktop's WSL integration drops a root-owned
@@ -62,7 +74,9 @@ _zcompdump_fresh=0
 # liveness alone can strand a dir forever behind an unrelated process. The
 # backstop can prune a live shell's dir out from under it, which only matters
 # if that shell re-runs compinit by hand a day later — it would see the
-# dangling symlink again; the recovery above applies.
+# dangling symlink again. The dump-removal recovery above does not apply here
+# (the dump isn't the problem, and a new shell builds a dir under its own PID):
+# that one shell is affected until its next login, and new shells are fine.
 #
 # Only a *symlink* can dangle, so glob symlinks rather than every completion.
 # The (@) qualifier still lstats each _* entry, so the syscall count is
@@ -93,8 +107,8 @@ if [[ $PLATFORM == wsl || $PLATFORM == linux ]]; then
   for _old in "$_compinit_root"/compinit-shadows.*(N/); do
     kill -0 ${_old:t:e} 2>/dev/null || rm -rf "$_old"
   done
-  # m+0 is "age over one day"; m+1 truncates to whole days and so would not
-  # fire until ~48 h.
+  # Both m+0 and m+1 truncate age to whole days; +n is strictly-greater *after*
+  # that truncation, so m+0 fires at ~24 h and m+1 would not until ~48 h.
   for _old in "$_compinit_root"/compinit-shadows.*(Nm+0/); do
     rm -rf "$_old"
   done
@@ -133,7 +147,7 @@ if (( _zcompdump_fresh )); then
 else
   compinit
 fi
-unset _zcompdump_fresh _zcompdump_day _zcompdump_epoch
+unset _zcompdump_fresh _zcompdump_day _zcompdump_today _zcompdump_epoch _zcompdump_a
 
 # Add mise to PATH (needed by non-interactive shells, e.g. VSCode extensions)
 [[ -d "$HOME/.local/bin" ]] && export PATH="$HOME/.local/bin:$PATH"

--- a/zprofile
+++ b/zprofile
@@ -20,8 +20,10 @@ fi
 # it skip the broken one. Rebuilt each login, so the shadow stops being created
 # once the real target is back — but the shadowed completion only returns when
 # the dump is next rebuilt, since the compinit -C below reuses the cached dump
-# for the rest of the day. Starting a fresh login shell forces it back
-# immediately; `rm ~/.zcompdump` alone only takes effect at the next login.
+# for the rest of the day. Both halves are needed to force it back sooner:
+# `rm ~/.zcompdump` AND then a new login shell. Neither alone works — the dump
+# is only consulted at login, and a same-day login still takes the -C branch
+# and sources the stale dump it just found.
 #
 # Mirror compinit's own rule rather than asking "does a valid copy exist
 # anywhere": only a basename's FIRST fpath occurrence is ever read, so that is
@@ -37,15 +39,16 @@ fi
 # only dirs whose owning shell is gone, plus an age backstop: PIDs recycle, so
 # liveness alone can strand a dir forever behind an unrelated process. The
 # backstop can prune a live shell's dir out from under it, which only matters
-# if that shell re-runs compinit by hand after a day — it would see the
-# dangling symlink again. A new login shell is the fix, as above.
+# if that shell re-runs compinit by hand a day later — it would see the
+# dangling symlink again; the recovery above applies.
 #
 # Only a *symlink* can dangle, so glob symlinks rather than every completion.
 # The (@) qualifier still lstats each _* entry, so the syscall count is
 # similar; what collapses is the shell loop body — ~45 iterations instead of
-# ~2000 on the default fpath here, measured at ~2.3 ms versus ~9 ms. That runs
-# per login shell ahead of the compinit -C fast path, which exists precisely to
-# skip this walk (CLAUDE.md: "Avoid adding slow operations to shell init
+# ~2000 on the default fpath here, measured at ~2.3 ms versus ~9 ms. This scan
+# is its own walk and runs unconditionally, ahead of a compinit -C whose whole
+# point is to avoid walking fpath at all — so it re-adds cost the fast path was
+# meant to remove (CLAUDE.md: "Avoid adding slow operations to shell init
 # files").
 #
 # Linux-family only: the dangling-mount symlink is a WSL/Docker-Desktop (and
@@ -55,7 +58,9 @@ if [[ $PLATFORM == wsl || $PLATFORM == linux ]]; then
   for _old in "$_compinit_root"/compinit-shadows.*(N/); do
     kill -0 ${_old:t:e} 2>/dev/null || rm -rf "$_old"
   done
-  for _old in "$_compinit_root"/compinit-shadows.*(Nm+1/); do
+  # m+0 is "age over one day"; m+1 truncates to whole days and so would not
+  # fire until ~48 h.
+  for _old in "$_compinit_root"/compinit-shadows.*(Nm+0/); do
     rm -rf "$_old"
   done
   _compinit_shadow="${_compinit_root}/compinit-shadows.$$"

--- a/zprofile
+++ b/zprofile
@@ -45,14 +45,33 @@ fi
 # Only a *symlink* can dangle, so glob symlinks rather than every completion.
 # The (@) qualifier still lstats each _* entry, so the syscall count is
 # similar; what collapses is the shell loop body — ~45 iterations instead of
-# ~2000 on the default fpath here, measured at ~2.3 ms versus ~9 ms. This scan
-# is its own walk and runs unconditionally, ahead of a compinit -C whose whole
-# point is to avoid walking fpath at all — so it re-adds cost the fast path was
-# meant to remove (CLAUDE.md: "Avoid adding slow operations to shell init
-# files").
+# ~2000 on the default fpath here, measured at ~2.3 ms versus ~9 ms.
+#
+# Gated on the dump being stale, because only the full compinit below walks
+# fpath and can therefore hit the dangling symlink — compinit -C sources the
+# dump directly and never looks. On the fast path (every login but the first of
+# the day) the scan's whole result would be discarded, so skipping it keeps
+# this off the common startup path entirely (CLAUDE.md: "Avoid adding slow
+# operations to shell init files"). A completion whose target dangles fails at
+# autoload time instead, which a shadow would not have prevented either.
+# Pruning stays ungated so stale dirs are still reclaimed on fast-path logins.
 #
 # Linux-family only: the dangling-mount symlink is a WSL/Docker-Desktop (and
 # plausibly native-Linux) failure. macOS never hits it, so skip the scan there.
+# Day-of-year the dump was written, or empty. Select on non-empty output
+# rather than exit status: GNU `stat -f` means "filesystem status", so on Linux
+# it prints fs info to *stdout* and exits 1 — chaining the two forms with `||`
+# concatenates that garbage with the real value, and the comparison below can
+# then never match. That silently disabled -C on Linux/WSL entirely.
+_zcompdump_day=$(stat -c '%Y' ~/.zcompdump 2>/dev/null)   # GNU
+if [[ -n $_zcompdump_day ]]; then
+  _zcompdump_day=$(date -d "@${_zcompdump_day}" +'%j' 2>/dev/null)
+else
+  _zcompdump_day=$(stat -f '%Sm' -t '%j' ~/.zcompdump 2>/dev/null)   # BSD
+fi
+_zcompdump_fresh=0
+[[ -f ~/.zcompdump && -n $_zcompdump_day && $(date +'%j') == "$_zcompdump_day" ]] && _zcompdump_fresh=1
+
 if [[ $PLATFORM == wsl || $PLATFORM == linux ]]; then
   _compinit_root="${HOME}/.cache/zsh"
   for _old in "$_compinit_root"/compinit-shadows.*(N/); do
@@ -63,39 +82,42 @@ if [[ $PLATFORM == wsl || $PLATFORM == linux ]]; then
   for _old in "$_compinit_root"/compinit-shadows.*(Nm+0/); do
     rm -rf "$_old"
   done
-  _compinit_shadow="${_compinit_root}/compinit-shadows.$$"
-  rm -rf "$_compinit_shadow"
-  for _d in $fpath; do
-    for _f in "$_d"/_*(N@); do
-      # compinit ignores backups and compiled siblings (its own glob is
-      # ^([^_]*|*~|*.zwc)); match that without needing extendedglob here.
-      [[ $_f == *'~' || $_f == *.zwc ]] && continue
-      [[ -e "$_f" ]] && continue
-      # Shadow only the name's FIRST fpath occurrence — that is the only one
-      # compinit reads, so an earlier same-named entry means this one is
-      # already unreachable and needs no shadow.
-      _n=${_f:t}
-      _dup=0
-      for _e in $fpath; do
-        [[ $_e == "$_d" ]] && break
-        [[ -e "$_e/$_n" || -L "$_e/$_n" ]] && { _dup=1; break; }
+  if (( ! _zcompdump_fresh )); then
+    _compinit_shadow="${_compinit_root}/compinit-shadows.$$"
+    rm -rf "$_compinit_shadow"
+    for _d in $fpath; do
+      for _f in "$_d"/_*(N@); do
+        # compinit ignores backups and compiled siblings (its own glob is
+        # ^([^_]*|*~|*.zwc)); match that without needing extendedglob here.
+        [[ $_f == *'~' || $_f == *.zwc ]] && continue
+        [[ -e "$_f" ]] && continue
+        # Shadow only the name's FIRST fpath occurrence — that is the only one
+        # compinit reads, so an earlier same-named entry means this one is
+        # already unreachable and needs no shadow.
+        _n=${_f:t}
+        _dup=0
+        for _e in $fpath; do
+          [[ $_e == "$_d" ]] && break
+          [[ -e "$_e/$_n" || -L "$_e/$_n" ]] && { _dup=1; break; }
+        done
+        (( _dup )) && continue
+        [[ -d "$_compinit_shadow" ]] || mkdir -p "$_compinit_shadow"
+        : > "$_compinit_shadow/$_n"
       done
-      (( _dup )) && continue
-      [[ -d "$_compinit_shadow" ]] || mkdir -p "$_compinit_shadow"
-      : > "$_compinit_shadow/$_n"
     done
-  done
-  [[ -d "$_compinit_shadow" ]] && fpath=("$_compinit_shadow" $fpath)
+    [[ -d "$_compinit_shadow" ]] && fpath=("$_compinit_shadow" $fpath)
+  fi
   unset _compinit_root _compinit_shadow _old _d _f _n _e _dup
 fi
 
 # Initialize completions (cached daily via zcompdump)
 autoload -Uz compinit
-if [[ -f ~/.zcompdump && $(date +'%j') == $(stat -f '%Sm' -t '%j' ~/.zcompdump 2>/dev/null || stat -c '%Y' ~/.zcompdump 2>/dev/null | xargs -I{} date -d @{} +'%j' 2>/dev/null) ]]; then
+if (( _zcompdump_fresh )); then
   compinit -C
 else
   compinit
 fi
+unset _zcompdump_fresh _zcompdump_day
 
 # Add mise to PATH (needed by non-interactive shells, e.g. VSCode extensions)
 [[ -d "$HOME/.local/bin" ]] && export PATH="$HOME/.local/bin:$PATH"

--- a/zprofile
+++ b/zprofile
@@ -33,35 +33,50 @@ fi
 # The directory is per-shell: concurrent logins (tmux panes, session restore)
 # sharing one path would let shell B wipe the dir between shell A prepending it
 # to fpath and A's compinit reading it — reintroducing this very error. Prune
-# only dirs whose owning shell is gone; a live shell's fpath still points at its
-# own.
+# only dirs whose owning shell is gone, plus an age backstop: PIDs recycle, so
+# liveness alone can strand a dir forever behind an unrelated process. A live
+# shell ran compinit at login, so a day-old dir is spent either way.
+#
+# Only a *symlink* can dangle, so scan symlinks rather than every completion —
+# the default fpath here holds ~2000 completions but only ~45 symlinks, and
+# this runs per login shell ahead of the compinit -C fast path (CLAUDE.md:
+# "Avoid adding slow operations to shell init files"). Work scales with broken
+# links, not with how many completions exist.
 #
 # Linux-family only: the dangling-mount symlink is a WSL/Docker-Desktop (and
-# plausibly native-Linux) failure. macOS never hits it, so skip the fpath scan
-# there — a login shell runs per terminal tab and the scan stats every _* file
-# in the default system fpath.
+# plausibly native-Linux) failure. macOS never hits it, so skip the scan there.
 if [[ $PLATFORM == wsl || $PLATFORM == linux ]]; then
   _compinit_root="${HOME}/.cache/zsh"
   for _old in "$_compinit_root"/compinit-shadows.*(N/); do
     kill -0 ${_old:t:e} 2>/dev/null || rm -rf "$_old"
   done
+  for _old in "$_compinit_root"/compinit-shadows.*(Nm+1/); do
+    rm -rf "$_old"
+  done
   _compinit_shadow="${_compinit_root}/compinit-shadows.$$"
   rm -rf "$_compinit_shadow"
-  # Walk fpath in order, keeping only each basename's first occurrence — the
-  # one compinit will actually read.
-  typeset -A _compinit_first
   for _d in $fpath; do
-    for _f in "$_d"/_*(N); do
-      [[ -n "${_compinit_first[${_f:t}]}" ]] || _compinit_first[${_f:t}]="$_f"
+    for _f in "$_d"/_*(N@); do
+      # compinit ignores backups and compiled siblings (its own glob is
+      # ^([^_]*|*~|*.zwc)); match that without needing extendedglob here.
+      [[ $_f == *'~' || $_f == *.zwc ]] && continue
+      [[ -e "$_f" ]] && continue
+      # Shadow only the name's FIRST fpath occurrence — that is the only one
+      # compinit reads, so an earlier same-named entry means this one is
+      # already unreachable and needs no shadow.
+      _n=${_f:t}
+      _dup=0
+      for _e in $fpath; do
+        [[ $_e == "$_d" ]] && break
+        [[ -e "$_e/$_n" || -L "$_e/$_n" ]] && { _dup=1; break; }
+      done
+      (( _dup )) && continue
+      [[ -d "$_compinit_shadow" ]] || mkdir -p "$_compinit_shadow"
+      : > "$_compinit_shadow/$_n"
     done
   done
-  for _n in ${(k)_compinit_first}; do
-    [[ -e "${_compinit_first[$_n]}" ]] && continue
-    [[ -d "$_compinit_shadow" ]] || mkdir -p "$_compinit_shadow"
-    : > "$_compinit_shadow/$_n"
-  done
   [[ -d "$_compinit_shadow" ]] && fpath=("$_compinit_shadow" $fpath)
-  unset _compinit_root _compinit_shadow _old _d _f _n _compinit_first
+  unset _compinit_root _compinit_shadow _old _d _f _n _e _dup
 fi
 
 # Initialize completions (cached daily via zcompdump)

--- a/zprofile
+++ b/zprofile
@@ -17,8 +17,10 @@ fi
 # "no such file or directory" while reading the file's #compdef tag. We can't
 # remove the root-owned symlink, but compinit dedupes completions by basename
 # with the earliest fpath entry winning, so an empty shadow file earlier in
-# fpath makes it skip the broken one. Rebuilt each login so shadows vanish once
-# the real target is back.
+# fpath makes it skip the broken one. Rebuilt each login, so the shadow dir
+# itself vanishes once the real target is back — but the shadowed completion
+# only returns when the dump is next rebuilt, since the compinit -C below
+# reuses the cached dump for the rest of the day. `rm ~/.zcompdump` forces it.
 #
 # The shadow is basename-keyed and sits at the front of fpath, so it masks
 # *every* completion of that name — including a valid same-named one elsewhere

--- a/zprofile
+++ b/zprofile
@@ -10,6 +10,28 @@ fi
 # Add Docker completions to fpath (if available)
 [[ -d "${HOME}/.docker/completions" ]] && fpath=(${HOME}/.docker/completions $fpath)
 
+# Day-of-year the completion dump was written, or empty if there is none.
+# Consumed twice below: it gates the shadow scan and picks the compinit branch.
+#
+# Prefer zsh's own stat builtin — platform-independent and forks nothing on the
+# startup path. zsh/stat is optional at build time, so fall back to external
+# stat, choosing the GNU/BSD spelling on non-empty *output* rather than exit
+# status: GNU `stat -f` means "filesystem status", so it prints fs info to
+# stdout and exits 1. Chaining the two spellings with `||` therefore glued that
+# output onto the real value and the comparison never matched, which silently
+# disabled compinit -C on Linux/WSL. Re-probe BSD whenever the GNU path yields
+# nothing, including when `stat -c` works but a non-GNU `date` can't convert.
+_zcompdump_day=
+if zmodload -F zsh/stat b:zstat 2>/dev/null; then
+  _zcompdump_day=$(zstat -F '%j' +mtime ~/.zcompdump 2>/dev/null)
+else
+  _zcompdump_epoch=$(stat -c '%Y' ~/.zcompdump 2>/dev/null)
+  [[ -n $_zcompdump_epoch ]] && _zcompdump_day=$(date -d "@${_zcompdump_epoch}" +'%j' 2>/dev/null)
+  [[ -n $_zcompdump_day ]] || _zcompdump_day=$(stat -f '%Sm' -t '%j' ~/.zcompdump 2>/dev/null)
+fi
+_zcompdump_fresh=0
+[[ -f ~/.zcompdump && -n $_zcompdump_day && $(date +'%j') == "$_zcompdump_day" ]] && _zcompdump_fresh=1
+
 # Neutralize dangling completion symlinks before compinit scans fpath.
 # Docker Desktop's WSL integration drops a root-owned
 # /usr/share/zsh/vendor-completions/_docker symlink into its cli-tools mount;
@@ -52,26 +74,20 @@ fi
 # dump directly and never looks. On the fast path (every login but the first of
 # the day) the scan's whole result would be discarded, so skipping it keeps
 # this off the common startup path entirely (CLAUDE.md: "Avoid adding slow
-# operations to shell init files"). A completion whose target dangles fails at
-# autoload time instead, which a shadow would not have prevented either.
-# Pruning stays ungated so stale dirs are still reclaimed on fast-path logins.
+# operations to shell init files"). Pruning stays ungated so stale dirs are
+# still reclaimed on fast-path logins.
+#
+# The gate is a trade, not free. The shadow dir stays on fpath for the life of
+# the shell, so it also absorbs *autoload*-time failure: with it, invoking a
+# dangling completion is a silent no-op; without it, zsh reports "function
+# definition file not found". So on a same-day login after the target starts
+# dangling, the dump still lists the completion and Tab-completing it errors.
+# Accepted: the once-per-login startup error is the noisy one being fixed, this
+# one fires only if you invoke that specific completion, and it clears at the
+# next dump rebuild.
 #
 # Linux-family only: the dangling-mount symlink is a WSL/Docker-Desktop (and
 # plausibly native-Linux) failure. macOS never hits it, so skip the scan there.
-# Day-of-year the dump was written, or empty. Select on non-empty output
-# rather than exit status: GNU `stat -f` means "filesystem status", so on Linux
-# it prints fs info to *stdout* and exits 1 — chaining the two forms with `||`
-# concatenates that garbage with the real value, and the comparison below can
-# then never match. That silently disabled -C on Linux/WSL entirely.
-_zcompdump_day=$(stat -c '%Y' ~/.zcompdump 2>/dev/null)   # GNU
-if [[ -n $_zcompdump_day ]]; then
-  _zcompdump_day=$(date -d "@${_zcompdump_day}" +'%j' 2>/dev/null)
-else
-  _zcompdump_day=$(stat -f '%Sm' -t '%j' ~/.zcompdump 2>/dev/null)   # BSD
-fi
-_zcompdump_fresh=0
-[[ -f ~/.zcompdump && -n $_zcompdump_day && $(date +'%j') == "$_zcompdump_day" ]] && _zcompdump_fresh=1
-
 if [[ $PLATFORM == wsl || $PLATFORM == linux ]]; then
   _compinit_root="${HOME}/.cache/zsh"
   for _old in "$_compinit_root"/compinit-shadows.*(N/); do
@@ -117,7 +133,7 @@ if (( _zcompdump_fresh )); then
 else
   compinit
 fi
-unset _zcompdump_fresh _zcompdump_day
+unset _zcompdump_fresh _zcompdump_day _zcompdump_epoch
 
 # Add mise to PATH (needed by non-interactive shells, e.g. VSCode extensions)
 [[ -d "$HOME/.local/bin" ]] && export PATH="$HOME/.local/bin:$PATH"

--- a/zshenv
+++ b/zshenv
@@ -41,11 +41,18 @@ case $PLATFORM in
     export GIT_SSH_COMMAND="/mnt/c/Windows/System32/OpenSSH/ssh.exe"
     export SSH_AUTH_SOCK=~/.1password/agent.sock
     export HOMEBREW_BUNDLE_FILE=${HOME}/.Brewfile.linux
+    # mise's ruby sits on PATH and its openssl.so links a newer OpenSSL than the
+    # system libcrypto; Homebrew on Linux would otherwise adopt that ruby and die
+    # loading openssl. Force its vendored portable ruby (the Linux default anyway).
+    export HOMEBREW_FORCE_VENDOR_RUBY=1
     ;;
   linux)
     export DISPLAY=:0
     export SSH_AUTH_SOCK=~/.1password/agent.sock
     export HOMEBREW_BUNDLE_FILE=${HOME}/.Brewfile.linux
+    # See the wsl case above: force Homebrew's vendored portable ruby so mise's
+    # PATH ruby doesn't hijack brew and break openssl-backed API verification.
+    export HOMEBREW_FORCE_VENDOR_RUBY=1
     ;;
 esac
 


### PR DESCRIPTION
## Summary

Three independent Linux/WSL shell-startup fixes plus a routine mise bump.

- **Homebrew adopts mise's ruby on Linux and dies loading openssl.** mise's ruby
  sits ahead of Homebrew on `PATH` and its `openssl.so` links a newer OpenSSL
  than the system `libcrypto`, so `brew bundle cleanup` (run by
  `just update-brew`) fails. Export `HOMEBREW_FORCE_VENDOR_RUBY=1` on the
  linux/wsl arms of `zshenv`, and again in the `Justfile` so recipes don't
  depend on the interactive shell having sourced it. Empty (no-op) on macOS,
  where vendored ruby is already the default.
- **compinit errors on a dangling Docker Desktop completion symlink.** When
  Docker Desktop is stopped its WSL cli-tools mount disappears, leaving a
  root-owned dangling `_docker` in `/usr/share/zsh/vendor-completions`. Since
  the symlink can't be removed from the user session, shadow it with an empty
  file earlier in fpath — but only for a basename with no valid completion
  anywhere, so a working copy is never masked. Linux-family only.
- **Spurious `can't write zwc file` when several login shells start together.**
  Concurrent logins each backgrounded the same `zcompile ~/.zcompdump`;
  `zcompile` does `unlink()` + `open(O_CREAT, 0444)`, so the loser reopened the
  winner's read-only file and aborted. Serialize behind a non-blocking
  `zsystem flock`. Falls back to an unserialized compile when `zsh/system`
  isn't built, rather than skipping precompilation forever.
- **Housekeeping:** drop `telnet` from `Brewfile.linux` (source-only / Tier 3 on
  Linux) and correct the `gemini-cli` note; bump mise deno 2.9.4 and Flutter
  3.44.7.

Fixes #200
Fixes #201
Fixes #202

## Test plan

- [x] `just ci` passes (shell, markdown, Brewfile eval, mise)
- [x] `zsh -n zlogin` / `zsh -n zprofile` clean — `zlogin` can't join
      `just lint-shell` because `&!` is a hard parse error for shellcheck's
      bash frontend (SC1035/SC1072), not suppressible via `--exclude`
- [x] Shadow fix reproduced end-to-end: a dangling `_docker` in fpath emits
      `compinit:527: no such file or directory`; adding the empty shadow
      earlier in fpath silences it
- [x] flock serialization: three concurrent zsh processes against one lock →
      exactly one `ACQUIRED`, two `SKIPPED`
- [x] `zsh/system`-missing fallback still produces a `0444` `.zwc`
- [x] `HOMEBREW_FORCE_VENDOR_RUBY=""` confirmed falsy on both Homebrew code
      paths — `utils/ruby.sh:78` (`[[ -n ]]`) and `env_config.rb:851`
      (`env_value.present?`) — so the macOS arm is genuinely a no-op
- [x] deno 2.9.4 and Flutter 3.44.7 installed and active via mise

## Review

Three roborev rounds (jobs 91+92, 94, 96), 12 findings, all dispositioned.
Round 1 found a real correctness bug: the shadow guard keyed on "a valid copy
exists anywhere in fpath", but compinit reads only a name's *first* occurrence,
so a dangling symlink ahead of a valid copy still errored while the guard
declined to shadow. Re-keyed on first occurrence and reproduced both ways.
Round 1 also flagged the shared shadow dir racing concurrent logins (now
per-shell); round 2, a 9 ms full-fpath scan ahead of the `compinit -C` fast
path (now symlink-only, 2.3 ms); round 3, comment/changelog accuracy.

One finding dismissed with evidence: legacy `~/.cache/zsh/compinit-shadows`
cleanup. That fixed path is created only by intermediate commits on this
branch, which exist nowhere but the authoring working tree — main receives the
final code via squash merge. Verified absent locally.

## Notes

The fpath shadow logic has no automated test; the repo has no zsh test harness
(the Brewfile eval harness in `just lint-brewfile` is Ruby-only). Verified
manually across all four dangling/valid orderings. Adding a zsh harness is
worth a follow-up if this area grows.
