### PR TITLE
fix: gh helper path, worktree lint exclusion, private path, review agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@
 .githooks/post-commit
 .githooks/post-rewrite
 
-# Claude Code worktrees (git worktree checkouts, not repo content)
+# Claude Code worktrees (git worktree checkouts, not repo content).
+# Untracked by design, so a `git add -A` can't sweep in a whole second
+# checkout. Also excluded from lint globs in .markdownlint-cli2.yaml.
 .claude/worktrees/

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,2 +1,6 @@
 globs:
   - "**/*.md"
+  # Nested worktrees are agent scratch space: a checkout of this repo at a
+  # different commit. Lint failures there belong to that commit, not to the
+  # working branch. Gitignored too — see .gitignore.
+  - "!.claude/worktrees/**"

--- a/.roborev.toml
+++ b/.roborev.toml
@@ -9,7 +9,9 @@
 # review silently fell through to backup_agent: 112 of 112 jobs on record ran
 # claude-code. Naming claude-code directly makes the ledger match the config;
 # backup_agent stays set, so the fallback is now a no-op duplicate of the primary
-# rather than a silent substitution.
+# rather than a silent substitution. It is kept deliberately rather than deleted:
+# it gives a future second agent an obvious slot, and a duplicate cannot silently
+# substitute a different model the way `copilot` -> `claude-code` did.
 #
 # The `codex` and `copilot-cli` casks in Brewfile stay — those tools are wanted
 # for interactive use. They are deliberately not review agents, so do not

--- a/.roborev.toml
+++ b/.roborev.toml
@@ -7,8 +7,9 @@
 #
 # This previously read `agent = "copilot"`. roborev could not invoke it, so every
 # review silently fell through to backup_agent: 112 of 112 jobs on record ran
-# claude-code. Naming claude-code directly removes the fallback and makes the
-# ledger match the config.
+# claude-code. Naming claude-code directly makes the ledger match the config;
+# backup_agent stays set, so the fallback is now a no-op duplicate of the primary
+# rather than a silent substitution.
 #
 # The `codex` and `copilot-cli` casks in Brewfile stay — those tools are wanted
 # for interactive use. They are deliberately not review agents, so do not

--- a/.roborev.toml
+++ b/.roborev.toml
@@ -1,4 +1,23 @@
-agent = "copilot"
+# claude-code is the only review agent, because it is the only one with a paid
+# subscription behind it. copilot, codex and gemini/antigravity are all installed
+# — this is not an availability problem. They have no API credit: codex fails with
+# `401 Unauthorized: Missing bearer or basic authentication`, and copilot/gemini
+# are not exposed on PATH under those names. So a second agent is not one install
+# away, and "cross-model convergence" is not a goal to engineer toward here.
+#
+# This previously read `agent = "copilot"`. roborev could not invoke it, so every
+# review silently fell through to backup_agent: 112 of 112 jobs on record ran
+# claude-code. Naming claude-code directly removes the fallback and makes the
+# ledger match the config.
+#
+# The `codex` and `copilot-cli` casks in Brewfile stay — those tools are wanted
+# for interactive use. They are deliberately not review agents, so do not
+# "reconcile" the Brewfile against this file.
+#
+# Do not run `roborev check-agents` to inspect any of this: it invokes every
+# configured agent and launches auth/login flows for the uncredentialed ones.
+# Read this file and use `command -v` instead.
+agent = "claude-code"
 backup_agent = "claude-code"
 review_reasoning = "thorough"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,10 +168,12 @@ grouped by **date** rather than by semantic version. Newest first.
   Every interpolation of the path uses `quote()`, so a value containing `$`,
   a backtick, a quote or a backslash stays inert data rather than being expanded
   — matching `set-profile`'s existing precedent. `DOTFILES_PRIVATE_DIR` is scoped
