### PR TITLE
docs(brew): add homebrew update + cask recovery guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,13 @@ grouped by **date** rather than by semantic version. Newest first.
   than a native-installer tool: `just setup` installs it and `just update`
   upgrades it.
 - `docs/homebrew.md` — Homebrew update flow plus troubleshooting for the
-  recurring `just update` failure where an interrupted cask upgrade leaves a
-  partial app bundle in the Caskroom staging directory ("It seems there is
-  already an App at ..."). Indexed from `README.md` and `CLAUDE.md`.
+  recurring `just update` failure where an interrupted cask upgrade leaves
+  something behind in the Caskroom staging directory ("It seems there is
+  already an App at ..."). The leftover can be a truncated partial, a complete
+  backup of the live app, or a wrapper directory holding a nested `.app`; the
+  documented remedy is `brew reinstall --cask <cask>` followed by re-running
+  `just update`, which handles all three without inspecting which one you have.
+  Indexed from `README.md` and `CLAUDE.md`.
 - `python@3.13` in `Brewfile` (macOS) — satisfies the `gcloud-cli` cask's
   declared dependency, clearing the `brew missing` warning. macOS-only:
   `gcloud-cli` is a cask, so `Brewfile.linux` (native gcloud installer) is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ grouped by **date** rather than by semantic version. Newest first.
   formula, `node` dependency), so it is brew-managed on both platforms rather
   than a native-installer tool: `just setup` installs it and `just update`
   upgrades it.
+- `docs/homebrew.md` — Homebrew update flow plus troubleshooting for the
+  recurring `just update` failure where an interrupted cask upgrade leaves a
+  partial app bundle in the Caskroom staging directory ("It seems there is
+  already an App at ..."). Indexed from `README.md` and `CLAUDE.md`.
 - `python@3.13` in `Brewfile` (macOS) — satisfies the `gcloud-cli` cask's
   declared dependency, clearing the `brew missing` warning. macOS-only:
   `gcloud-cli` is a cask, so `Brewfile.linux` (native gcloud installer) is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,4 +113,5 @@ entries not yet dated.
 
 Detailed guides live in `docs/`:
 
+- `docs/homebrew.md` — update flow, cask-upgrade recovery, `just update` troubleshooting
 - `docs/tmux.md` — configuration overview, cheat sheet, troubleshooting

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Or run individual update steps:
 
 Detailed guides live in the `docs/` folder:
 
+- [Homebrew](docs/homebrew.md) — update flow, cask-upgrade recovery, and `just update` troubleshooting
 - [tmux](docs/tmux.md) — configuration overview, cheat sheet, and troubleshooting
 
 ## Structure

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -93,27 +93,29 @@ Caskroom copy is the only copy of the app you have. Reinstall covers that case
 by construction: it fetches before it uninstalls, so nothing is removed until
 the replacement is already on disk.
 
-**If you want a rollback copy**, take one before reinstalling — `cp -R`, never
-`mv`, so the staging directory is left exactly as it is and the reinstall path
-is unchanged:
+**Reinstall lands the current version, and does not preserve the old one.** A
+cask tap generally serves only the current version, so once the forced
+uninstall runs there is no Homebrew route back to what was installed before.
+That is the same version `just update` was trying to install, so it is normally
+what you want. If keeping the *old* version specifically matters, stop — that
+is a downgrade, a separate task with its own procedure, and this runbook will
+not get you there.
 
-```sh
-cp -R "$(brew --prefix)/Caskroom/<cask>/<old-version>/<App>.app" "$HOME/Desktop/"
-```
+Do not improvise a rollback by copying the Caskroom leftover aside. It is one
+of the three shapes above, only one of which is a working app, so the copy may
+be unlaunchable — and restoring it is not symmetric: Homebrew's metadata would
+still record the new version, leaving `brew list --cask --versions` and the
+next `just update` disagreeing with what is on disk.
 
-Casks generally serve only the current version, so once the forced uninstall
-runs the old bundle is not recoverable from Homebrew. Delete the copy once the
-new version is verified.
-
-Hand-moving the leftover buys nothing. `brew upgrade --cask` fetches the same
-artifact `brew reinstall --cask` does, and the aborted upgrade already
+Hand-moving the leftover buys nothing either. `brew upgrade --cask` fetches the
+same artifact `brew reinstall --cask` does, and the aborted upgrade already
 downloaded it — `brew cleanup --prune=all` never ran, so it is still cached.
 The manual route costs the same download and adds every failure mode reinstall
 avoids.
 
-**Finish the update.** The failure aborted `update-brew` at its
-second step, so `brew upgrade`, both cleanups, and `brew doctor` never ran.
-Re-run the pipeline so the direct `brew` call stays a one-off:
+**Finish the update.** The failure aborted `update-brew` at its second step, so
+`brew upgrade`, both cleanups, and `brew doctor` never ran. Re-run the pipeline
+so the direct `brew` call stays a one-off:
 
 ```sh
 just update

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -97,11 +97,19 @@ the replacement is already on disk.
 cask tap generally serves only the current version, so once the forced
 uninstall runs there is no Homebrew route back to what was installed before.
 That is the same version `just update` was trying to install, so it is normally
-what you want. If keeping the *old* version specifically matters, note that
-Homebrew has no supported cask downgrade — it means checking out an older tap
-revision, which is out of scope here. Until you run the reinstall your current
-install is untouched, but the wedge stays in place and every `just update`
-keeps failing, so this branch has no resting state: decide, then reinstall.
+what you want.
+
+If keeping the *old* version specifically matters, check
+`brew search --cask '<cask>@'` first — homebrew-cask maintains versioned tokens
+for a subset of apps (`1password@7`, `ableton-live-suite@10`), which is a
+supported route to an older version. Without one, downgrading means checking
+out an older tap revision, which is out of scope here.
+
+The reinstall is not what puts your install at risk, though: the interrupted
+upgrade may have stripped `/Applications/<App>.app` already, so confirm it is
+present and non-empty before treating it as an old version you still have to
+weigh. Either way the wedge stays in place and every `just update` keeps
+failing until you reinstall — this branch has no resting state.
 
 Do not improvise a rollback by copying the Caskroom leftover aside. It is one
 of the three shapes above, only one of which is a working app, so the copy may

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -97,9 +97,11 @@ the replacement is already on disk.
 cask tap generally serves only the current version, so once the forced
 uninstall runs there is no Homebrew route back to what was installed before.
 That is the same version `just update` was trying to install, so it is normally
-what you want. If keeping the *old* version specifically matters, stop — that
-is a downgrade, a separate task with its own procedure, and this runbook will
-not get you there.
+what you want. If keeping the *old* version specifically matters, note that
+Homebrew has no supported cask downgrade — it means checking out an older tap
+revision, which is out of scope here. Until you run the reinstall your current
+install is untouched, but the wedge stays in place and every `just update`
+keeps failing, so this branch has no resting state: decide, then reinstall.
 
 Do not improvise a rollback by copying the Caskroom leftover aside. It is one
 of the three shapes above, only one of which is a working app, so the copy may

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -93,13 +93,25 @@ Caskroom copy is the only copy of the app you have. Reinstall covers that case
 by construction: it fetches before it uninstalls, so nothing is removed until
 the replacement is already on disk.
 
+**If you want a rollback copy**, take one before reinstalling — `cp -R`, never
+`mv`, so the staging directory is left exactly as it is and the reinstall path
+is unchanged:
+
+```sh
+cp -R "$(brew --prefix)/Caskroom/<cask>/<old-version>/<App>.app" "$HOME/Desktop/"
+```
+
+Casks generally serve only the current version, so once the forced uninstall
+runs the old bundle is not recoverable from Homebrew. Delete the copy once the
+new version is verified.
+
 Hand-moving the leftover buys nothing. `brew upgrade --cask` fetches the same
 artifact `brew reinstall --cask` does, and the aborted upgrade already
 downloaded it — `brew cleanup --prune=all` never ran, so it is still cached.
 The manual route costs the same download and adds every failure mode reinstall
 avoids.
 
-**Finish the update either way.** The failure aborted `update-brew` at its
+**Finish the update.** The failure aborted `update-brew` at its
 second step, so `brew upgrade`, both cleanups, and `brew doctor` never ran.
 Re-run the pipeline so the direct `brew` call stays a one-off:
 

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -41,6 +41,9 @@ something else breaks.
 macOS only — `Brewfile.linux` declares no casks, so there is no Caskroom
 staging directory to wedge.
 
+Paths below are shown for the Apple Silicon prefix `/opt/homebrew`; Intel Macs
+use `/usr/local`. The commands all derive it via `$(brew --prefix)`.
+
 **Symptom** — `just update` dies in `update-brew` with a single failed cask:
 
 ```text
@@ -73,22 +76,43 @@ ls -la "$CASKROOM/<App>.app/Contents/"
 du -sh "$CASKROOM/<App>.app" "/Applications/<App>.app"
 ```
 
-**Fix** — move the leftover aside rather than deleting it outright, so the step
-is reversible, then re-run the upgrade. The timestamped destination keeps a
-second occurrence from nesting inside the first:
+**Stop if it is not a partial.** Homebrew puts the *live* app in this same
+path when it backs one up, so a complete bundle here may be the only copy you
+have. Abort and do not move anything if any of these hold:
+
+- `Contents/Info.plist` **is** present
+- the two `du -sh` sizes are within a few MB of each other
+- `du -sh` on `/Applications/<App>.app` errors with "No such file or directory"
+
+That combination means the interruption happened *after* the backup, so the
+Caskroom copy is a working app and `/Applications` is missing it. Move that
+copy back to `/Applications` (or reinstall the cask) instead — clearing the
+staging directory here would discard the only good bundle.
+
+**Fix** — once confirmed stale, move the leftover aside rather than deleting it
+outright, so the step is reversible, then re-run the upgrade. The timestamped
+destination keeps a second occurrence from nesting inside the first, and
+`${CASKROOM:?}` aborts loudly rather than building a path rooted at `/` if the
+variable is unset:
 
 ```sh
 CASKROOM="$(brew --prefix)/Caskroom/<cask>/<old-version>"   # repeated: do not rely on the block above
 STALE="$HOME/Desktop/stale-<cask>-$(date +%Y%m%d%H%M%S).app"
-mv "$CASKROOM/<App>.app" "$STALE"
+mv "${CASKROOM:?set CASKROOM first}/<App>.app" "$STALE"
 brew upgrade --cask <cask>
 brew list --cask --versions <cask>   # verify the new version landed
 ```
 
 Once the upgrade succeeds, delete `$STALE`. If the upgrade fails instead,
-restore with `mv "$STALE" "$CASKROOM/<App>.app"` — run it in the same shell, or
-re-assign `CASKROOM` first. With `CASKROOM` unset that command expands to the
-volume root, so never run the restore against a bare `/<App>.app`.
+restore with:
+
+```sh
+mv "$STALE" "${CASKROOM:?set CASKROOM first}/<App>.app"
+```
+
+The `:?` guard matters because both directions build a path from `$CASKROOM`.
+Pasted into a fresh shell where it is unset, an unguarded expansion would
+target the volume root.
 
 `brew reinstall --cask <cask>` also clears the leftover, because reinstall
 always *forces* its internal uninstall and a forced backup overwrites the

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -54,7 +54,7 @@ Error: <cask>: It seems there is already an App at
 ```
 
 **Cause** — an earlier cask upgrade was interrupted (Ctrl-C, sleep, crash, or a
-self-updating app racing brew) and left a partial app bundle in the Caskroom
+self-updating app racing brew) and left something behind in the Caskroom
 staging directory. Before swapping in the new version, Homebrew backs the live
 app up into that exact path:
 
@@ -66,58 +66,43 @@ An unforced upgrade refuses to overwrite what is already sitting there, so
 every subsequent `just update` fails the same way until the leftover is
 cleared.
 
-**Which branch you are in** turns on one question: does the live app still
-exist? Homebrew stages the *live* app into this same path when it backs one up,
-so the Caskroom copy is only disposable while `/Applications` still has its
-own.
+**Fix** — reinstall the cask:
+
+```sh
+brew reinstall --cask <cask>
+```
+
+That is the whole remedy in nearly every case. Three properties make it the
+default rather than a fallback:
+
+- Its internal uninstall is **forced**, so the backup step overwrites the
+  wedged staging directory instead of refusing — which is exactly what a plain
+  `brew upgrade` cannot do.
+- It **fetches before it uninstalls**, so a failed or interrupted download
+  leaves the current install untouched.
+- It yields a known-good bundle regardless of what the leftover was, and the
+  leftover can be any of three shapes: a truncated partial, a *complete* backup
+  of the live app, or a wrapper directory holding a nested `<App>.app` from an
+  earlier bad move. Inspecting which one you have is exactly the step this
+  avoids.
+
+**If `/Applications/<App>.app` is missing**, the leftover may be your only copy
+of the app — the interruption landed after the backup. Reinstall still fixes
+it, but do not delete the Caskroom directory by hand until it succeeds.
+
+**Only if the download is prohibitively large**, clear the staging directory
+manually instead and upgrade in place:
 
 ```sh
 CASKROOM="$(brew --prefix)/Caskroom/<cask>/<old-version>"
-ls -d "$CASKROOM/<App>.app" "/Applications/<App>.app"
-```
-
-Everything else — a missing `Contents/Info.plist`, a much smaller `du -sh` — is
-corroboration that the leftover is a partial, not the decision itself.
-
-**Branch A — `/Applications/<App>.app` exists.** The usual case, and the live
-app is intact, so the Caskroom copy is disposable whether it is a partial or a
-completed backup. Move it aside rather than deleting it, then re-run the
-upgrade. The timestamped destination keeps a second occurrence from nesting
-inside the first, and `${CASKROOM:?}` aborts loudly rather than building a path
-rooted at `/` if the variable is unset:
-
-```sh
-CASKROOM="$(brew --prefix)/Caskroom/<cask>/<old-version>"   # repeated: do not rely on the block above
-STALE="$HOME/Desktop/stale-<cask>-$(date +%Y%m%d%H%M%S).app"
-mv "${CASKROOM:?set CASKROOM first}/<App>.app" "$STALE"
+mv "${CASKROOM:?set CASKROOM first}/<App>.app" "$HOME/Desktop/stale-<cask>.app"
 brew upgrade --cask <cask>
 ```
 
-Once the upgrade succeeds, delete `$STALE`. If it fails instead, restore with:
-
-```sh
-mkdir -p "${CASKROOM:?set CASKROOM first}"   # a partial upgrade may have purged it
-mv "$STALE" "${CASKROOM:?set CASKROOM first}/<App>.app"
-```
-
-Or skip the hand-move entirely: `brew reinstall --cask <cask>` clears the
-leftover on its own, because reinstall always *forces* its internal uninstall
-and a forced backup overwrites the staging directory instead of refusing. It
-re-downloads the whole cask, so prefer the move above when the download is
-large. Branch A only — if the live app is missing, use Branch B instead, which
-recovers it without a download.
-
-**Branch B — `/Applications/<App>.app` is missing.** The interruption landed
-after the backup, so the Caskroom copy is the only app you have. Do **not**
-move it to the Desktop. Put it back where it belongs:
-
-```sh
-mv "${CASKROOM:?set CASKROOM first}/<App>.app" "/Applications/<App>.app"
-```
-
-Never run that `mv` when `/Applications/<App>.app` already exists — `mv` onto
-an existing bundle nests the copy *inside* it and corrupts the working app.
-That is why the branch is gated on absence.
+Leave the moved copy on the Desktop as evidence and delete it once the upgrade
+succeeds. Do **not** move it back into the Caskroom if the upgrade fails —
+that restores the precise state that raises the error and re-arms the wedge.
+Fall back to `brew reinstall --cask <cask>` instead.
 
 **Finish the update either way.** The failure aborted `update-brew` at its
 second step, so `brew upgrade`, both cleanups, and `brew doctor` never ran.

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -86,23 +86,18 @@ default rather than a fallback:
   earlier bad move. Inspecting which one you have is exactly the step this
   avoids.
 
-**If `/Applications/<App>.app` is missing**, the leftover may be your only copy
-of the app — the interruption landed after the backup. Reinstall still fixes
-it, but do not delete the Caskroom directory by hand until it succeeds.
+**Do not clear the staging directory by hand first.** If `/Applications/<App>.app`
+is missing — or present but *empty*, which Homebrew can leave behind when an
+upgrade strips a bundle's contents without removing its directory — then the
+Caskroom copy is the only copy of the app you have. Reinstall covers that case
+by construction: it fetches before it uninstalls, so nothing is removed until
+the replacement is already on disk.
 
-**Only if the download is prohibitively large**, clear the staging directory
-manually instead and upgrade in place:
-
-```sh
-CASKROOM="$(brew --prefix)/Caskroom/<cask>/<old-version>"
-mv "${CASKROOM:?set CASKROOM first}/<App>.app" "$HOME/Desktop/stale-<cask>.app"
-brew upgrade --cask <cask>
-```
-
-Leave the moved copy on the Desktop as evidence and delete it once the upgrade
-succeeds. Do **not** move it back into the Caskroom if the upgrade fails —
-that restores the precise state that raises the error and re-arms the wedge.
-Fall back to `brew reinstall --cask <cask>` instead.
+Hand-moving the leftover buys nothing. `brew upgrade --cask` fetches the same
+artifact `brew reinstall --cask` does, and the aborted upgrade already
+downloaded it — `brew cleanup --prune=all` never ran, so it is still cached.
+The manual route costs the same download and adds every failure mode reinstall
+avoids.
 
 **Finish the update either way.** The failure aborted `update-brew` at its
 second step, so `brew upgrade`, both cleanups, and `brew doctor` never ran.

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -66,58 +66,66 @@ An unforced upgrade refuses to overwrite what is already sitting there, so
 every subsequent `just update` fails the same way until the leftover is
 cleared.
 
-**Confirm it is a stale partial** — compare it against the live app. The
-leftover is typically missing `Contents/Info.plist` and is much smaller than
-the installed copy:
+**Which branch you are in** turns on one question: does the live app still
+exist? Homebrew stages the *live* app into this same path when it backs one up,
+so the Caskroom copy is only disposable while `/Applications` still has its
+own.
 
 ```sh
 CASKROOM="$(brew --prefix)/Caskroom/<cask>/<old-version>"
-ls -la "$CASKROOM/<App>.app/Contents/"
-du -sh "$CASKROOM/<App>.app" "/Applications/<App>.app"
+ls -d "$CASKROOM/<App>.app" "/Applications/<App>.app"
 ```
 
-**Stop if it is not a partial.** Homebrew puts the *live* app in this same
-path when it backs one up, so a complete bundle here may be the only copy you
-have. Abort and do not move anything if any of these hold:
+Everything else — a missing `Contents/Info.plist`, a much smaller `du -sh` — is
+corroboration that the leftover is a partial, not the decision itself.
 
-- `Contents/Info.plist` **is** present
-- the two `du -sh` sizes are within a few MB of each other
-- `du -sh` on `/Applications/<App>.app` errors with "No such file or directory"
-
-That combination means the interruption happened *after* the backup, so the
-Caskroom copy is a working app and `/Applications` is missing it. Move that
-copy back to `/Applications` (or reinstall the cask) instead — clearing the
-staging directory here would discard the only good bundle.
-
-**Fix** — once confirmed stale, move the leftover aside rather than deleting it
-outright, so the step is reversible, then re-run the upgrade. The timestamped
-destination keeps a second occurrence from nesting inside the first, and
-`${CASKROOM:?}` aborts loudly rather than building a path rooted at `/` if the
-variable is unset:
+**Branch A — `/Applications/<App>.app` exists.** The usual case, and the live
+app is intact, so the Caskroom copy is disposable whether it is a partial or a
+completed backup. Move it aside rather than deleting it, then re-run the
+upgrade. The timestamped destination keeps a second occurrence from nesting
+inside the first, and `${CASKROOM:?}` aborts loudly rather than building a path
+rooted at `/` if the variable is unset:
 
 ```sh
 CASKROOM="$(brew --prefix)/Caskroom/<cask>/<old-version>"   # repeated: do not rely on the block above
 STALE="$HOME/Desktop/stale-<cask>-$(date +%Y%m%d%H%M%S).app"
 mv "${CASKROOM:?set CASKROOM first}/<App>.app" "$STALE"
 brew upgrade --cask <cask>
-brew list --cask --versions <cask>   # verify the new version landed
 ```
 
-Once the upgrade succeeds, delete `$STALE`. If the upgrade fails instead,
-restore with:
+Once the upgrade succeeds, delete `$STALE`. If it fails instead, restore with:
 
 ```sh
+mkdir -p "${CASKROOM:?set CASKROOM first}"   # a partial upgrade may have purged it
 mv "$STALE" "${CASKROOM:?set CASKROOM first}/<App>.app"
 ```
 
-The `:?` guard matters because both directions build a path from `$CASKROOM`.
-Pasted into a fresh shell where it is unset, an unguarded expansion would
-target the volume root.
+Or skip the hand-move entirely: `brew reinstall --cask <cask>` clears the
+leftover on its own, because reinstall always *forces* its internal uninstall
+and a forced backup overwrites the staging directory instead of refusing. It
+re-downloads the whole cask, so prefer the move above when the download is
+large. Branch A only — if the live app is missing, use Branch B instead, which
+recovers it without a download.
 
-`brew reinstall --cask <cask>` also clears the leftover, because reinstall
-always *forces* its internal uninstall and a forced backup overwrites the
-staging directory instead of refusing. It re-downloads the entire cask, so
-prefer clearing the directory when the download is large.
+**Branch B — `/Applications/<App>.app` is missing.** The interruption landed
+after the backup, so the Caskroom copy is the only app you have. Do **not**
+move it to the Desktop. Put it back where it belongs:
+
+```sh
+mv "${CASKROOM:?set CASKROOM first}/<App>.app" "/Applications/<App>.app"
+```
+
+Never run that `mv` when `/Applications/<App>.app` already exists — `mv` onto
+an existing bundle nests the copy *inside* it and corrupts the working app.
+That is why the branch is gated on absence.
+
+**Finish the update either way.** The failure aborted `update-brew` at its
+second step, so `brew upgrade`, both cleanups, and `brew doctor` never ran.
+Re-run the pipeline so the direct `brew` call stays a one-off:
+
+```sh
+just update
+```
 
 ### `brew bundle` fails on a missing profile marker
 

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -1,0 +1,122 @@
+# Homebrew
+
+Operating notes for the `just update` pipeline, which is dominated by
+Homebrew. Packages are declared in the Brewfiles and applied through `just`
+recipes — never through raw `brew install`.
+
+For Brewfile authoring conventions (file set, profile overlays, sorting, the
+native-installer pattern), see `.claude/rules/brewfile.md`. This doc covers
+*operating* the toolchain: the update flow and recovery from a wedged state.
+
+## Update flow
+
+`just update` runs `update-brew` first, which is the step most likely to fail
+because it touches the network and mutates installed apps:
+
+```sh
+brew update                     # refresh formula/cask definitions
+brew bundle install --file=...  # install missing AND upgrade outdated
+brew upgrade                    # upgrade whatever the Brewfile pass left
+brew cleanup --prune=all
+brew bundle cleanup --force --file=...
+brew doctor                     # non-fatal: prefixed with `-` in the Justfile
+```
+
+Note the asymmetry with `just setup`, which runs `brew bundle install` **with**
+`--no-upgrade`. Bootstrap is deliberately install-only, so a fresh machine does
+not depend on every pre-existing package upgrading cleanly. `update-brew` omits
+the flag because upgrading is the point — which is also why a single wedged
+cask takes the whole update down, and why the failure below surfaces during
+`brew bundle install` rather than during `brew upgrade`.
+
+A failure in `brew bundle install` aborts the whole recipe by design. Do not
+paper over it with `|| true` or `continue-on-error` — a red `just update` means
+a package really is broken, and silencing it hides a half-installed app until
+something else breaks.
+
+## Troubleshooting
+
+### Cask upgrade fails with "there is already an App at"
+
+macOS only — `Brewfile.linux` declares no casks, so there is no Caskroom
+staging directory to wedge.
+
+**Symptom** — `just update` dies in `update-brew` with a single failed cask:
+
+```text
+Error: <cask>: It seems there is already an App at
+'/opt/homebrew/Caskroom/<cask>/<old-version>/<App>.app'.
+==> Purging files for version <new-version> of Cask <cask>
+`brew bundle` failed! 1 Brewfile dependency failed to install
+```
+
+**Cause** — an earlier cask upgrade was interrupted (Ctrl-C, sleep, crash, or a
+self-updating app racing brew) and left a partial app bundle in the Caskroom
+staging directory. Before swapping in the new version, Homebrew backs the live
+app up into that exact path:
+
+```text
+==> Backing up App '<App>.app' to '/opt/homebrew/Caskroom/<cask>/<old-version>/<App>.app'
+```
+
+An unforced upgrade refuses to overwrite what is already sitting there, so
+every subsequent `just update` fails the same way until the leftover is
+cleared.
+
+**Confirm it is a stale partial** — compare it against the live app. The
+leftover is typically missing `Contents/Info.plist` and is much smaller than
+the installed copy:
+
+```sh
+CASKROOM="$(brew --prefix)/Caskroom/<cask>/<old-version>"
+ls -la "$CASKROOM/<App>.app/Contents/"
+du -sh "$CASKROOM/<App>.app" "/Applications/<App>.app"
+```
+
+**Fix** — move the leftover aside rather than deleting it outright, so the step
+is reversible, then re-run the upgrade. The timestamped destination keeps a
+second occurrence from nesting inside the first:
+
+```sh
+CASKROOM="$(brew --prefix)/Caskroom/<cask>/<old-version>"   # repeated: do not rely on the block above
+STALE="$HOME/Desktop/stale-<cask>-$(date +%Y%m%d%H%M%S).app"
+mv "$CASKROOM/<App>.app" "$STALE"
+brew upgrade --cask <cask>
+brew list --cask --versions <cask>   # verify the new version landed
+```
+
+Once the upgrade succeeds, delete `$STALE`. If the upgrade fails instead,
+restore with `mv "$STALE" "$CASKROOM/<App>.app"` — run it in the same shell, or
+re-assign `CASKROOM` first. With `CASKROOM` unset that command expands to the
+volume root, so never run the restore against a bare `/<App>.app`.
+
+`brew reinstall --cask <cask>` also clears the leftover, because reinstall
+always *forces* its internal uninstall and a forced backup overwrites the
+staging directory instead of refusing. It re-downloads the entire cask, so
+prefer clearing the directory when the download is large.
+
+### `brew bundle` fails on a missing profile marker
+
+macOS only — `Brewfile.linux` has no profile overlay and never reads the
+marker.
+
+`brew bundle` fails loud when `~/.config/dotfiles/profile` is absent, empty, or
+unknown, because merging the wrong overlay would make `brew bundle cleanup
+--force` uninstall the other profile's apps. Set it:
+
+```sh
+just set-profile work    # or: personal
+```
+
+### mise warns about the python-build repo
+
+A warning like `failed to update python-build repo ... 'origin' does not
+appear to be a git repository` in `update-mise` is self-healing — mise reclones
+the cached pyenv checkout in the same run and continues.
+
+To confirm, re-run `mise outdated` on its own and check that the warning does
+not recur. Use `mise outdated`, not `just update-mise`: the recipe also runs
+`mise upgrade --bump`, which upgrades tools and rewrites the version pins — far
+more than a diagnostic should do. Judge by the warning text, not the exit
+code: `mise outdated` exits 0 whether or not tools are outdated, which is
+exactly why the recipe can run it first under just's fail-fast.

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -99,17 +99,13 @@ uninstall runs there is no Homebrew route back to what was installed before.
 That is the same version `just update` was trying to install, so it is normally
 what you want.
 
-If keeping the *old* version specifically matters, check
-`brew search --cask '<cask>@'` first — homebrew-cask maintains versioned tokens
-for a subset of apps (`1password@7`, `ableton-live-suite@10`), which is a
-supported route to an older version. Without one, downgrading means checking
-out an older tap revision, which is out of scope here.
+Needing a *different* version is a separate task: pinning or downgrading a cask
+has its own constraints and is out of scope here.
 
 The reinstall is not what puts your install at risk, though: the interrupted
 upgrade may have stripped `/Applications/<App>.app` already, so confirm it is
-present and non-empty before treating it as an old version you still have to
-weigh. Either way the wedge stays in place and every `just update` keeps
-failing until you reinstall — this branch has no resting state.
+present and non-empty before treating it as a version you still have. Until the
+wedge is cleared, every `just update` keeps failing on this cask.
 
 Do not improvise a rollback by copying the Caskroom leftover aside. It is one
 of the three shapes above, only one of which is a working app, so the copy may


### PR DESCRIPTION
## Summary

Adds `docs/homebrew.md` — the `just update` Homebrew flow and recovery from a
wedged cask upgrade, the failure where an interrupted upgrade leaves something
in the Caskroom staging directory and every subsequent run dies with
`It seems there is already an App at ...`.

- **The recovery is one command: `brew reinstall --cask <cask>`.** Verified
  against Homebrew's `cask/installer.rb`: `fetch` runs before
  `uninstall_existing_cask`, so a failed download leaves the install untouched,
  and that uninstall is hardcoded `force: true`, so it overwrites the wedged
  staging directory instead of raising. It yields a known-good bundle whatever
  shape the leftover has — truncated partial, complete backup of the live app,
  or a wrapper directory holding a nested `.app` from an earlier bad move.
- **No destructive command in the runbook.** No `mv`, `rm`, `mkdir`, no
  `$CASKROOM`. Reinstall makes classifying the leftover unnecessary, which is
  what every hazard in earlier revisions came from.
- Records the `--no-upgrade` asymmetry that makes this bite: `just setup` passes
  it, `update-brew` deliberately does not, so the failure surfaces during the
  Brewfile pass rather than during `brew upgrade`.
- Warns that a missing **or empty** `/Applications/<App>.app` means the Caskroom
  copy is the only one left; reinstall covers it by fetching before uninstalling.
- Covers two adjacent `just update` snags: the profile-marker failure (macOS
  only) and the self-healing mise python-build warning.
- Indexed from `README.md` and `CLAUDE.md`.

No change to `update-brew`. The recipe behaved correctly by failing loud — this
was host-state corruption, not a defect. `|| true` or `continue-on-error` would
have hidden a genuinely broken install, so the doc says so explicitly.

## Review history

Eleven rounds, **zero P0 in every one**. Nothing was ever merge-blocking; the rounds went into operator safety inside the runbook, and they changed the design rather than polishing it.

The arc: the doc began as a branching hand-move procedure and ended as a single non-destructive command. Rounds 4, 5, 6 and 8 each found a defect *in the previous round's fix* — an any-of/all-of mismatch whose remedy nested a bundle inside the live app; a path that promoted a wrapper directory (verified live: `google-chrome`'s Caskroom copy on this machine is exactly that shape); a hand-move whose only justification turned out to be false; a rollback copy sourced from the untrusted leftover. Each time the answer was to delete surface rather than gate it.

