### PR TITLE
chore(mise): bump flutter to 3.44.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Changed
 
+- Bump mise Flutter (`vfox-flutter`) 3.44.7 → 3.44.8.
 - Tap trust is now declared in the Brewfiles: `trusted: true` on
   `kenn-io/tap/roborev` and `terror/tap/just-lsp` (formula-level trust, as
   Homebrew recommends), in both `Brewfile` and `Brewfile.linux`. This replaces

--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -9,7 +9,7 @@ deno = "2.9.4"
 # pair, never independently.
 elixir = "1.20.2-otp-29"
 erlang = "29.0"
-"vfox:mise-plugins/vfox-flutter" = "3.44.7"
+"vfox:mise-plugins/vfox-flutter" = "3.44.8"
 go = "1.26.5"
 helm = "4.2.3"
 node = "26"


### PR DESCRIPTION
## Summary

- Bump mise Flutter (`vfox:mise-plugins/vfox-flutter`) 3.44.7 → 3.44.8.
- Changelog entry under `[Unreleased] / Changed`.

## Test plan

- [x] `just ci` passes locally (shellcheck, markdownlint, zsh syntax, Brewfile merge/duplicate guards, mise config resolve)
- [x] CI green on the PR (Lint pass)