### PR TITLE
feat(just): add a link recipe to re-apply symlinks without setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Install tools
         run: |
-          sudo apt-get install -y shellcheck
+          sudo apt-get install -y shellcheck jq
           npm install -g markdownlint-cli2
 
       - name: Run all checks

--- a/.roborev.toml
+++ b/.roborev.toml
@@ -41,7 +41,7 @@ SCOPE CONTEXT — understand before flagging:
 
 - rcup symlinks: tracked files are symlinked into $HOME by rcm based on `rcrc`. Both this repo and `dotfiles-private` are merged via `DOTFILES_DIRS`.
 - Versioning: SemVer and changelog policy are defined in the global Claude Code config (in `dotfiles-private`) and auto-load via rcm. Don't expect a `versioning.md` file in this repo's tree.
-- CI: `just ci` runs shell, markdown, Brewfile, and mise lints — the same checks run in GitHub Actions.
+- CI: `just ci` runs shell, markdown, Brewfile, mise, and Justfile lints — the same checks run in GitHub Actions.
 
 DO NOT FLAG:
 

--- a/.roborev.toml
+++ b/.roborev.toml
@@ -41,7 +41,7 @@ SCOPE CONTEXT — understand before flagging:
 
 - rcup symlinks: tracked files are symlinked into $HOME by rcm based on `rcrc`. Both this repo and `dotfiles-private` are merged via `DOTFILES_DIRS`.
 - Versioning: SemVer and changelog policy are defined in the global Claude Code config (in `dotfiles-private`) and auto-load via rcm. Don't expect a `versioning.md` file in this repo's tree.
-- CI: `just ci` runs shell, markdown, Brewfile, mise, and Justfile lints — the same checks run in GitHub Actions.
+- CI: `just ci` runs shell, markdown, Brewfile, mise, and Justfile lints, plus the keyword guard delegated to the private repo — the same checks run in GitHub Actions.
 
 DO NOT FLAG:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Added
 