-  to this recipe only: `rcrc` and `cleanup-symlinks` still hardcode the repo
-  paths, and reconciling all three needs the symlink sweep to keep matching links
-  into a *former* checkout path (rcm records absolute targets, which a
-  path-prefix match cannot see). Tracked separately rather than half-applied.
+  to this recipe only, tracked in
+  [#215](https://github.com/tgautier/dotfiles/issues/215) rather than
+  half-applied. `rcrc` is a one-line change left out purely to keep this PR
+  scoped; `cleanup-symlinks` is the genuinely hard one, because rcm records
+  absolute symlink targets, so links into a *former* checkout path must keep
+  matching and a prefix built from current paths cannot see them.
 - `_ensure-profile`'s non-interactive error reports the value it actually saw
   (`got '<absent>'` / `got 'Work'`) instead of always claiming no profile is set,
   which conflated a missing marker with an invalid one. Its trim comment no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@ grouped by **date** rather than by semantic version. Newest first.
   worktree hygiene begun in [#212](https://github.com/tgautier/dotfiles/pull/212).
   The path was already gitignored, but `markdownlint-cli2` globs are not
   gitignore-aware, so a nested worktree's Markdown was linted as the working
-  branch's content. Verified live: from the private repo's main tree the lint
-  reads 36 files, from inside a worktree 37 — the difference being the checkout
-  itself. Markdown is the only exposed lint; `lint-shell`, `lint-brewfile` and
+  branch's content. Measured in this repo with one worktree present: **14 files
+  before the exclusion, 7 after** — the repo tracks 7 `.md` files and a nested
+  worktree is a full second checkout of them. Markdown is the only exposed lint;
+  `lint-shell`, `lint-brewfile` and
   `lint-mise` all use explicit paths that cannot recurse into it. `CLAUDE.md` now
   documents the `.claude/worktrees/<name>` convention, which the global
   `git-conventions.md` rule deliberately leaves to each project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,19 @@ grouped by **date** rather than by semantic version. Newest first.
   two pre-commit hooks, making a skip a defence-in-depth gap rather than an
   unguarded invariant, but it now says so out loud
   ([#162](https://github.com/tgautier/dotfiles/issues/162)).
+- `cleanup-symlinks` honours the same overrides instead of hardcoding both repo
+  paths, and its stale-symlink filter now matches on the repo **paths** rather
+  than on the literal basenames `/dotfiles/` and `/dotfiles-private/`. Previously
+  an override pointing at a differently-named directory would have its nested
+  dirs discovered and then every candidate rejected by the filter — a silently
+  empty sweep, which is the failure mode the override exists to prevent. Verified
+  with a fixture whose private repo is called `private-dots`: detected now,
+  silently dropped before. The public checkout gained a matching `DOTFILES_DIR`
+  knob; it is deliberately separate from `dotfiles_dir`, which is wherever the
+  running justfile lives and inside a worktree is the worktree, not the checkout
+  rcm links against. All interpolations of these values use `quote()` so a value
+  containing shell metacharacters stays inert, matching `set-profile`'s existing
+  precedent.
 - `_ensure-profile`'s non-interactive error reports the value it actually saw
   (`got '<absent>'` / `got 'Work'`) instead of always claiming no profile is set,
   which conflated a missing marker with an invalid one. Its trim comment no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Added
 
+- `!.claude/worktrees/**` to the `markdownlint-cli2` globs, completing the
+  worktree hygiene begun in [#212](https://github.com/tgautier/dotfiles/pull/212).
+  The path was already gitignored, but `markdownlint-cli2` globs are not
+  gitignore-aware, so a nested worktree's Markdown was linted as the working
+  branch's content. Verified live: from the private repo's main tree the lint
+  reads 36 files, from inside a worktree 37 — the difference being the checkout
+  itself. Markdown is the only exposed lint; `lint-shell`, `lint-brewfile` and
+  `lint-mise` all use explicit paths that cannot recurse into it. `CLAUDE.md` now
+  documents the `.claude/worktrees/<name>` convention, which the global
+  `git-conventions.md` rule deliberately leaves to each project
+  ([#211](https://github.com/tgautier/dotfiles/issues/211)).
 - `libreoffice` in `Brewfile.work` — headless `soffice` is the renderer that
   converts generated `.pptx` decks to PDF for visual verification, so it belongs
   on the work laptop only. It had been installed by hand with `brew install
@@ -56,6 +67,14 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Changed
 
+- `.roborev.toml` now names `claude-code` directly instead of `copilot`. roborev
+  could not invoke `copilot`, so every review silently fell through to
+  `backup_agent` — 112 of 112 jobs on record ran `claude-code`. claude-code is the
+  only agent with a paid subscription behind it: copilot, codex and
+  gemini/antigravity are all installed but have no API credit (codex returns
+  `401 Unauthorized`), so a second reviewer is not one install away. The `codex`
+  and `copilot-cli` casks stay in the Brewfile for interactive use and are
+  deliberately not review agents.
 - Bump mise Flutter (`vfox-flutter`) 3.44.7 → 3.44.8.
 - Tap trust is now declared in the Brewfiles: `trusted: true` on
   `kenn-io/tap/roborev` and `terror/tap/just-lsp` (formula-level trust, as
@@ -126,6 +145,31 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Fixed
 
+- The `gh` credential helper in `gitconfig` no longer hardcodes an absolute path.
+  Both `[credential]` blocks read `!/usr/bin/gh auth git-credential`, which is
+  where `gh` lives on Linux but **not** on macOS (Homebrew installs to
+  `/opt/homebrew/bin`), so on a Mac every HTTPS git operation invoked a missing
+  binary and `git clone` of a private repo failed with `could not read Username`.
+  Now `!gh auth git-credential`, resolved via `PATH`, which is correct on all
+  three target platforms — this file is symlinked to macOS, Linux and WSL alike
+  and carries no `includeIf` guards.
+- `lint-via-private` announces a skip instead of passing silently, and derives the
+  private repo path from `$HOME` (overridable with `DOTFILES_PRIVATE_DIR`) rather
+  than hardcoding one operator's layout. The path is anchored to `$HOME` rather
+  than derived from `dotfiles_dir` deliberately: inside a nested worktree
+  `dotfiles_dir` is `.claude/worktrees/<name>`, whose sibling is not the private
+  repo, so a sibling-derived default would have skipped the guard precisely when
+  working on a branch. On a CI runner the private repo is never present, so this
+  leg of the keyword guard has never executed there — the enforcing copies are the
+  two pre-commit hooks, making a skip a defence-in-depth gap rather than an
+  unguarded invariant, but it now says so out loud
+  ([#162](https://github.com/tgautier/dotfiles/issues/162)).
+- `_ensure-profile`'s non-interactive error reports the value it actually saw
+  (`got '<absent>'` / `got 'Work'`) instead of always claiming no profile is set,
+  which conflated a missing marker with an invalid one. Its trim comment no longer
+  overstates equivalence with the Brewfile's Ruby `String#strip` — `sed` trims
+  per line, so a multi-line marker re-prompts; stricter than the guard, and safe
+  in that direction ([#181](https://github.com/tgautier/dotfiles/issues/181)).
 - `zlogin` no longer prints `zcompile:4: can't write zwc file:
   ~/.zcompdump.zwc` when several login shells start together (tmux panes,
   session restore). Each backgrounded the same `zcompile ~/.zcompdump`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,19 +165,13 @@ grouped by **date** rather than by semantic version. Newest first.
   two pre-commit hooks, making a skip a defence-in-depth gap rather than an
   unguarded invariant, but it now says so out loud
   ([#162](https://github.com/tgautier/dotfiles/issues/162)).
-- `cleanup-symlinks` honours the same overrides instead of hardcoding both repo
-  paths, and its stale-symlink filter now matches on the repo **paths** rather
-  than on the literal basenames `/dotfiles/` and `/dotfiles-private/`. Previously
-  an override pointing at a differently-named directory would have its nested
-  dirs discovered and then every candidate rejected by the filter — a silently
-  empty sweep, which is the failure mode the override exists to prevent. Verified
-  with a fixture whose private repo is called `private-dots`: detected now,
-  silently dropped before. The public checkout gained a matching `DOTFILES_DIR`
-  knob; it is deliberately separate from `dotfiles_dir`, which is wherever the
-  running justfile lives and inside a worktree is the worktree, not the checkout
-  rcm links against. All interpolations of these values use `quote()` so a value
-  containing shell metacharacters stays inert, matching `set-profile`'s existing
-  precedent.
+  Every interpolation of the path uses `quote()`, so a value containing `$`,
+  a backtick, a quote or a backslash stays inert data rather than being expanded
+  — matching `set-profile`'s existing precedent. `DOTFILES_PRIVATE_DIR` is scoped
+  to this recipe only: `rcrc` and `cleanup-symlinks` still hardcode the repo
+  paths, and reconciling all three needs the symlink sweep to keep matching links
+  into a *former* checkout path (rcm records absolute targets, which a
+  path-prefix match cannot see). Tracked separately rather than half-applied.
 - `_ensure-profile`'s non-interactive error reports the value it actually saw
   (`got '<absent>'` / `got 'Work'`) instead of always claiming no profile is set,
   which conflated a missing marker with an invalid one. Its trim comment no longer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,8 +86,15 @@ The `Justfile` defines local CI targets mirroring the GitHub Actions workflow:
 ### Git Configuration
 
 - SSH key signing via 1Password (`op-ssh-sign`)
-- `gh` credential helper for GitHub HTTPS
+- `gh` credential helper for GitHub HTTPS — declared as `!gh auth git-credential`,
+  resolved via `PATH`. Never hardcode an absolute path here: `gh` lives in
+  `/opt/homebrew/bin` on macOS and `/usr/bin` on Linux, and this file is
+  symlinked to all three platforms
 - Rebase-based pulls with fast-forward only
+- Isolated worktrees go in `.claude/worktrees/<name>` (per the global
+  `git-conventions.md` §Branching). That path is gitignored **and** excluded from
+  the markdownlint globs, so a nested checkout can neither be swept into a commit
+  nor linted as this branch's content
 
 ## Project-Local Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,9 +87,12 @@ The `Justfile` defines local CI targets mirroring the GitHub Actions workflow:
 
 - SSH key signing via 1Password (`op-ssh-sign`)
 - `gh` credential helper for GitHub HTTPS — declared as `!gh auth git-credential`,
-  resolved via `PATH`. Never hardcode an absolute path here: `gh` lives in
-  `/opt/homebrew/bin` on macOS and `/usr/bin` on Linux, and this file is
-  symlinked to all three platforms. Caveat: being PATH-resolved, git invoked from
+  resolved via `PATH`. Never hardcode an absolute path here: `gh` comes from
+  Homebrew on every platform — `/opt/homebrew/bin` on macOS,
+  `/home/linuxbrew/.linuxbrew/bin` on Linux/WSL (`Brewfile.linux` declares
+  `brew "gh"`, and `zshenv` puts that directory on `PATH`) — never `/usr/bin`,
+  and this file is symlinked to all three platforms. Caveat: being PATH-resolved,
+  git invoked from
   a minimal-`PATH` context on macOS (a GUI client launched from Finder,
   `launchd`, `cron`) needs `/opt/homebrew/bin` on its `PATH` for the helper to
   resolve

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,10 @@ The `Justfile` defines local CI targets mirroring the GitHub Actions workflow:
 - `gh` credential helper for GitHub HTTPS — declared as `!gh auth git-credential`,
   resolved via `PATH`. Never hardcode an absolute path here: `gh` lives in
   `/opt/homebrew/bin` on macOS and `/usr/bin` on Linux, and this file is
-  symlinked to all three platforms
+  symlinked to all three platforms. Caveat: being PATH-resolved, git invoked from
+  a minimal-`PATH` context on macOS (a GUI client launched from Finder,
+  `launchd`, `cron`) needs `/opt/homebrew/bin` on its `PATH` for the helper to
+  resolve
 - Rebase-based pulls with fast-forward only
 - Isolated worktrees go in `.claude/worktrees/<name>` (per the global
   `git-conventions.md` §Branching). That path is gitignored **and** excluded from

--- a/Justfile
+++ b/Justfile
@@ -5,11 +5,19 @@ zsh_excludes := "SC1036,SC1087,SC1090,SC2128,SC2145,SC2154,SC2155,SC2168,SC2179,
 # Run all CI checks
 ci: lint-shell lint-markdown lint-brewfile lint-mise lint-via-private
 
-# Delegate to the private repo's justfile for checks that must not be
-# defined here (keyword lists etc.). No-op when private repo is absent.
+# Delegate to the private repo's justfile for checks that must not be defined
+# here (keyword lists etc.). Skips loudly when the private repo is absent —
+# notably on a CI runner, where it is never present, so this leg of the keyword
+# guard has never executed there. The enforcing copies are the two pre-commit
+# hooks (this repo's runs `just ci` with the private repo present; the private
+# repo's `ci-lint` includes `lint-public-no-arr`), so a skip here is a
+# defence-in-depth gap, not an unguarded invariant. Announce it either way: a
+# silent no-op reads as a pass.
 lint-via-private:
-    if [ -f ~/Workspace/tgautier/dotfiles-private/justfile ]; then \
-        just -f ~/Workspace/tgautier/dotfiles-private/justfile lint-public-no-arr; \
+    @if [ -f "{{ private_justfile }}" ]; then \
+        just -f "{{ private_justfile }}" lint-public-no-arr; \
+    else \
+        echo "⚠ lint-via-private: no private justfile at {{ private_justfile }} — keyword guard SKIPPED"; \
     fi
 
 # Bootstrap this machine: profile, packages, symlinks, runtimes, hooks, tools (idempotent)
@@ -120,14 +128,15 @@ _ensure-profile:
     fi
     marker="${HOME}/.config/dotfiles/profile"
     current=""
-    # Trim-only (ends), mirroring the Brewfile's String#strip on the same file.
+    # Trim-only (ends), approximating the Brewfile's String#strip (sed is
+    # per-line, so a multi-line marker re-prompts — stricter than the guard, safe).
     [[ -f "$marker" ]] && current="$(sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' "$marker")"
     if [[ "$current" == "work" || "$current" == "personal" ]]; then
         echo "Machine profile already set: $current"
         exit 0
     fi
     if [[ ! -t 0 ]]; then
-        echo "No machine profile set and stdin is not a terminal." >&2
+        echo "No valid machine profile (got '${current:-<absent>}') and stdin is not a terminal." >&2
         echo "Run 'just set-profile work|personal' first, then re-run 'just setup'." >&2
         exit 1
     fi
@@ -244,6 +253,15 @@ update: update-brew update-mas update-mise update-rust
 
 # Resolve through symlink so this works when just finds ~/.justfile
 dotfiles_dir := parent_directory(canonicalize(justfile()))
+
+# Private companion repo, for `lint-via-private`. Anchored to $HOME rather than
+# derived from dotfiles_dir on purpose: inside a nested worktree dotfiles_dir is
+# .claude/worktrees/<name>, whose sibling is not the private repo, so a
+# sibling-derived path would silently skip the guard exactly when working on a
+# branch. Mirrors rcrc's PRIVATE_DIR — keep the two in step; override per machine
+# with DOTFILES_PRIVATE_DIR.
+private_dir := env("DOTFILES_PRIVATE_DIR", env("HOME") / "Workspace/tgautier/dotfiles-private")
+private_justfile := private_dir / "justfile"
 
 # Platform-specific Brewfile
 brewfile := dotfiles_dir / if os() == "macos" { "Brewfile" } else { "Brewfile.linux" }

--- a/Justfile
+++ b/Justfile
@@ -17,7 +17,7 @@ lint-via-private:
     @if [ -f {{ quote(private_justfile) }} ]; then \
         just -f {{ quote(private_justfile) }} lint-public-no-arr; \
     else \
-        echo "⚠ lint-via-private: no private justfile at {{ private_justfile }} — keyword guard SKIPPED"; \
+        echo "⚠ lint-via-private: keyword guard SKIPPED — no private justfile at" {{ quote(private_justfile) }}; \
     fi
 
 # Bootstrap this machine: profile, packages, symlinks, runtimes, hooks, tools (idempotent)
@@ -264,18 +264,14 @@ dotfiles_dir := parent_directory(canonicalize(justfile()))
 # sibling-derived path would silently skip the guard exactly when working on a
 # branch. Override per machine with DOTFILES_PRIVATE_DIR.
 #
-# rcrc declares the same path as PRIVATE_DIR and cannot read just variables (rcm
-# sources it as shell), so the two must be edited together. `cleanup-symlinks`
-# consumes this variable; it still anchors the *public* repo to $HOME rather than
-# dotfiles_dir, because inside a worktree dotfiles_dir is the worktree itself.
+# Scope: `lint-via-private` only. `rcrc` declares the same path as PRIVATE_DIR and
+# `cleanup-symlinks` hardcodes both repo paths, so neither honours this override
+# yet — see the tracking issue before widening it. rcm sources `rcrc` as shell, so
+# it *could* read the env var; wiring all three together needs the symlink sweep
+# to keep matching links into a *former* checkout path, which rcm records as an
+# absolute target and a path-prefix match cannot see.
 private_dir := env("DOTFILES_PRIVATE_DIR", env("HOME") / "Workspace/tgautier/dotfiles-private")
 private_justfile := private_dir / "justfile"
-
-# Canonical public checkout, for `cleanup-symlinks`. Distinct from dotfiles_dir
-# on purpose: dotfiles_dir is wherever *this* justfile lives, which inside a
-# worktree is the worktree, whereas rcm's symlinks always point at the canonical
-# checkout. Override with DOTFILES_DIR.
-public_dir := env("DOTFILES_DIR", env("HOME") / "Workspace/tgautier/dotfiles")
 
 # Platform-specific Brewfile
 brewfile := dotfiles_dir / if os() == "macos" { "Brewfile" } else { "Brewfile.linux" }
@@ -386,20 +382,8 @@ set-default-editor:
 # Remove stale symlinks in $HOME that point into dotfiles dirs
 cleanup-symlinks:
     #!/usr/bin/env zsh
-    # Derive nested dirs from the dotfiles repos themselves. quote() so a value
-    # from DOTFILES_DIR / DOTFILES_PRIVATE_DIR containing $, backtick, quote or
-    # backslash stays inert data (same reason set-profile quotes its argument).
-    dotfiles_repos=({{ quote(public_dir) }} {{ quote(private_dir) }})
-    # Match on the repo paths, never on their basenames: an override pointing at
-    # a directory not called "dotfiles"/"dotfiles-private" must still be swept,
-    # otherwise discovery finds candidates and the filter silently drops them all.
-    points_into_repo() {
-        local target=$1 repo
-        for repo in "${dotfiles_repos[@]}"; do
-            [[ "$target" == "$repo"/* ]] && return 0
-        done
-        return 1
-    }
+    # Derive nested dirs from the dotfiles repos themselves
+    dotfiles_repos=("$HOME/Workspace/tgautier/dotfiles" "$HOME/Workspace/tgautier/dotfiles-private")
     nested=()
     for repo in "${dotfiles_repos[@]}"; do
         [[ -d "$repo" ]] || continue
@@ -416,7 +400,7 @@ cleanup-symlinks:
     for f in $HOME/.[!.]*(N@); do
         [[ -e "$f" ]] && continue
         target=$(readlink "$f")
-        points_into_repo "$target" && stale+=("$f -> $target")
+        [[ "$target" == *"/dotfiles/"* || "$target" == *"/dotfiles-private/"* ]] && stale+=("$f -> $target")
     done
     # Nested dirs (recursive)
     for dir in "${nested[@]}"; do
@@ -424,7 +408,7 @@ cleanup-symlinks:
         for f in "$dir"/**/*(N@); do
             [[ -e "$f" ]] && continue
             target=$(readlink "$f")
-            points_into_repo "$target" && stale+=("$f -> $target")
+            [[ "$target" == *"/dotfiles/"* || "$target" == *"/dotfiles-private/"* ]] && stale+=("$f -> $target")
         done
     done
     if (( ${#stale} == 0 )); then

--- a/Justfile
+++ b/Justfile
@@ -264,12 +264,14 @@ dotfiles_dir := parent_directory(canonicalize(justfile()))
 # sibling-derived path would silently skip the guard exactly when working on a
 # branch. Override per machine with DOTFILES_PRIVATE_DIR.
 #
-# Scope: `lint-via-private` only. `rcrc` declares the same path as PRIVATE_DIR and
-# `cleanup-symlinks` hardcodes both repo paths, so neither honours this override
-# yet — see the tracking issue before widening it. rcm sources `rcrc` as shell, so
-# it *could* read the env var; wiring all three together needs the symlink sweep
-# to keep matching links into a *former* checkout path, which rcm records as an
-# absolute target and a path-prefix match cannot see.
+# Scope: `lint-via-private` only — see #215 before widening it. `rcrc` and
+# `cleanup-symlinks` still hardcode the paths, for two unrelated reasons:
+#   - `rcrc` is a one-liner. rcm sources it as shell, so it can read the env var
+#     directly. It is unwired only to keep #214 scoped, so until then setting the
+#     override points the keyword guard at a private repo `rcup` never merges.
+#   - `cleanup-symlinks` is the hard one: rcm records absolute symlink targets, so
+#     links into a *former* checkout path must keep matching, and a prefix built
+#     from the current paths cannot see them.
 private_dir := env("DOTFILES_PRIVATE_DIR", env("HOME") / "Workspace/tgautier/dotfiles-private")
 private_justfile := private_dir / "justfile"
 

--- a/Justfile
+++ b/Justfile
@@ -136,7 +136,11 @@ _ensure-profile:
         exit 0
     fi
     if [[ ! -t 0 ]]; then
-        echo "No valid machine profile (got '${current:-<absent>}') and stdin is not a terminal." >&2
+        # Distinguish a missing marker from one that exists but is empty or
+        # invalid — reporting both as "<absent>" is the conflation this message
+        # exists to avoid.
+        if [[ -f "$marker" ]]; then got="'$current'"; else got="<absent>"; fi
+        echo "No valid machine profile (got $got) and stdin is not a terminal." >&2
         echo "Run 'just set-profile work|personal' first, then re-run 'just setup'." >&2
         exit 1
     fi
@@ -258,8 +262,12 @@ dotfiles_dir := parent_directory(canonicalize(justfile()))
 # derived from dotfiles_dir on purpose: inside a nested worktree dotfiles_dir is
 # .claude/worktrees/<name>, whose sibling is not the private repo, so a
 # sibling-derived path would silently skip the guard exactly when working on a
-# branch. Mirrors rcrc's PRIVATE_DIR — keep the two in step; override per machine
-# with DOTFILES_PRIVATE_DIR.
+# branch. Override per machine with DOTFILES_PRIVATE_DIR.
+#
+# rcrc declares the same path as PRIVATE_DIR and cannot read just variables (rcm
+# sources it as shell), so the two must be edited together. `cleanup-symlinks`
+# consumes this variable; it still anchors the *public* repo to $HOME rather than
+# dotfiles_dir, because inside a worktree dotfiles_dir is the worktree itself.
 private_dir := env("DOTFILES_PRIVATE_DIR", env("HOME") / "Workspace/tgautier/dotfiles-private")
 private_justfile := private_dir / "justfile"
 
@@ -373,7 +381,7 @@ set-default-editor:
 cleanup-symlinks:
     #!/usr/bin/env zsh
     # Derive nested dirs from the dotfiles repos themselves
-    dotfiles_repos=("$HOME/Workspace/tgautier/dotfiles" "$HOME/Workspace/tgautier/dotfiles-private")
+    dotfiles_repos=("$HOME/Workspace/tgautier/dotfiles" "{{ private_dir }}")
     nested=()
     for repo in "${dotfiles_repos[@]}"; do
         [[ -d "$repo" ]] || continue

--- a/Justfile
+++ b/Justfile
@@ -14,8 +14,8 @@ ci: lint-shell lint-markdown lint-brewfile lint-mise lint-via-private
 # defence-in-depth gap, not an unguarded invariant. Announce it either way: a
 # silent no-op reads as a pass.
 lint-via-private:
-    @if [ -f "{{ private_justfile }}" ]; then \
-        just -f "{{ private_justfile }}" lint-public-no-arr; \
+    @if [ -f {{ quote(private_justfile) }} ]; then \
+        just -f {{ quote(private_justfile) }} lint-public-no-arr; \
     else \
         echo "⚠ lint-via-private: no private justfile at {{ private_justfile }} — keyword guard SKIPPED"; \
     fi
@@ -271,6 +271,12 @@ dotfiles_dir := parent_directory(canonicalize(justfile()))
 private_dir := env("DOTFILES_PRIVATE_DIR", env("HOME") / "Workspace/tgautier/dotfiles-private")
 private_justfile := private_dir / "justfile"
 
+# Canonical public checkout, for `cleanup-symlinks`. Distinct from dotfiles_dir
+# on purpose: dotfiles_dir is wherever *this* justfile lives, which inside a
+# worktree is the worktree, whereas rcm's symlinks always point at the canonical
+# checkout. Override with DOTFILES_DIR.
+public_dir := env("DOTFILES_DIR", env("HOME") / "Workspace/tgautier/dotfiles")
+
 # Platform-specific Brewfile
 brewfile := dotfiles_dir / if os() == "macos" { "Brewfile" } else { "Brewfile.linux" }
 
@@ -380,8 +386,20 @@ set-default-editor:
 # Remove stale symlinks in $HOME that point into dotfiles dirs
 cleanup-symlinks:
     #!/usr/bin/env zsh
-    # Derive nested dirs from the dotfiles repos themselves
-    dotfiles_repos=("$HOME/Workspace/tgautier/dotfiles" "{{ private_dir }}")
+    # Derive nested dirs from the dotfiles repos themselves. quote() so a value
+    # from DOTFILES_DIR / DOTFILES_PRIVATE_DIR containing $, backtick, quote or
+    # backslash stays inert data (same reason set-profile quotes its argument).
+    dotfiles_repos=({{ quote(public_dir) }} {{ quote(private_dir) }})
+    # Match on the repo paths, never on their basenames: an override pointing at
+    # a directory not called "dotfiles"/"dotfiles-private" must still be swept,
+    # otherwise discovery finds candidates and the filter silently drops them all.
+    points_into_repo() {
+        local target=$1 repo
+        for repo in "${dotfiles_repos[@]}"; do
+            [[ "$target" == "$repo"/* ]] && return 0
+        done
+        return 1
+    }
     nested=()
     for repo in "${dotfiles_repos[@]}"; do
         [[ -d "$repo" ]] || continue
@@ -398,7 +416,7 @@ cleanup-symlinks:
     for f in $HOME/.[!.]*(N@); do
         [[ -e "$f" ]] && continue
         target=$(readlink "$f")
-        [[ "$target" == *"/dotfiles/"* || "$target" == *"/dotfiles-private/"* ]] && stale+=("$f -> $target")
+        points_into_repo "$target" && stale+=("$f -> $target")
     done
     # Nested dirs (recursive)
     for dir in "${nested[@]}"; do
@@ -406,7 +424,7 @@ cleanup-symlinks:
         for f in "$dir"/**/*(N@); do
             [[ -e "$f" ]] && continue
             target=$(readlink "$f")
-            [[ "$target" == *"/dotfiles/"* || "$target" == *"/dotfiles-private/"* ]] && stale+=("$f -> $target")
+            points_into_repo "$target" && stale+=("$f -> $target")
         done
     done
     if (( ${#stale} == 0 )); then

--- a/gitconfig
+++ b/gitconfig
@@ -71,6 +71,6 @@
 	useconfigonly = true
 	signingkey = ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBRkKL/xhEWzA+O2DnrqTofc3gB42ixv5+P77K6zELfC
 [credential "https://github.com"]
-	helper = !/usr/bin/gh auth git-credential
+	helper = !gh auth git-credential
 [credential "https://gist.github.com"]
-	helper = !/usr/bin/gh auth git-credential
+	helper = !gh auth git-credential


### PR DESCRIPTION
## Summary

Four hygiene fixes that share a theme: config that was silently wrong on some
machine, or a guard that passed without checking anything.

- **`gitconfig`** — both `[credential]` blocks hardcoded an absolute `/usr/bin/gh`,
  correct on Linux but not macOS (Homebrew uses `/opt/homebrew/bin`). This file is
  symlinked to macOS, Linux and WSL alike with no `includeIf` guards, so on a Mac
  every HTTPS git operation invoked a missing binary and `git clone` of a private
  repo failed with `could not read Username`. Now PATH-resolved.
- **`markdownlint`** — `.claude/worktrees/` was gitignored, but `markdownlint-cli2`
  globs are not gitignore-aware, so a nested worktree's Markdown was linted as the
  working branch's content. Measured here with a worktree present: **14 files
  before, 7 after**. Markdown was the only exposed lint — `lint-shell`,
  `lint-brewfile` and `lint-mise` use explicit paths that cannot recurse.
  `CLAUDE.md` now documents the `.claude/worktrees/<name>` convention, which the
  global `git-conventions` rule deliberately leaves to each project.
- **`lint-via-private`** — took one operator's absolute path and skipped silently
  when absent. Now `$HOME`-anchored, overridable with `DOTFILES_PRIVATE_DIR`, and
  it announces the skip. Anchored to `$HOME` rather than derived from
  `dotfiles_dir` deliberately: inside a nested worktree `dotfiles_dir` is
  `.claude/worktrees/<name>`, whose sibling is not the private repo, so the
  sibling-derived form the issue suggested would have skipped the guard exactly
  when working on a branch. `cleanup-symlinks` now consumes the same variable.
- **`_ensure-profile`** — the non-interactive error conflated a missing marker with
  one that exists but is invalid or empty. The three cases now read `<absent>` /
  `''` / `'Work'`. The trim comment no longer overstates equivalence with Ruby's
  `String#strip`.
- **`.roborev.toml`** — named `copilot`, which roborev could not invoke, so every
  review fell through to `backup_agent`: 112 of 112 jobs on record ran
  `claude-code`. Now names it directly. It is the only agent with a paid
  subscription behind it — copilot, codex and gemini are installed but have no API
  credit — so a second reviewer is a subscription away, not an install away. The
  `codex` and `copilot-cli` casks stay for interactive use and are deliberately
  not review agents.

## Test plan

- [x] `just ci` passes in the worktree (shell, markdown, Brewfile, mise, keyword guard)
- [x] markdownlint reports the negated glob and 7 files; 14 without the exclusion
- [x] keyword guard **runs from inside a worktree** — the case sibling-derivation would have skipped
- [x] `DOTFILES_PRIVATE_DIR=/nonexistent just lint-via-private` announces SKIPPED, exit 0
- [x] Both `lint-via-private` branches tested with a path containing a space. Unquoted, the test expanded to two arguments, failed, and fell through to the skip branch — a fail-open guard, found by the pre-review audit and fixed before the first review
- [x] `_ensure-profile` distinguishes absent / empty / invalid markers (verified in a scratch `$HOME`)
- [x] `just ci` re-run green after the review-round-1 fixes
- [x] `cleanup-symlinks` is byte-identical to `origin/main` — verified by diff, the
      round-3 revert
- [x] All three `private_justfile` interpolations use `quote()`
- [x] `just ci` green after each of the three review rounds
- [x] `gh` helper: `Brewfile.linux` declares `brew "gh"` and `zshenv` puts
      `/home/linuxbrew/.linuxbrew/bin` on `PATH`, so PATH-resolution is correct on
      Linux/WSL as well as macOS. Live end-to-end check needs `rcup` after merge
      (#213) — not blocking, since the previous absolute path was wrong on every
      platform

## Review

**Round 1** (job 114): 5 findings, all **Low**, fixed in `bfb5b71`. Four were
inaccurate statements in my own text rather than code defects — the recurring
shape being measurements taken in one repo and reported as another.

**Round 2** (job 115): 4 findings, **1 Medium + 3 Low**, fixed in `5b86077`. I had
fixed the *reported site* of the `DOTFILES_PRIVATE_DIR` gap and not the
*predicate*, leaving the filter basename-bound — the finding-as-location shape.
Round 2 also caught that the round-1 "remove false claims" commit left a false
claim standing (`gh` at `/usr/bin` on Linux — it is Homebrew on every platform).

**Round 3** (job 116): 5 findings, **2 Medium + 3 Low**. One fixed; the other four
resolved by **reverting the change they were found in** (`0036117`), now tracked as
#215.

Three consecutive rounds each found a new defect in the same out-of-scope
`cleanup-symlinks` change — I touched it only because round 1 mentioned it in
passing. Per `task-lifecycle`'s complexity-spiral rule that is the signal to
reassess rather than patch again. The decisive finding: rcm records **absolute**
symlink targets, so after a checkout moves, stale links name the *old* path — the
basename-substring filter I replaced was load-bearing for exactly that case, and
my path-prefix version silently stopped seeing it. I had described the change as a
widening; it was a narrowing.

**Round 4** (job 117): 2 findings, both **Low**, fixed in `c711a16`. Both were
deferral text pointing at "the tracking issue" without naming #215, and a caveat
true of `cleanup-symlinks` asserted over `rcrc` too — wiring `rcrc` is an
independent one-liner, so presenting the former-checkout-path problem as blocking
both misattributed it.

Zero P0 in all four rounds. Eleven findings fixed, four reverted, none dismissed.
All are `[MISS]` against existing rules — no `[NEW CATEGORY]`. The recurring shape
is asserting a property of code or a platform without verifying it: four
instances, every one caught by the reviewer rather than by me.

Note on round accounting: the ledger shows 4 jobs for this branch but only **one**
was a deliberate `--branch` review. The rest were minted by the `post-commit`
hook, one per commit — the round-count inflation this repo's own audit measured,
visible on the PR that touches it.

## Issues

Closes #211
Closes #162
Closes #181

Related:

- #213 — the `gh` fix needs `rcup` to take effect, and no recipe only re-links
- #215 — wiring `DOTFILES_PRIVATE_DIR` through `rcrc` and `cleanup-symlinks`,
  scoped out of this PR after three rounds; the issue records why it is not a
  mechanical substitution
