### PR TITLE
docs(brew): drop the bundle check rather than dress it up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,10 +154,10 @@ grouped by **date** rather than by semantic version. Newest first.
   forced uninstall had already replaced. What survives is the one load-bearing
   fact, stated where it matters — the interrupted upgrade may already have
   stripped the live app, so the Caskroom leftover can be the only copy, which is
-  why deleting it by hand can lose the app. Separately, the same paragraph
-  restated two facts already stated above — wedge persistence (under **Cause**,
-  six paragraphs earlier) and fetch-before-uninstall (in the property list four
-  lines earlier). Both duplicates are removed, and each claim now appears once
+  why deleting it by hand can lose the app. Separately, the branch removes two
+  restatements of facts already given above: the deleted paragraph repeated the
+  wedge-persistence fact from **Cause**, and the do-not-clear paragraph repeated
+  the fetch-before-uninstall property from the list. Each claim now appears once
   ([#210](https://github.com/tgautier/dotfiles/issues/210)).
 - The `gh` credential helper in `gitconfig` no longer hardcodes an absolute path.
   Both `[credential]` blocks read `!/usr/bin/gh auth git-credential`, which is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,20 +146,19 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Fixed
 
-- `docs/homebrew.md`'s cask-recovery runbook: the bundle check now feeds a
-  decision and carries a command. It previously asked the operator to confirm
-  `/Applications/<App>.app` was "present and non-empty" with nothing branching on
-  the answer — the prescribed action was `brew reinstall --cask` either way — and
-  it sat *after* the reinstall was prescribed, so a literal reading had you
-  inspecting a bundle the forced uninstall had already replaced. The check moves
-  into the do-not-clear-the-staging-directory paragraph, where its answer does
-  matter: it tells you whether the Caskroom leftover is your only copy, which is
-  why deleting it by hand can lose the app. It also gains the copy-pasteable
-  `ls -A "/Applications/<App>.app"`, with all three outcomes spelled out —
-  verified against a healthy bundle (prints `Contents`), an empty one (no
-  output), and a missing one (`No such file or directory`). Separately, the same
-  paragraph restated the wedge-persistence fact already given six paragraphs
-  earlier; that duplicate is removed and the claim now appears once
+- `docs/homebrew.md`'s cask-recovery runbook drops the bundle check instead of
+  dressing it up. It asked the operator to confirm `/Applications/<App>.app` was
+  "present and non-empty" while nothing branched on the answer — the prescribed
+  action was `brew reinstall --cask` either way — and it sat *after* the
+  reinstall was prescribed, so read literally it had you inspecting a bundle the
+  forced uninstall had already replaced. Adding a command and an outcome table
+  was tried first and rejected on review: every outcome still led to the same
+  step, so the check remained decorative. What survives is the one load-bearing
+  fact, stated where it matters — the interrupted upgrade may already have
+  stripped the live app, so the Caskroom leftover can be the only copy, which is
+  why deleting it by hand can lose the app. Separately, the same paragraph
+  restated the wedge-persistence fact already given six paragraphs earlier under
+  **Cause**; that duplicate is removed and the claim now appears once
   ([#210](https://github.com/tgautier/dotfiles/issues/210)).
 - The `gh` credential helper in `gitconfig` no longer hardcodes an absolute path.
   Both `[credential]` blocks read `!/usr/bin/gh auth git-credential`, which is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,8 +155,9 @@ grouped by **date** rather than by semantic version. Newest first.
   fact, stated where it matters — the interrupted upgrade may already have
   stripped the live app, so the Caskroom leftover can be the only copy, which is
   why deleting it by hand can lose the app. Separately, the same paragraph
-  restated the wedge-persistence fact already given six paragraphs earlier under
-  **Cause**; that duplicate is removed and the claim now appears once
+  restated two facts already stated above — wedge persistence (under **Cause**,
+  six paragraphs earlier) and fetch-before-uninstall (in the property list four
+  lines earlier). Both duplicates are removed, and each claim now appears once
   ([#210](https://github.com/tgautier/dotfiles/issues/210)).
 - The `gh` credential helper in `gitconfig` no longer hardcodes an absolute path.
   Both `[credential]` blocks read `!/usr/bin/gh auth git-credential`, which is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,9 +151,7 @@ grouped by **date** rather than by semantic version. Newest first.
   "present and non-empty" while nothing branched on the answer — the prescribed
   action was `brew reinstall --cask` either way — and it sat *after* the
   reinstall was prescribed, so read literally it had you inspecting a bundle the
-  forced uninstall had already replaced. Adding a command and an outcome table
-  was tried first and rejected on review: every outcome still led to the same
-  step, so the check remained decorative. What survives is the one load-bearing
+  forced uninstall had already replaced. What survives is the one load-bearing
   fact, stated where it matters — the interrupted upgrade may already have
   stripped the live app, so the Caskroom leftover can be the only copy, which is
   why deleting it by hand can lose the app. Separately, the same paragraph

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,21 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Fixed
 
+- `docs/homebrew.md`'s cask-recovery runbook: the bundle check now feeds a
+  decision and carries a command. It previously asked the operator to confirm
+  `/Applications/<App>.app` was "present and non-empty" with nothing branching on
+  the answer — the prescribed action was `brew reinstall --cask` either way — and
+  it sat *after* the reinstall was prescribed, so a literal reading had you
+  inspecting a bundle the forced uninstall had already replaced. The check moves
+  into the do-not-clear-the-staging-directory paragraph, where its answer does
+  matter: it tells you whether the Caskroom leftover is your only copy, which is
+  why deleting it by hand can lose the app. It also gains the copy-pasteable
+  `ls -A "/Applications/<App>.app"`, with all three outcomes spelled out —
+  verified against a healthy bundle (prints `Contents`), an empty one (no
+  output), and a missing one (`No such file or directory`). Separately, the same
+  paragraph restated the wedge-persistence fact already given six paragraphs
+  earlier; that duplicate is removed and the claim now appears once
+  ([#210](https://github.com/tgautier/dotfiles/issues/210)).
 - The `gh` credential helper in `gitconfig` no longer hardcodes an absolute path.
   Both `[credential]` blocks read `!/usr/bin/gh auth git-credential`, which is
   where `gh` lives on Linux but **not** on macOS (Homebrew installs to

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -90,8 +90,8 @@ default rather than a fallback:
 already have stripped the live app — either removing `/Applications/<App>.app`
 outright, or leaving the directory in place with its contents gone — so the
 Caskroom leftover can be the only copy you have, and deleting it can lose the
-app. Reinstall handles every case by construction: it fetches before it
-uninstalls, so nothing is removed until the replacement is already on disk.
+app. Reinstall does not need it cleared — see the fetch-before-uninstall
+property above.
 
 **Reinstall lands the current version, and does not preserve the old one.** A
 cask tap generally serves only the current version, so once the forced

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -86,24 +86,12 @@ default rather than a fallback:
   earlier bad move. Inspecting which one you have is exactly the step this
   avoids.
 
-**Do not clear the staging directory by hand first.** The interrupted upgrade may
-already have stripped the live app, in which case the Caskroom copy is the only
-copy you have. Check before touching anything:
-
-```sh
-ls -A "/Applications/<App>.app"
-```
-
-- Prints `Contents` — the live app is intact.
-- **No output** — the bundle directory survived but its contents did not, which
-  is what Homebrew leaves behind when an upgrade strips an app without removing
-  its directory.
-- **`No such file or directory`** — the live app is gone entirely.
-
-In the last two cases the Caskroom leftover is your only copy, which is why
-deleting it by hand can lose the app outright. Reinstall covers all three by
-construction: it fetches before it uninstalls, so nothing is removed until the
-replacement is already on disk.
+**Do not clear the staging directory by hand.** The interrupted upgrade may
+already have stripped the live app — either removing `/Applications/<App>.app`
+outright, or leaving the directory in place with its contents gone — so the
+Caskroom leftover can be the only copy you have, and deleting it can lose the
+app. Reinstall handles every case by construction: it fetches before it
+uninstalls, so nothing is removed until the replacement is already on disk.
 
 **Reinstall lands the current version, and does not preserve the old one.** A
 cask tap generally serves only the current version, so once the forced

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -90,8 +90,8 @@ default rather than a fallback:
 already have stripped the live app — either removing `/Applications/<App>.app`
 outright, or leaving the directory in place with its contents gone — so the
 Caskroom leftover can be the only copy you have, and deleting it can lose the
-app. Reinstall does not need it cleared — see the fetch-before-uninstall
-property above.
+app. Reinstall does not need the staging directory cleared — its uninstall is
+forced, per the first property above.
 
 **Reinstall lands the current version, and does not preserve the old one.** A
 cask tap generally serves only the current version, so once the forced

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -86,12 +86,24 @@ default rather than a fallback:
   earlier bad move. Inspecting which one you have is exactly the step this
   avoids.
 
-**Do not clear the staging directory by hand first.** If `/Applications/<App>.app`
-is missing — or present but *empty*, which Homebrew can leave behind when an
-upgrade strips a bundle's contents without removing its directory — then the
-Caskroom copy is the only copy of the app you have. Reinstall covers that case
-by construction: it fetches before it uninstalls, so nothing is removed until
-the replacement is already on disk.
+**Do not clear the staging directory by hand first.** The interrupted upgrade may
+already have stripped the live app, in which case the Caskroom copy is the only
+copy you have. Check before touching anything:
+
+```sh
+ls -A "/Applications/<App>.app"
+```
+
+- Prints `Contents` — the live app is intact.
+- **No output** — the bundle directory survived but its contents did not, which
+  is what Homebrew leaves behind when an upgrade strips an app without removing
+  its directory.
+- **`No such file or directory`** — the live app is gone entirely.
+
+In the last two cases the Caskroom leftover is your only copy, which is why
+deleting it by hand can lose the app outright. Reinstall covers all three by
+construction: it fetches before it uninstalls, so nothing is removed until the
+replacement is already on disk.
 
 **Reinstall lands the current version, and does not preserve the old one.** A
 cask tap generally serves only the current version, so once the forced
@@ -101,11 +113,6 @@ what you want.
 
 Needing a *different* version is a separate task: pinning or downgrading a cask
 has its own constraints and is out of scope here.
-
-The reinstall is not what puts your install at risk, though: the interrupted
-upgrade may have stripped `/Applications/<App>.app` already, so confirm it is
-present and non-empty before treating it as a version you still have. Until the
-wedge is cleared, every `just update` keeps failing on this cask.
 
 Do not improvise a rollback by copying the Caskroom leftover aside. It is one
 of the three shapes above, only one of which is a working app, so the copy may


### PR DESCRIPTION
## Summary

`docs/homebrew.md`'s cask-recovery runbook asked the operator to confirm
`/Applications/<App>.app` was "present and non-empty" — and then branched on
nothing. The prescribed action was `brew reinstall --cask` either way, since
needing a *different* version is explicitly out of scope. It was also the one
step with no copy-pasteable command, and it sat *after* the reinstall was
prescribed, so read literally it had you inspecting a bundle the forced
uninstall had already replaced.

**The check is dropped rather than dressed up.** The first attempt in this PR
moved it and gave it `ls -A "/Applications/<App>.app"` with the three outcomes
spelled out — and review correctly pointed out that every outcome still led to
the same step, so it remained decorative. The runbook's whole thrust is that the
operator never hand-manages the Caskroom, which makes an inspection step surplus
by construction; the alternative (make the outcome consequential) would have had
to invent a hand-clearing decision the document deliberately steers away from.

What survives is the one load-bearing fact, in the paragraph where it does work:
the interrupted upgrade may already have stripped the live app, so the Caskroom
leftover can be the only copy you have — which is why deleting it by hand can
lose the app outright.

**Also removed, not raised in the issue:** the same paragraph restated the
wedge-persistence fact ("every `just update` keeps failing until the wedge is
cleared") already given six paragraphs earlier under **Cause**. It now appears
once.

Net effect on the runbook is subtraction — six lines shorter, one fewer command
for the operator to run, and no step whose answer changes nothing.

## Test plan

- [x] `just ci` green (shell, markdown, Brewfile, mise, keyword guard)
- [x] The wedge-persistence claim now appears exactly once (`grep` confirms a
      single occurrence, under **Cause**)
- [x] No orphaned references left behind — no stale `ls -A` command, no dangling
      "all three outcomes"
- [x] Section still reads linearly: **Cause** → **Fix** → do-not-clear →
      version caveat → do-not-improvise-a-rollback

## Review

Round 1 (job 128): 1 Medium, 2 Low — all three resolved by a single
simplification.

The Medium was that my own first fix reproduced the defect the issue names: the
check was relocated but still branched nothing. Both Lows were properties of the
outcome table I had added — the three outcomes were presented as exhaustive but
were not (a bundle with a custom icon, or the wrapper shape this same doc
describes two paragraphs earlier, prints something else), and "all three" reused
a numeral that already meant the three shapes of the Caskroom leftover. Deleting
the table resolved both.

## Issues

Closes #210