+- `just link` — re-applies the rcm symlinks on their own, so an edit to a
+  symlinked dotfile (`gitconfig`, `zshrc`, `zshenv`, `tmux.conf`, …) can take
+  effect without running the full `just setup` bootstrap. Previously the only
+  `rcup` invocation lived inline in `setup`, and the recipe reached for far more
+  often — `just update` — does not re-link at all, so the natural "apply my
+  changes" command was the wrong one. `setup` now calls `just link` instead of
+  repeating the command, making the `RCRC=`-prefixed form (required because this
+  repo keeps its `rcrc` in-tree rather than at `~/.rcrc`) exist in exactly one
+  place. `README.md` and `CLAUDE.md` now point at `just link` rather than a bare
+  `rcup`, and state that `just update` does not re-link
+  ([#213](https://github.com/tgautier/dotfiles/issues/213)).
 - `!.claude/worktrees/**` to the `markdownlint-cli2` globs, completing the
   worktree hygiene begun in [#212](https://github.com/tgautier/dotfiles/pull/212).
   The path was already gitignored, but `markdownlint-cli2` globs are not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,14 @@ grouped by **date** rather than by semantic version. Newest first.
   surfaced only mid-bootstrap on a fresh machine, after `brew bundle` had
   already run. The recipe list comes from `just --dump` rather than
   `--summary`, which omits the `_`-prefixed recipes — two of which are called
-  from bodies. The check fails loud when its own pattern matches nothing, so it
-  cannot silently rot into a no-op. `jq` is now installed explicitly in CI
-  rather than assumed present in the runner image
-  ([#213](https://github.com/tgautier/dotfiles/issues/213)).
+  from bodies. Two negative fixtures run on every invocation (a call to a
+  non-existent recipe, and a scan that matches nothing), each asserting the
+  failure came from its own guard rather than from any incidental error — the
+  convention `.claude/rules/brewfile.md` sets for guard logic. `jq` is now
+  installed explicitly in CI rather than assumed present in the runner image.
+  The README lint table also gains the `lint-via-private` row it was missing
+  ([#213](https://github.com/tgautier/dotfiles/issues/213),
+  partially [#219](https://github.com/tgautier/dotfiles/issues/219)).
 - `!.claude/worktrees/**` to the `markdownlint-cli2` globs, completing the
   worktree hygiene begun in [#212](https://github.com/tgautier/dotfiles/pull/212).
   The path was already gitignored, but `markdownlint-cli2` globs are not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ grouped by **date** rather than by semantic version. Newest first.
   `rcup` invocation lived inline in `setup`, and the recipe reached for far more
   often — `just update` — does not re-link at all, so the natural "apply my
   changes" command was the wrong one. `setup` now calls `just link` instead of
-  repeating the command, making the `RCRC=`-prefixed form (required because this
-  repo keeps its `rcrc` in-tree rather than at `~/.rcrc`) exist in exactly one
-  place. `README.md` and `CLAUDE.md` now point at `just link` rather than a bare
-  `rcup`, and state that `just update` does not re-link
+  repeating the command, so the `RCRC=`-prefixed form exists in exactly one
+  place. That form points rcm at the in-tree `rcrc` explicitly, which is what
+  makes it work on a machine that has never been bootstrapped — `~/.rcrc` is
+  itself one of the symlinks rcm creates, so a bare `rcup` finds the same config
+  only after the first run. `README.md` and `CLAUDE.md` now point at `just link`
+  rather than a bare `rcup`, and state that `just update` does not re-link
   ([#213](https://github.com/tgautier/dotfiles/issues/213)).
 - `!.claude/worktrees/**` to the `markdownlint-cli2` globs, completing the
   worktree hygiene begun in [#212](https://github.com/tgautier/dotfiles/pull/212).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ grouped by **date** rather than by semantic version. Newest first.
   only after the first run. `README.md` and `CLAUDE.md` now point at `just link`
   rather than a bare `rcup`, and state that `just update` does not re-link
   ([#213](https://github.com/tgautier/dotfiles/issues/213)).
+- `just lint-just`, wired into `just ci` — asserts every in-body
+  `just <recipe>` call names a recipe that exists. Those calls are opaque shell
+  strings to `just`, so nothing caught a typo in one: `just --summary` and
+  `just --dry-run setup` both exit 0 on a misspelt call, and `just --fmt
+  --check` exits 1 on this file for formatting reasons alone. A typo would have
+  surfaced only mid-bootstrap on a fresh machine, after `brew bundle` had
+  already run. The recipe list comes from `just --dump` rather than
+  `--summary`, which omits the `_`-prefixed recipes — two of which are called
+  from bodies. The check fails loud when its own pattern matches nothing, so it
+  cannot silently rot into a no-op. `jq` is now installed explicitly in CI
+  rather than assumed present in the runner image
+  ([#213](https://github.com/tgautier/dotfiles/issues/213)).
 - `!.claude/worktrees/**` to the `markdownlint-cli2` globs, completing the
   worktree hygiene begun in [#212](https://github.com/tgautier/dotfiles/pull/212).
   The path was already gitignored, but `markdownlint-cli2` globs are not

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,13 +79,12 @@ Shell startup is optimized with caching (kubectl context, environment vars). Avo
 
 The `Justfile` defines local CI targets mirroring the GitHub Actions workflow:
 
-- `just ci` — runs all checks (shell, markdown, Brewfile, mise, Justfile, plus
-  the keyword guard delegated to the private repo)
+- `just ci` — runs every lint (the individual targets are listed in
+  `README.md`'s CI / Linting table)
 - `just setup` — full machine bootstrap (profile, packages, symlinks, runtimes, hooks, tools)
 
-The individual lint targets are enumerated once, in `README.md`'s CI / Linting
-table — don't duplicate that list here. Two copies of it drifted apart three
-times while this file was being written.
+Duplicating that target list here has drifted from the table before — keep the
+single enumeration in `README.md`.
 
 ### tmux
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,8 @@ Cross-platform personal dotfiles for macOS and Linux/WSL2, managed with **rcm** 
 ```sh
 # Re-apply the rcm symlinks (uses DOTFILES_DIRS from rcrc). Required for an
 # edit to a symlinked dotfile — gitconfig, zshrc, zshenv, tmux.conf — to take
-# effect on this machine. `just update` does NOT re-link. Never run bare `rcup`:
-# this repo keeps its rcrc in-tree, and the recipe carries the required RCRC=
+# effect on this machine. `just update` does NOT re-link. Prefer this over a
+# bare `rcup`, which finds the same config only once ~/.rcrc is itself linked
 just link
 
 # Install packages (auto-selects the platform Brewfile and, on macOS, the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,8 @@ Shell startup is optimized with caching (kubectl context, environment vars). Avo
 
 The `Justfile` defines local CI targets mirroring the GitHub Actions workflow:
 
-- `just ci` — runs all checks (shell, markdown, Brewfile, mise, Justfile)
+- `just ci` — runs all checks (shell, markdown, Brewfile, mise, Justfile, plus
+  the keyword guard delegated to the private repo)
 - `just lint-shell` — shellcheck on `bin/*` and zsh files
 - `just lint-just` — asserts in-body `just <recipe>` calls name recipes that exist
 - `just setup` — full machine bootstrap (profile, packages, symlinks, runtimes, hooks, tools)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,8 @@ Cross-platform personal dotfiles for macOS and Linux/WSL2, managed with **rcm** 
 # Re-apply the rcm symlinks (uses DOTFILES_DIRS from rcrc). Required for an
 # edit to a symlinked dotfile — gitconfig, zshrc, zshenv, tmux.conf — to take
 # effect on this machine. `just update` does NOT re-link. Prefer this over a
-# bare `rcup`, which finds the same config only once ~/.rcrc is itself linked
+# bare `rcup`, which finds the same config only once ~/.rcrc is itself linked.
+# Run it from this checkout — ~/.justfile points at the private repo's justfile
 just link
 
 # Install packages (auto-selects the platform Brewfile and, on macOS, the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,9 +81,11 @@ The `Justfile` defines local CI targets mirroring the GitHub Actions workflow:
 
 - `just ci` — runs all checks (shell, markdown, Brewfile, mise, Justfile, plus
   the keyword guard delegated to the private repo)
-- `just lint-shell` — shellcheck on `bin/*` and zsh files
-- `just lint-just` — asserts in-body `just <recipe>` calls name recipes that exist
 - `just setup` — full machine bootstrap (profile, packages, symlinks, runtimes, hooks, tools)
+
+The individual lint targets are enumerated once, in `README.md`'s CI / Linting
+table — don't duplicate that list here. Two copies of it drifted apart three
+times while this file was being written.
 
 ### tmux
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,8 +79,9 @@ Shell startup is optimized with caching (kubectl context, environment vars). Avo
 
 The `Justfile` defines local CI targets mirroring the GitHub Actions workflow:
 
-- `just ci` — runs all checks (shell, markdown, Brewfile, mise)
+- `just ci` — runs all checks (shell, markdown, Brewfile, mise, Justfile)
 - `just lint-shell` — shellcheck on `bin/*` and zsh files
+- `just lint-just` — asserts in-body `just <recipe>` calls name recipes that exist
 - `just setup` — full machine bootstrap (profile, packages, symlinks, runtimes, hooks, tools)
 
 ### tmux

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,11 @@ Cross-platform personal dotfiles for macOS and Linux/WSL2, managed with **rcm** 
 ## Key Commands
 
 ```sh
-# Link/update dotfiles after changes (uses DOTFILES_DIRS from rcrc)
-rcup
+# Re-apply the rcm symlinks (uses DOTFILES_DIRS from rcrc). Required for an
+# edit to a symlinked dotfile — gitconfig, zshrc, zshenv, tmux.conf — to take
+# effect on this machine. `just update` does NOT re-link. Never run bare `rcup`:
+# this repo keeps its rcrc in-tree, and the recipe carries the required RCRC=
+just link
 
 # Install packages (auto-selects the platform Brewfile and, on macOS, the
 # work/personal overlay). Never run raw `brew install` / `brew bundle` —

--- a/Justfile
+++ b/Justfile
@@ -34,10 +34,12 @@ lint-just:
     # rather than a copy of it.
     check() {
         local file=$1 called status=0 name
-        # `if !` is load-bearing: a plain `called=$(scan …)` assignment would
-        # take the pipeline's exit status under `pipefail`, and `set -e` would
-        # kill the recipe here — making the empty-match guard below unreachable
-        # and its diagnostic unprintable.
+        # Keeps the guard below reachable if `check` is ever called outside a
+        # condition context. Today's call sites (`check … || exit 1`, and the
+        # fixtures' `if check …`) already suppress `-e` for this whole body, so
+        # a plain assignment would fall through on its own — but a refactor to a
+        # bare `check Justfile` would restore `-e` here, and the no-match
+        # pipeline under `pipefail` would abort before the guard could report.
         if ! called=$(scan "$file"); then called=""; fi
         # An empty result means the regex broke, not that the file is clean:
         # `setup` alone makes three such calls. Without this the lint would
@@ -82,7 +84,10 @@ lint-just:
     fi
     echo "lint-just unknown-recipe detection OK"
 
-    printf '# just %s in a comment must not match\nnothing:\n    echo hi\n' link > "$tmp/empty"
+    # The comment is INDENTED so the emptiness comes from the comment filter
+    # rather than the indent filter — a column-0 comment would be dropped by the
+    # first filter and leave the comment-exclusion branch untested.
+    printf 'nothing:\n    # just %s in a comment must not match\n    echo hi\n' link > "$tmp/empty"
     if out=$(check "$tmp/empty" 2>&1); then
         echo "ERROR: lint-just did not fire when the pattern matched nothing" >&2
         exit 1

--- a/Justfile
+++ b/Justfile
@@ -34,16 +34,9 @@ lint-just:
     # rather than a copy of it.
     check() {
         local file=$1 called status=0 name
-        # Keeps the guard below reachable if `check` is ever called outside a
-        # condition context. Today's call sites — `check … || exit 1` and the
-        # fixtures' `if out=$(check … 2>&1)` — already suppress `-e` for this
-        # whole body: bash carries the ignore-return state into command
-        # substitutions (its own `comsub_ignore_return`), so the fixtures' form
-        # suppresses it too. A plain assignment would therefore fall through to
-        # the guard on its own at both of today's call sites. But a refactor to
-        # a bare `check Justfile` would restore `-e` here, and the no-match
-        # pipeline under `pipefail` would abort before the guard could report.
-        if ! called=$(scan "$file"); then called=""; fi
+        # `|| true` so a no-match pipeline yields an empty string instead of
+        # aborting under `pipefail`, in any caller's `-e` context.
+        called=$(scan "$file" || true)
         # An empty result means the regex broke, not that the file is clean:
         # `setup` alone makes three such calls. Without this the lint would
         # silently pass forever.

--- a/Justfile
+++ b/Justfile
@@ -44,10 +44,11 @@ setup: _ensure-profile
     #    package upgrading cleanly.
     brew bundle install --no-upgrade --file="{{brewfile}}"
 
-    # 2. Symlink dotfiles. RCRC points rcm at the repo config so a fresh machine
-    #    (no ~/.rcrc yet) links every DOTFILES_DIRS entry; a missing private repo
-    #    is skipped, not fatal.
-    RCRC="{{dotfiles_dir}}/rcrc" rcup
+    # 2. Symlink dotfiles. Delegated to `link` so the RCRC-prefixed invocation
+    #    lives in exactly one place. Called here rather than declared as a
+    #    dependency because dependencies run before the recipe body, and rcm
+    #    itself comes from the `brew bundle` in step 1.
+    just link
 
     # 3. Language runtimes from the pinned mise config. Install mise first if the
     #    machine doesn't have it yet (matches the README curl bootstrap).
@@ -76,6 +77,18 @@ setup: _ensure-profile
 
     # 7. Linux/WSL: symlink libsqlite3 for Dart/Flutter FFI (no-op on macOS).
     {{ if os() == "macos" { "true" } else { "just _link-libsqlite3" } }}
+
+# Run this after editing any dotfile rcm links into $HOME (gitconfig, zshrc,
+# zshenv, tmux.conf, …) — the edit lands in this repo, but the running machine
+# only picks it up once the links are re-applied. `just update` does NOT
+# re-link: it upgrades installed software, not local config. RCRC points rcm at
+# this repo's in-tree config rather than ~/.rcrc, so every DOTFILES_DIRS entry
+# is linked; this is the authoritative invocation, and `setup` calls it rather
+# than repeating it. The [doc] attribute carries the summary because `just
+# --list` would otherwise show only the last line of this comment.
+[doc("Re-apply the rcm symlinks (run after editing a symlinked dotfile)")]
+link:
+    RCRC="{{dotfiles_dir}}/rcrc" rcup
 
 # Symlink the system libsqlite3 into a dedicated ~/.local/lib/flutter-ffi dir for
 # Dart/Flutter (Drift) FFI, which dlopen()s the unversioned 'libsqlite3.so' the

--- a/Justfile
+++ b/Justfile
@@ -82,10 +82,12 @@ setup: _ensure-profile
 # zshenv, tmux.conf, …) — the edit lands in this repo, but the running machine
 # only picks it up once the links are re-applied. `just update` does NOT
 # re-link: it upgrades installed software, not local config. RCRC points rcm at
-# this repo's in-tree config rather than ~/.rcrc, so every DOTFILES_DIRS entry
-# is linked; this is the authoritative invocation, and `setup` calls it rather
-# than repeating it. The [doc] attribute carries the summary because `just
-# --list` would otherwise show only the last line of this comment.
+# this repo's in-tree config, so every DOTFILES_DIRS entry is linked even on a
+# machine that has never been bootstrapped — `~/.rcrc` is itself one of the
+# symlinks rcm creates, so a bare `rcup` only finds the same config after the
+# first run. That makes this the authoritative invocation, and `setup` calls it
+# rather than repeating it. The [doc] attribute carries the summary because
+# `just --list` would otherwise show only the last line of this comment.
 [doc("Re-apply the rcm symlinks (run after editing a symlinked dotfile)")]
 link:
     RCRC="{{dotfiles_dir}}/rcrc" rcup

--- a/Justfile
+++ b/Justfile
@@ -3,7 +3,47 @@
 zsh_excludes := "SC1036,SC1087,SC1090,SC2128,SC2145,SC2154,SC2155,SC2168,SC2179,SC2206,SC2211,SC2296"
 
 # Run all CI checks
-ci: lint-shell lint-markdown lint-brewfile lint-mise lint-via-private
+ci: lint-shell lint-markdown lint-brewfile lint-mise lint-just lint-via-private
+
+# Assert every in-body `just <recipe>` call names a recipe that exists here.
+# Those calls are opaque shell strings to just, so nothing else catches a typo:
+# `just --summary` and `just --dry-run setup` both exit 0 with a misspelt one,
+# and it would surface only mid-bootstrap on a fresh machine, after `brew
+# bundle` has already run. (`just --fmt --check` is no help either — it exits 1
+# on this file for formatting reasons alone.) The recipe list comes from
+# --dump rather than --summary because --summary omits `_`-prefixed recipes,
+# two of which are called from bodies. Calls carrying `-f` target another
+# justfile and are skipped by the pattern, which requires a recipe name
+# directly after `just`.
+[doc("Check that in-body `just <recipe>` calls name recipes that exist")]
+lint-just:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    known=" $(just --dump --dump-format json | jq -r '.recipes | keys[]' | tr '\n' ' ')"
+    # Recipe bodies only: indented, and not a comment line. Prose in comments
+    # ("so this works when just finds ~/.justfile") would otherwise match.
+    called=$(grep -E '^[[:space:]]' Justfile | grep -vE '^[[:space:]]*#' \
+                | grep -oE '(^|[^-[:alnum:]_])just +[a-z_][a-z0-9_-]*' \
+                | grep -oE '[a-z_][a-z0-9_-]*$' | sort -u)
+    # Fail loud if the pattern matches nothing: `setup` alone makes three such
+    # calls, so an empty result means the regex broke, not that the file is
+    # clean. Without this the lint would silently pass forever.
+    if [ -z "$called" ]; then
+        echo "lint-just: matched no \`just <recipe>\` calls — the pattern is broken" >&2
+        exit 1
+    fi
+    status=0
+    for name in $called; do
+        case "$known" in
+            *" $name "*) ;;
+            *) echo "lint-just: body calls \`just $name\`, which is not a recipe here" >&2
+               status=1 ;;
+        esac
+    done
+    if [ "$status" -eq 0 ]; then
+        echo "Justfile recipe calls OK ($(echo "$called" | wc -w | tr -d ' ') checked)"
+    fi
+    exit "$status"
 
 # Delegate to the private repo's justfile for checks that must not be defined
 # here (keyword lists etc.). Skips loudly when the private repo is absent —
@@ -86,8 +126,12 @@ setup: _ensure-profile
 # machine that has never been bootstrapped — `~/.rcrc` is itself one of the
 # symlinks rcm creates, so a bare `rcup` only finds the same config after the
 # first run. That makes this the authoritative invocation, and `setup` calls it
-# rather than repeating it. The [doc] attribute carries the summary because
-# `just --list` would otherwise show only the last line of this comment.
+# rather than repeating it. An absent private repo is skipped, not fatal.
+#
+# Must be run from this checkout: `~/.justfile` is a symlink to the PRIVATE
+# repo's justfile, so `just link` from $HOME resolves there and fails with an
+# unknown-recipe error. The [doc] attribute carries the summary because `just
+# --list` would otherwise show only the last line of this comment.
 [doc("Re-apply the rcm symlinks (run after editing a symlinked dotfile)")]
 link:
     RCRC="{{dotfiles_dir}}/rcrc" rcup

--- a/Justfile
+++ b/Justfile
@@ -14,36 +14,85 @@ ci: lint-shell lint-markdown lint-brewfile lint-mise lint-just lint-via-private
 # --dump rather than --summary because --summary omits `_`-prefixed recipes,
 # two of which are called from bodies. Calls carrying `-f` target another
 # justfile and are skipped by the pattern, which requires a recipe name
-# directly after `just`.
+# directly after `just`. Two negative fixtures run on every invocation, per the
+# guard-testing convention in .claude/rules/brewfile.md.
 [doc("Check that in-body `just <recipe>` calls name recipes that exist")]
 lint-just:
     #!/usr/bin/env bash
     set -euo pipefail
     known=" $(just --dump --dump-format json | jq -r '.recipes | keys[]' | tr '\n' ' ')"
+
     # Recipe bodies only: indented, and not a comment line. Prose in comments
     # ("so this works when just finds ~/.justfile") would otherwise match.
-    called=$(grep -E '^[[:space:]]' Justfile | grep -vE '^[[:space:]]*#' \
-                | grep -oE '(^|[^-[:alnum:]_])just +[a-z_][a-z0-9_-]*' \
-                | grep -oE '[a-z_][a-z0-9_-]*$' | sort -u)
-    # Fail loud if the pattern matches nothing: `setup` alone makes three such
-    # calls, so an empty result means the regex broke, not that the file is
-    # clean. Without this the lint would silently pass forever.
-    if [ -z "$called" ]; then
-        echo "lint-just: matched no \`just <recipe>\` calls — the pattern is broken" >&2
+    scan() {
+        grep -E '^[[:space:]]' "$1" | grep -vE '^[[:space:]]*#' \
+            | grep -oE '(^|[^-[:alnum:]_])just +[a-z_][a-z0-9_-]*' \
+            | grep -oE '[a-z_][a-z0-9_-]*$' | sort -u
+    }
+
+    # Factored out so the negative fixtures below exercise this exact logic
+    # rather than a copy of it.
+    check() {
+        local file=$1 called status=0 name
+        # `if !` is load-bearing: a plain `called=$(scan …)` assignment would
+        # take the pipeline's exit status under `pipefail`, and `set -e` would
+        # kill the recipe here — making the empty-match guard below unreachable
+        # and its diagnostic unprintable.
+        if ! called=$(scan "$file"); then called=""; fi
+        # An empty result means the regex broke, not that the file is clean:
+        # `setup` alone makes three such calls. Without this the lint would
+        # silently pass forever.
+        if [ -z "$called" ]; then
+            echo "lint-just: no \`just <recipe>\` call matched in $file — the pattern is broken" >&2
+            return 1
+        fi
+        for name in $called; do
+            case "$known" in
+                *" $name "*) ;;
+                *) echo "lint-just: $file calls \`just $name\`, which is not a recipe here" >&2
+                   status=1 ;;
+            esac
+        done
+        if [ "$status" -eq 0 ]; then
+            echo "Justfile recipe calls OK ($(printf '%s\n' "$called" | wc -l | tr -d ' ') checked)"
+        fi
+        return "$status"
+    }
+
+    check Justfile || exit 1
+
+    # Negative fixtures, mirroring `lint-brewfile`: assert each guard fires on
+    # known-bad input AND that the failure came from that guard, not from any
+    # incidental error. A guard that never fires is worse than no guard.
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+
+    # The recipe names go through printf ARGUMENTS, never as literal text on
+    # these lines: this file is itself scanned, so an inline `just <name>` here
+    # would be picked up as a real call by the check under test.
+    printf 'real:\n    echo hi\n\ncaller:\n    just %s\n' nosuchrecipe > "$tmp/unknown"
+    if out=$(check "$tmp/unknown" 2>&1); then
+        echo "ERROR: lint-just did not fire on a call to a non-existent recipe" >&2
         exit 1
     fi
-    status=0
-    for name in $called; do
-        case "$known" in
-            *" $name "*) ;;
-            *) echo "lint-just: body calls \`just $name\`, which is not a recipe here" >&2
-               status=1 ;;
-        esac
-    done
-    if [ "$status" -eq 0 ]; then
-        echo "Justfile recipe calls OK ($(echo "$called" | wc -w | tr -d ' ') checked)"
+    if ! grep -q 'is not a recipe here' <<<"$out"; then
+        echo "ERROR: unknown-recipe case did not come from the unknown-recipe guard:" >&2
+        echo "$out" >&2
+        exit 1
     fi
-    exit "$status"
+    echo "lint-just unknown-recipe detection OK"
+
+    printf '# just %s in a comment must not match\nnothing:\n    echo hi\n' link > "$tmp/empty"
+    if out=$(check "$tmp/empty" 2>&1); then
+        echo "ERROR: lint-just did not fire when the pattern matched nothing" >&2
+        exit 1
+    fi
+    if ! grep -q 'the pattern is broken' <<<"$out"; then
+        echo "ERROR: empty-match case did not come from the empty-match guard:" >&2
+        echo "$out" >&2
+        exit 1
+    fi
+    echo "lint-just empty-match detection OK"
 
 # Delegate to the private repo's justfile for checks that must not be defined
 # here (keyword lists etc.). Skips loudly when the private repo is absent —

--- a/Justfile
+++ b/Justfile
@@ -35,10 +35,11 @@ lint-just:
     check() {
         local file=$1 called status=0 name
         # Keeps the guard below reachable if `check` is ever called outside a
-        # condition context. Today's call sites (`check … || exit 1`, and the
-        # fixtures' `if check …`) already suppress `-e` for this whole body, so
-        # a plain assignment would fall through on its own — but a refactor to a
-        # bare `check Justfile` would restore `-e` here, and the no-match
+        # condition context. Today's call sites — `check … || exit 1` and the
+        # fixtures' `if out=$(check … 2>&1)` — already suppress `-e` for this
+        # whole body (it reaches into the command substitution too; verified),
+        # so a plain assignment would fall through on its own. But a refactor to
+        # a bare `check Justfile` would restore `-e` here, and the no-match
         # pipeline under `pipefail` would abort before the guard could report.
         if ! called=$(scan "$file"); then called=""; fi
         # An empty result means the regex broke, not that the file is clean:

--- a/Justfile
+++ b/Justfile
@@ -37,8 +37,10 @@ lint-just:
         # Keeps the guard below reachable if `check` is ever called outside a
         # condition context. Today's call sites — `check … || exit 1` and the
         # fixtures' `if out=$(check … 2>&1)` — already suppress `-e` for this
-        # whole body (it reaches into the command substitution too; verified),
-        # so a plain assignment would fall through on its own. But a refactor to
+        # whole body: bash carries the ignore-return state into command
+        # substitutions (its own `comsub_ignore_return`), so the fixtures' form
+        # suppresses it too. A plain assignment would therefore fall through to
+        # the guard on its own at both of today's call sites. But a refactor to
         # a bare `check Justfile` would restore `-e` here, and the no-match
         # pipeline under `pipefail` would abort before the guard could report.
         if ! called=$(scan "$file"); then called=""; fi

--- a/README.md
+++ b/README.md
@@ -182,16 +182,20 @@ After editing a dotfile that rcm links into `$HOME` (`gitconfig`, `zshrc`,
 `zshenv`, `tmux.conf`, …), re-link so the running machine picks the change up:
 
 ```sh
+cd ~/Workspace/tgautier/dotfiles
 just link
 ```
+
+The `cd` matters: `~/.justfile` is a symlink to the private repo's justfile, so
+`just link` from `$HOME` resolves there and fails with an unknown-recipe error.
 
 `just setup` also re-links, but it is the whole bootstrap — `just link` is the
 one step.
 
-Prefer it over a bare `rcup`. This repo keeps its `rcrc` in-tree rather than at
-`~/.rcrc`, and the recipe passes `RCRC=` explicitly, so it works on any machine.
-A bare `rcup` reads the same config only *after* the first bootstrap, because
-`~/.rcrc` is itself one of the symlinks rcm creates.
+Prefer it over a bare `rcup`. This repo's `rcrc` lives in-tree, and the recipe
+passes `RCRC=` explicitly, so it works on any machine — including one that has
+never been bootstrapped. A bare `rcup` reads the same config only *after* the
+first bootstrap, because `~/.rcrc` is itself one of the symlinks rcm creates.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,20 @@ Or run individual update steps:
 | `just update-mise` | Show outdated mise tools and upgrade them         |
 | `just update-rust` | Update Rust toolchain                             |
 
+### Applying config changes
+
+`just update` upgrades installed software — it does **not** re-apply symlinks.
+After editing a dotfile that rcm links into `$HOME` (`gitconfig`, `zshrc`,
+`zshenv`, `tmux.conf`, …), re-link so the running machine picks the change up:
+
+```sh
+just link
+```
+
+`just setup` also re-links, but it is the whole bootstrap — `just link` is the
+one step. Run neither as a bare `rcup`: this repo keeps its `rcrc` in-tree, and
+the recipe carries the `RCRC=` that points rcm at it.
+
 ## Documentation
 
 Detailed guides live in the `docs/` folder:

--- a/README.md
+++ b/README.md
@@ -186,8 +186,12 @@ just link
 ```
 
 `just setup` also re-links, but it is the whole bootstrap — `just link` is the
-one step. Run neither as a bare `rcup`: this repo keeps its `rcrc` in-tree, and
-the recipe carries the `RCRC=` that points rcm at it.
+one step.
+
+Prefer it over a bare `rcup`. This repo keeps its `rcrc` in-tree rather than at
+`~/.rcrc`, and the recipe passes `RCRC=` explicitly, so it works on any machine.
+A bare `rcup` reads the same config only *after* the first bootstrap, because
+`~/.rcrc` is itself one of the symlinks rcm creates.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -253,12 +253,14 @@ just ci
 
 Individual targets:
 
-| Target                 | Description                                          |
-| ---------------------- | ---------------------------------------------------- |
-| `just lint-shell`      | ShellCheck on `bin/*` and zsh files                  |
-| `just lint-markdown`   | markdownlint-cli2                                    |
-| `just lint-brewfile`   | Ruby syntax check on Brewfiles                       |
-| `just lint-mise`       | Validate mise config                                 |
+| Target                  | Description                                          |
+| ----------------------- | ---------------------------------------------------- |
+| `just lint-shell`       | ShellCheck on `bin/*` and zsh files                  |
+| `just lint-markdown`    | markdownlint-cli2                                    |
+| `just lint-brewfile`    | Ruby syntax check on Brewfiles                       |
+| `just lint-mise`        | Validate mise config                                 |
+| `just lint-just`        | Check in-body `just <recipe>` calls resolve          |
+| `just lint-via-private` | Keyword guard, delegated to the private repo         |
 
 The pre-commit hook is enabled by the bootstrap (idempotent — safe to re-run):
 


### PR DESCRIPTION
## Summary

- Add a `link` recipe holding the authoritative `RCRC=`-prefixed `rcup`
  invocation, so re-applying the rcm symlinks no longer requires running the
  whole `just setup` bootstrap. `setup` calls it at step 2 instead of repeating
  the command — a body call rather than a dependency, because dependencies run
  before the recipe body and rcm itself is installed by the `brew bundle` in
  step 1.
- `README.md` and `CLAUDE.md` now point at `just link` and state explicitly that
  `just update` does **not** re-link. That was the trap the issue describes:
  `update` is the recipe reached for far more often, and it was the wrong one.
- Both docs also record that `just link` must be run **from the checkout** —
  `~/.justfile` is a symlink to the private repo's justfile, so `just link` from
  `$HOME` (the likely cwd right after editing `~/.zshrc`) fails with an
  unknown-recipe error.
- Add `lint-just`, wired into `just ci`: it asserts every in-body
  `just <recipe>` call names a recipe that exists. Those calls are opaque shell
  strings to `just`, so nothing caught a typo in one, and it would have surfaced
  only mid-bootstrap on a fresh machine after `brew bundle` had already run.
- A `[doc]` attribute carries the `just --list` summary for both new recipes —
  `just` otherwise shows only the last line of a recipe's comment block.

`update` deliberately still does not re-link. Making it do so would conflate
"refresh installed software" with "apply local config", and would make a routine
update command mutate `$HOME` symlinks as a side effect.

## On `lint-just`

The reviewer's first suggested implementation does not work, so it was not
adopted as written. Measured on this file: `just --summary` exits 0 with a
misspelt in-body call, `just --dry-run setup` exits 0 too (the call is an opaque
shell string until runtime), and `just --fmt --check --unstable` exits 1 on the
*clean* file for formatting reasons alone. It is implemented instead as a scan of
non-comment body lines checked against `just --dump`, which unlike `--summary`
lists the `_`-prefixed recipes — two of which are called from bodies.

Two negative fixtures run on every invocation, each asserting the failure came
from **its own** guard rather than any incidental error, per the convention
`.claude/rules/brewfile.md` sets and `lint-brewfile` already follows.

## Review history

Five rounds; every finding either fixed or dispositioned. The notable ones:

- The first commit claimed "never run bare `rcup`". False — `rcrc` is absent from
  `EXCLUDES`, so rcm links it to `~/.rcrc` and a bare `rcup` reads the same
  config on a bootstrapped machine. It also contradicted `rcrc:8`. Corrected to
  the real distinction: passing `RCRC=` is what makes the recipe work on a
  machine that has never been bootstrapped.
- `lint-just`'s own empty-match guard was **dead code**. Under `set -euo
  pipefail` the plain `called=$(grep … )` assignment took the pipeline's status,
  so a no-match grep killed the recipe before the guard could report. The recipe
  still exited 1, which is exactly why the hand-run fixture looked correct — and
  why the fixtures are now automated and assert guard-specific messages.
- Writing those fixtures surfaced a self-reference bug: a literal
  `just nosuchrecipe` in the fixture's `printf` is an indented non-comment line,
  so the scan picked it up as a real call. Recipe names now go through `printf`
  arguments.
- Three consecutive rounds then rewrote the *comment* on the guard's capture
  line — ten lines of rationale for one line of code, each revision fixing an
  inaccuracy in the last. That was a complexity spiral, and the right answer was
  to delete the construct rather than annotate it better: `scan "$file" || true`
  has no caller-context failure mode to explain, so the comment is two lines.
- Rounds 5–7 kept finding the same shape — an inaccurate *justification* comment
  ("never run bare `rcup`", "load-bearing", the wrong call form, `; verified`).
  Worth noting for the audit checklist: its doc-drift rows cover claims about
  behavior, but not claims about *why a construct is necessary*.

## Test plan

- [x] `just ci` passes (shell, markdown, Brewfile, mise, Justfile, keyword guard)
- [x] `just --list` shows `link` and `lint-just` with readable descriptions
      rather than dangling comment fragments
- [x] `just link` exits 0 and is idempotent — rcup reports no changes, and
      `~/.zshrc`, `~/.gitconfig`, `~/.tmux.conf` all resolve into the repo
- [x] `just --dry-run setup` shows `just link` at step 2
- [x] `just link` from `$HOME` reproduces the unknown-recipe failure the docs now
      warn about
- [x] `lint-just` fixture matrix, all four re-run after every rewrite: clean file
      passes at 6 calls checked; a typo in a body call fails; a typo in the
      interpolated `_link-libsqlite3` call fails (proving `--dump` beats
      `--summary`); a sabotaged regex fails *naming the empty-match guard*
- [x] Empty-match fixture verified to exercise the **comment** filter, not the
      indent filter — its comment line survives `grep -E '^[[:space:]]'` and is
      dropped by `grep -vE '^[[:space:]]*#'`
- [x] The scan capture (`scan "$file" || true`) verified to reach the
      empty-result guard in **all four** call forms — `check || …`, bare
      `if check`, `if out=$(check …)`, and a bare `check` under `set -e` — so
      the guard is robust regardless of the caller's errexit context
- [x] Every `rcup` reference in the tree re-checked against reality
- [x] All three `just ci` enumerations (CLAUDE.md, README table, .roborev.toml)
      re-read and completed

## Notes

The README lint table also gains the `lint-via-private` row it was missing,
which clears one bullet from #219.

Fixes #213