What remains is `brew reinstall --cask <cask>` and `just update`. No `mv`, `rm`, `mkdir`, or `$CASKROOM` anywhere in the runbook.

Merging on the `finding-severity.md` stop rule: severity plateaued at Low and the last round produced only precision items on a much-rewritten paragraph. Those are filed as #210 rather than triggering a twelfth round.

Follow-up landing separately in `dotfiles-private` (#242): runbooks lose the doc-only pre-review-audit exemption, and `/documentation` gains a claim-verification section. This PR is the evidence for both.

## Test plan

- [x] `just update` runs end-to-end, exit 0 (previously failed at `Justfile:269`
      with 1 failed Brewfile dependency)
- [x] The original failure fixed live — `lm-studio` `0.4.18,1 -> 0.4.20,1`,
      confirmed via `brew list --cask --versions`
- [x] Every load-bearing claim checked against source, not assumed: `fetch`
      before `uninstall_existing_cask` and hardcoded `force: true`
      (`cask/installer.rb`), the raise site (`cask/artifact/moved.rb#move_back`),
      the empty-directory shape (`moved.rb#move`), `--no-upgrade` asymmetry
      (`Justfile:31-36`), macOS-only profile scope (`Justfile:104-112`)
- [x] No destructive command remains in the runbook — grep for `mv`/`rm`/`mkdir`/
      `CASKROOM` returns nothing
- [x] `just ci` passes: shellcheck clean, markdownlint 0 issues, Brewfile
      merge/absent-marker/duplicate tests OK
- [x] Rebased onto `ac0921f` after #209; `CHANGELOG.md` conflict resolved keeping
      both entries, verified present exactly once each
- [x] Public-repo hygiene: repo `PUBLIC`, word-boundary scan against the
      sensitive-terms list returns 0 hits, no personal paths

Addresses #206
