### PR TITLE
feat(just): honour DOTFILES_PRIVATE_DIR in rcrc and cleanup-symlinks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,10 @@ jobs:
 
       - name: Install tools
         run: |
-          sudo apt-get install -y shellcheck jq
+          # zsh: `lint-cleanup-symlinks` and the scanner it tests are zsh
+          # shebang recipes (the sweeper globs with zsh qualifiers). Not
+          # preinstalled on ubuntu-latest — verified by a 127 on this step.
+          sudo apt-get install -y shellcheck jq zsh
           npm install -g markdownlint-cli2
 
       - name: Run all checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,8 @@ jobs:
         run: |
           # zsh: `lint-cleanup-symlinks` and the scanner it tests are zsh
           # shebang recipes (the sweeper globs with zsh qualifiers). Not
-          # preinstalled on ubuntu-latest — verified by a 127 on this step.
+          # preinstalled on ubuntu-latest — verified by a 127 from
+          # `lint-cleanup-symlinks` in the "Run all checks" step below.
           sudo apt-get install -y shellcheck jq zsh
           npm install -g markdownlint-cli2
 

--- a/.roborev.toml
+++ b/.roborev.toml
@@ -39,9 +39,9 @@ HARD INVARIANTS — flag violations as blockers:
 
 SCOPE CONTEXT — understand before flagging:
 
-- rcup symlinks: tracked files are symlinked into $HOME by rcm based on `rcrc`. Both this repo and `dotfiles-private` are merged via `DOTFILES_DIRS`.
+- rcup symlinks: tracked files are symlinked into $HOME by rcm based on `rcrc`. Both this repo and `dotfiles-private` are merged via `DOTFILES_DIRS`. Their paths default to `$HOME/Workspace/tgautier/` and are overridable with `DOTFILES_DIR` / `DOTFILES_PRIVATE_DIR`, a contract shared by `rcrc`, the `Justfile` vars, and `_scan-stale-symlinks`.
 - Versioning: SemVer and changelog policy are defined in the global Claude Code config (in `dotfiles-private`) and auto-load via rcm. Don't expect a `versioning.md` file in this repo's tree.
-- CI: `just ci` runs shell, markdown, Brewfile, mise, and Justfile lints, plus the keyword guard delegated to the private repo — the same checks run in GitHub Actions.
+- CI: `just ci` runs shell, markdown, Brewfile, mise, Justfile and stale-symlink-scanner lints, plus the keyword guard delegated to the private repo — the same checks run in GitHub Actions.
 
 DO NOT FLAG:
 

--- a/.roborev.toml
+++ b/.roborev.toml
@@ -41,7 +41,7 @@ SCOPE CONTEXT — understand before flagging:
 
 - rcup symlinks: tracked files are symlinked into $HOME by rcm based on `rcrc`. Both this repo and `dotfiles-private` are merged via `DOTFILES_DIRS`. Their paths default to `$HOME/Workspace/tgautier/` and are overridable with `DOTFILES_DIR` / `DOTFILES_PRIVATE_DIR`, a contract shared by `rcrc`, the `Justfile` vars, and `_scan-stale-symlinks`.
 - Versioning: SemVer and changelog policy are defined in the global Claude Code config (in `dotfiles-private`) and auto-load via rcm. Don't expect a `versioning.md` file in this repo's tree.
-- CI: `just ci` runs shell, markdown, Brewfile, mise, Justfile and stale-symlink-scanner lints, plus the keyword guard delegated to the private repo — the same checks run in GitHub Actions.
+- CI: `just ci` runs shell, markdown, Brewfile, mise, Justfile, rcrc and stale-symlink-scanner lints, plus the keyword guard delegated to the private repo — the same checks run in GitHub Actions.
 
 DO NOT FLAG:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,11 @@ grouped by **date** rather than by semantic version. Newest first.
   stale-symlink scanner, which previously had no coverage at all despite ending
   in `rm`. Covers both halves of the predicate, the trailing-slash case, an
   absent configured dir, and — the one that matters most — a **survival** case:
-  an unrelated broken symlink must not be swept. Every assertion was verified to
-  fail when the corresponding logic is sabotaged, so none of them is vacuous
+  an unrelated broken symlink must not be swept. Every scan assertion was
+  verified to fail when the corresponding logic is sabotaged, so none of them is
+  vacuous. The sweep half can't be driven against a fixture tree (it refuses
+  `CLEANUP_HOME` by design), so what is covered there is the line parsing that
+  decides which path `rm` receives, including a target containing ` -> `
   ([#215](https://github.com/tgautier/dotfiles/issues/215)).
 - `just link` — re-applies the rcm symlinks on their own, so an edit to a
   symlinked dotfile (`gitconfig`, `zshrc`, `zshenv`, `tmux.conf`, …) can take

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Added
 
+- `DOTFILES_DIR` / `DOTFILES_PRIVATE_DIR` are now honoured by every consumer,
+  not just `lint-via-private`. `rcrc` reads them for both `DOTFILES_DIRS` and
+  `EXCLUDES` (it is sourced as shell by rcm, which is exactly why it can), and
+  the stale-symlink scanner derives its repo list from them. Setting one moves
+  all three together; previously it moved only the keyword guard, so an operator
+  who set the override pointed that guard at a private repo `rcup` never merged.
+  Documented in `README.md` → Custom checkout locations
+  ([#215](https://github.com/tgautier/dotfiles/issues/215)).
+- `just lint-cleanup-symlinks`, wired into `just ci` — fixture-tests the
+  stale-symlink scanner, which previously had no coverage at all despite ending
+  in `rm`. Covers both halves of the predicate, the trailing-slash case, an
+  absent configured dir, and — the one that matters most — a **survival** case:
+  an unrelated broken symlink must not be swept. Every assertion was verified to
+  fail when the corresponding logic is sabotaged, so none of them is vacuous
+  ([#215](https://github.com/tgautier/dotfiles/issues/215)).
 - `just link` — re-applies the rcm symlinks on their own, so an edit to a
   symlinked dotfile (`gitconfig`, `zshrc`, `zshenv`, `tmux.conf`, …) can take
   effect without running the full `just setup` bootstrap. Previously the only
@@ -97,6 +112,21 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Changed
 
+- The stale-symlink sweep is split in two: `_scan-stale-symlinks` finds and
+  prints stale links, `cleanup-symlinks` confirms and removes them. The scan
+  honours a `CLEANUP_HOME` override so fixtures can drive it against a temp
+  tree; `cleanup-symlinks` deliberately does **not**, so no environment setting
+  can redirect its `rm` at another tree. Its match is now a union — the
+  `dotfiles`/`dotfiles-private` path-segment match that catches links into a
+  *former* checkout path (rcm records absolute targets, so a moved checkout
+  leaves links naming the old location), plus prefixes derived from the
+  configured dirs, which catch a checkout whose basename isn't `dotfiles*` at
+  all. Neither subsumes the other, which is why
+  [#214](https://github.com/tgautier/dotfiles/pull/214) reverted after replacing
+  the first with the second. Paths are normalised with zsh's `:a` so a trailing
+  slash can't silently produce a prefix that matches nothing, and a failed scan
+  now aborts loudly instead of reporting a clean tree
+  ([#215](https://github.com/tgautier/dotfiles/issues/215)).
 - `.roborev.toml` now names `claude-code` directly instead of `copilot`. roborev
   could not invoke `copilot`, so every review silently fell through to
   `backup_agent` — 112 of 112 jobs on record ran `claude-code`. claude-code is the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,18 @@ grouped by **date** rather than by semantic version. Newest first.
   who set the override pointed that guard at a private repo `rcup` never merged.
   Documented in `README.md` → Custom checkout locations
   ([#215](https://github.com/tgautier/dotfiles/issues/215)).
-- `just lint-rcrc`, wired into `just ci` — pins how `rcrc` resolves
-  `DOTFILES_DIRS`: defaults with no override, each override alone and both
-  together, one *and* several trailing slashes stripped, a root value surviving
-  as `/` rather than collapsing to an empty entry (which would make the derived
-  prefix match anything), and no helper or temp var leaking into the sourcing
-  shell. `rcrc` is also now shellchecked (`--shell=sh`, since rcm sources it as
+- `just lint-rcrc`, wired into `just ci` — pins both halves of the override
+  contract. For `DOTFILES_DIRS`: defaults with no override, each override alone
+  and both together, one *and* several trailing slashes stripped, a root value
+  surviving as `/` rather than collapsing to an empty entry (which would make the
+  derived prefix match anything), and no helper or temp var leaking into the
+  sourcing shell. For `EXCLUDES`: the private `rcm-excludes` file is actually
+  sourced from the configured path, comment and blank lines are filtered out
+  (including *indented* comments, so the filter's whitespace tolerance is
+  exercised), multiple patterns are joined onto one line, and an absent private
+  repo leaves the base excludes intact rather than blank. `EXCLUDES` is the half
+  that fails silently — its sourcing hides behind a `2>/dev/null`, so a drifted
+  path yields a well-formed `DOTFILES_DIRS` and no private patterns at all. `rcrc` is also now shellchecked (`--shell=sh`, since rcm sources it as
   POSIX shell), which it never was — `lint-shell` covered `bin/*` and the zsh
   files only. `SC2034` is excluded for that file alone, because setting
   variables for rcm to read is precisely its purpose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ grouped by **date** rather than by semantic version. Newest first.
   who set the override pointed that guard at a private repo `rcup` never merged.
   Documented in `README.md` → Custom checkout locations
   ([#215](https://github.com/tgautier/dotfiles/issues/215)).
+- `just lint-rcrc`, wired into `just ci` — pins how `rcrc` resolves
+  `DOTFILES_DIRS`: defaults with no override, each override alone and both
+  together, one *and* several trailing slashes stripped, a root value surviving
+  as `/` rather than collapsing to an empty entry (which would make the derived
+  prefix match anything), and no helper or temp var leaking into the sourcing
+  shell. `rcrc` is also now shellchecked (`--shell=sh`, since rcm sources it as
+  POSIX shell), which it never was — `lint-shell` covered `bin/*` and the zsh
+  files only. `SC2034` is excluded for that file alone, because setting
+  variables for rcm to read is precisely its purpose
+  ([#215](https://github.com/tgautier/dotfiles/issues/215)).
 - `just lint-cleanup-symlinks`, wired into `just ci` — fixture-tests the
   stale-symlink scanner, which previously had no coverage at all despite ending
   in `rm`. Covers both halves of the predicate, the trailing-slash case, an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ grouped by **date** rather than by semantic version. Newest first.
   exercised), multiple patterns are joined onto one line, and an absent private
   repo leaves the base excludes intact rather than blank. `EXCLUDES` is the half
   that fails silently — its sourcing hides behind a `2>/dev/null`, so a drifted
-  path yields a well-formed `DOTFILES_DIRS` and no private patterns at all. `rcrc` is also now shellchecked (`--shell=sh`, since rcm sources it as
+  path yields a well-formed `DOTFILES_DIRS` and no private patterns at all.
+  `rcrc` is also now shellchecked (`--shell=sh`, since rcm sources it as
   POSIX shell), which it never was — `lint-shell` covered `bin/*` and the zsh
   files only. `SC2034` is excluded for that file alone, because setting
   variables for rcm to read is precisely its purpose

--- a/Justfile
+++ b/Justfile
@@ -3,7 +3,61 @@
 zsh_excludes := "SC1036,SC1087,SC1090,SC2128,SC2145,SC2154,SC2155,SC2168,SC2179,SC2206,SC2211,SC2296"
 
 # Run all CI checks
-ci: lint-shell lint-markdown lint-brewfile lint-mise lint-just lint-cleanup-symlinks lint-via-private
+ci: lint-shell lint-markdown lint-brewfile lint-mise lint-just lint-rcrc lint-cleanup-symlinks lint-via-private
+
+# Assert `rcrc` resolves DOTFILES_DIRS the way README documents. This is the one
+# half of the override contract that reaches the operator's real $HOME through
+# rcm — a stray trailing slash becomes a doubled separator and rcm derives a
+# wrongly-named link from it — so the documented cases are pinned rather than
+# asserted. Sourcing rcrc is side-effect-free: it only assigns, and its one
+# external touch is a `2>/dev/null`-guarded grep.
+[doc("Check rcrc resolves DOTFILES_DIRS and normalises the override paths")]
+lint-rcrc:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    resolve() {
+        env -u DOTFILES_DIR -u DOTFILES_PRIVATE_DIR ${1:+"$@"} \
+            sh -c '. ./rcrc; printf "%s" "$DOTFILES_DIRS"'
+    }
+    expect() {
+        local label=$1 want=$2 got=$3
+        if [[ "$got" != "$want" ]]; then
+            echo "ERROR [$label]: want [$want] got [$got]" >&2
+            exit 1
+        fi
+    }
+
+    home_default="$HOME/Workspace/tgautier/dotfiles"
+    priv_default="$HOME/Workspace/tgautier/dotfiles-private"
+
+    expect "no override" \
+        "$home_default $priv_default" "$(resolve)"
+    expect "both overridden" \
+        "/tmp/pub /tmp/priv" "$(resolve DOTFILES_DIR=/tmp/pub DOTFILES_PRIVATE_DIR=/tmp/priv)"
+    expect "private only" \
+        "$home_default /tmp/priv" "$(resolve DOTFILES_PRIVATE_DIR=/tmp/priv)"
+    # One trailing slash, and several — `${VAR%/}` alone strips only one, which
+    # is why rcrc loops.
+    expect "single trailing slash" \
+        "/tmp/pub $priv_default" "$(resolve DOTFILES_DIR=/tmp/pub/)"
+    expect "multiple trailing slashes" \
+        "/tmp/pub $priv_default" "$(resolve DOTFILES_DIR=/tmp/pub///)"
+    # A root value must survive as `/`, never collapse to empty — an empty entry
+    # in DOTFILES_DIRS would make the derived prefix match anything.
+    expect "root value not emptied" \
+        "$home_default /" "$(resolve DOTFILES_PRIVATE_DIR=/)"
+
+    # The strip helper and its temp var must not leak into the sourcing shell.
+    leaked=$(sh -c '. ./rcrc; printf "%s" "${_v-unset}"')
+    if [[ "$leaked" != "unset" ]]; then
+        echo "ERROR: rcrc leaked \$_v into the sourcing shell as [$leaked]" >&2
+        exit 1
+    fi
+    if sh -c '. ./rcrc; command -v _rcrc_strip_slashes' >/dev/null 2>&1; then
+        echo "ERROR: rcrc left _rcrc_strip_slashes defined in the sourcing shell" >&2
+        exit 1
+    fi
+    echo "rcrc OK (defaults, both overrides, slash normalisation, root value, no leaks)"
 
 # Assert every in-body `just <recipe>` call names a recipe that exists here.
 # Those calls are opaque shell strings to just, so nothing else catches a typo:
@@ -260,6 +314,12 @@ _ensure-profile:
 # Lint shell scripts with ShellCheck
 lint-shell:
     shellcheck --severity=warning bin/op-ssh-sign bin/kshow bin/kseal
+    # rcrc is POSIX sh sourced by rcm — checked with --shell=sh, not the zsh
+    # group below, since it must stay portable to whatever shell rcm uses.
+    # SC2034 (appears unused) is excluded for this file ONLY: setting variables
+    # for rcm to read IS its purpose, so every assignment is consumed
+    # externally. Scoped to rcrc rather than added to the shared exclude list.
+    shellcheck --severity=warning --shell=sh --exclude=SC2034 rcrc
     shellcheck --severity=warning --shell=bash --exclude={{zsh_excludes}} zshenv zprofile zshrc zsh/zaliases zsh/zcompletion zsh/functions/*
 
 # Lint markdown files
@@ -561,9 +621,24 @@ lint-cleanup-symlinks:
         echo "$out" >&2; exit 1
     fi
     # The sweep half can't be driven against a fixture tree — it deliberately
-    # refuses CLEANUP_HOME so nothing can redirect its `rm`. But the line parsing
-    # that decides WHICH path gets removed is pure string work, so pin it here
-    # using the same expansion `cleanup-symlinks` applies.
+    # refuses CLEANUP_HOME so nothing can redirect its `rm`. So bind the
+    # assertion to `cleanup-symlinks`' ACTUAL body instead: the two behaviour
+    # cases below would otherwise only prove a fact about zsh expansion, leaving
+    # a weakened `%%` in the real recipe green. Same convention as `lint-just`'s
+    # `check()` — exercise the real logic, never a copy of it.
+    #
+    # Comment lines are stripped first so the match can't be satisfied by a
+    # comment that merely mentions the expansion.
+    body=$(just --dump --dump-format json \
+              | jq -r '.recipes["cleanup-symlinks"].body | flatten | .[]' \
+              | grep -vE '^[[:space:]]*#')
+    if ! grep -qF 'link="${entry%% ->*}"' <<<"$body"; then
+        echo "ERROR: cleanup-symlinks no longer extracts the link with \${entry%% ->*}." >&2
+        echo "       A single % strips the SHORTEST match, so a target containing ' -> '" >&2
+        echo "       would feed rm a path that does not exist. Update this lint only if" >&2
+        echo "       the replacement is equivalent." >&2
+        exit 1
+    fi
     extract() { local entry=$1; printf '%s' "${entry%% ->*}"; }
     got=$(extract "$fake_home/.zshrc -> $override/zshrc")
     if [[ "$got" != "$fake_home/.zshrc" ]]; then

--- a/Justfile
+++ b/Justfile
@@ -79,16 +79,25 @@ lint-rcrc:
     # comment/blank-line filter together.
     tmp=$(mktemp -d)
     trap 'rm -rf "$tmp"' EXIT
-    # All four parts of rcrc's `grep -hvE '^[[:space:]]*(#|$)' | tr '\n' ' '` are
-    # pinned, but by DIFFERENT assertions — don't delete either one believing the
-    # other covers it:
+    # The regex's two alternatives, its `[[:space:]]*` tolerance and the `tr` join
+    # are each pinned, but by DIFFERENT assertions — don't delete either one
+    # believing the other covers it:
     #
     #   fixture ingredient      pins                caught by
     #   ----------------------  ------------------  ---------------------------
     #   two patterns            the `tr` join       expect_has (joined needle)
     #   blank line, mid-list    the `$` alternative expect_has (joined needle)
-    #   column-0 comment        the `#` alternative expect_lacks "comment"
     #   indented comment        `[[:space:]]*`      expect_lacks "comment"
+    #                           and the `#` alt.
+    #   column-0 comment        nothing on its own  — belt and braces; the
+    #                                                 indented line already
+    #                                                 pins both
+    #
+    # Boundary, so the table isn't read as totality over the whole pipeline:
+    # `-v` is pinned incidentally (drop it and BOTH assertions fire, since only
+    # the comment and blank lines survive). `-h` is NOT pinned and structurally
+    # cannot be here — grep only prefixes filenames for multiple inputs or `-H`,
+    # and rcrc passes exactly one file, so dropping it changes nothing observable.
     #
     # The blank line sits BETWEEN the patterns on purpose: a leaked blank then
     # breaks the contiguity of "sentinel-pattern second-pattern". Before the first

--- a/Justfile
+++ b/Justfile
@@ -19,10 +19,14 @@ lint-rcrc:
     # One place that sources rcrc under a clean environment. `var` picks which
     # resolved variable to read, so the DOTFILES_DIRS and EXCLUDES cases share
     # this rather than each hand-rolling its own `env -u … sh -c`.
+    #
+    # The `-u` pair is a clean-slate default, not a contradiction with a caller's
+    # `NAME=value` operand: env processes options before operands, so an operand
+    # deliberately re-supplies what `-u` cleared.
     read_var() {
         local var=$1; shift
         env -u DOTFILES_DIR -u DOTFILES_PRIVATE_DIR ${1:+"$@"} \
-            sh -c '. ./rcrc; eval printf "%s" "\"\$$0\""' "$var"
+            sh -c 'set -e; . ./rcrc; eval "printf %s \"\${$1}\""' sh "$var"
     }
     resolve() { read_var DOTFILES_DIRS ${1:+"$@"}; }
     expect() {
@@ -75,12 +79,20 @@ lint-rcrc:
     # comment/blank-line filter together.
     tmp=$(mktemp -d)
     trap 'rm -rf "$tmp"' EXIT
-    # Two patterns, so the `tr '\n' ' '` join is exercised (with one, an
-    # unjoined embedded newline would still substring-match). An INDENTED comment
-    # alongside the column-0 one, so the filter's `[[:space:]]*` tolerance is
-    # exercised too — without it an indented comment leaks in as two bogus
-    # exclude patterns.
-    printf '# a comment line\n\t  # indented comment\n\nsentinel-pattern\nsecond-pattern\n' \
+    # Every part of rcrc's `grep -hvE '^[[:space:]]*(#|$)' | tr '\n' ' '` is
+    # exercised by the single joined needle asserted below:
+    #   - two patterns          -> pins the `tr` join (with one, an unjoined
+    #                              embedded newline would still substring-match)
+    #   - an INDENTED comment   -> pins the `[[:space:]]*` tolerance; without it
+    #                              the line survives and contributes its words as
+    #                              exclude patterns
+    #   - a blank line BETWEEN  -> pins the `$` alternative. Placed between the
+    #     the two patterns          patterns on purpose: a leaked blank breaks the
+    #                              contiguity of "sentinel-pattern second-pattern",
+    #                              so the existing assertion catches it. Before
+    #                              the first pattern it would only add a space
+    #                              outside the needle and slip through.
+    printf '# a comment line\n\t  # indented comment\nsentinel-pattern\n\nsecond-pattern\n' \
         > "$tmp/rcm-excludes"
     excludes=$(read_var EXCLUDES DOTFILES_PRIVATE_DIR="$tmp")
     expect_has   "EXCLUDES sources the private file" "sentinel-pattern second-pattern" "$excludes"

--- a/Justfile
+++ b/Justfile
@@ -47,6 +47,35 @@ lint-rcrc:
     expect "root value not emptied" \
         "$home_default /" "$(resolve DOTFILES_PRIVATE_DIR=/)"
 
+    # EXCLUDES is the other half of the contract, and the one rcrc's own header
+    # names as the silent-failure path: if PRIVATE_DIR drifts, the exclude
+    # sourcing no-ops behind `2>/dev/null` and rcup resumes hanging on the
+    # excluded directory — a well-formed DOTFILES_DIRS with an EXCLUDES quietly
+    # missing every private pattern. Pin the path derivation and the
+    # comment/blank-line filter together.
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    printf '# a comment line\n\nsentinel-pattern\n' > "$tmp/rcm-excludes"
+    excludes=$(env -u DOTFILES_DIR DOTFILES_PRIVATE_DIR="$tmp" \
+                   sh -c '. ./rcrc; printf "%s" "$EXCLUDES"')
+    if [[ "$excludes" != *sentinel-pattern* ]]; then
+        echo "ERROR: EXCLUDES did not pick up the private rcm-excludes file" >&2
+        echo "       got [$excludes]" >&2
+        exit 1
+    fi
+    if [[ "$excludes" == *comment* ]]; then
+        echo "ERROR: EXCLUDES kept a comment line from rcm-excludes" >&2
+        echo "       got [$excludes]" >&2
+        exit 1
+    fi
+    # An absent private repo must leave the base excludes intact, not blank.
+    excludes=$(env -u DOTFILES_DIR DOTFILES_PRIVATE_DIR="$tmp/nope" \
+                   sh -c '. ./rcrc; printf "%s" "$EXCLUDES"')
+    if [[ "$excludes" != *CHANGELOG.md* ]]; then
+        echo "ERROR: an absent private repo emptied the base EXCLUDES: [$excludes]" >&2
+        exit 1
+    fi
+
     # The strip helper and its temp var must not leak into the sourcing shell.
     leaked=$(sh -c '. ./rcrc; printf "%s" "${_v-unset}"')
     if [[ "$leaked" != "unset" ]]; then
@@ -57,7 +86,7 @@ lint-rcrc:
         echo "ERROR: rcrc left _rcrc_strip_slashes defined in the sourcing shell" >&2
         exit 1
     fi
-    echo "rcrc OK (defaults, both overrides, slash normalisation, root value, no leaks)"
+    echo "rcrc OK (defaults, both overrides, slash normalisation, root value, EXCLUDES sourcing, no leaks)"
 
 # Assert every in-body `just <recipe>` call names a recipe that exists here.
 # Those calls are opaque shell strings to just, so nothing else catches a typo:
@@ -311,14 +340,18 @@ _ensure-profile:
     read -r reply
     just set-profile "${reply:-work}"
 
-# Lint shell scripts with ShellCheck
+# Lint shell scripts with ShellCheck.
+#
+# Rationale lives here rather than in the body: this is a LINEWISE recipe, so
+# every indented line — comments included — is echoed and handed to a shell.
+#
+# `rcrc` is checked with --shell=sh, not in the zsh group below, because rcm
+# sources it and it must stay portable to whatever shell rcm uses. SC2034
+# (appears unused) is excluded for that file ONLY: setting variables for rcm to
+# read IS its purpose, so every assignment is consumed externally. Scoped to the
+# file rather than added to the shared zsh_excludes list.
 lint-shell:
     shellcheck --severity=warning bin/op-ssh-sign bin/kshow bin/kseal
-    # rcrc is POSIX sh sourced by rcm — checked with --shell=sh, not the zsh
-    # group below, since it must stay portable to whatever shell rcm uses.
-    # SC2034 (appears unused) is excluded for this file ONLY: setting variables
-    # for rcm to read IS its purpose, so every assignment is consumed
-    # externally. Scoped to rcrc rather than added to the shared exclude list.
     shellcheck --severity=warning --shell=sh --exclude=SC2034 rcrc
     shellcheck --severity=warning --shell=bash --exclude={{zsh_excludes}} zshenv zprofile zshrc zsh/zaliases zsh/zcompletion zsh/functions/*
 
@@ -438,9 +471,9 @@ dotfiles_dir := parent_directory(canonicalize(justfile()))
 # together; previously it moved only this one, so an operator who set it pointed
 # the keyword guard at a private repo `rcup` never merged.
 #
-# The two defaults below are duplicated in `rcrc` on purpose — it is shell
-# sourced by rcm, these are justfile-load-time variables, and neither can read
-# the other's without a fragile bridge. Change one, change both.
+# The two defaults below live in three places on purpose — here, `rcrc`, and
+# `lint-rcrc`'s expected values (which run under `env -u`, so they cannot
+# inherit these). Change one, change all three; see the note in `rcrc`.
 public_dir := env("DOTFILES_DIR", env("HOME") / "Workspace/tgautier/dotfiles")
 private_dir := env("DOTFILES_PRIVATE_DIR", env("HOME") / "Workspace/tgautier/dotfiles-private")
 private_justfile := private_dir / "justfile"

--- a/Justfile
+++ b/Justfile
@@ -3,7 +3,7 @@
 zsh_excludes := "SC1036,SC1087,SC1090,SC2128,SC2145,SC2154,SC2155,SC2168,SC2179,SC2206,SC2211,SC2296"
 
 # Run all CI checks
-ci: lint-shell lint-markdown lint-brewfile lint-mise lint-just lint-via-private
+ci: lint-shell lint-markdown lint-brewfile lint-mise lint-just lint-cleanup-symlinks lint-via-private
 
 # Assert every in-body `just <recipe>` call names a recipe that exists here.
 # Those calls are opaque shell strings to just, so nothing else catches a typo:
@@ -367,20 +367,21 @@ update: update-brew update-mas update-mise update-rust
 # Resolve through symlink so this works when just finds ~/.justfile
 dotfiles_dir := parent_directory(canonicalize(justfile()))
 
-# Private companion repo, for `lint-via-private`. Anchored to $HOME rather than
-# derived from dotfiles_dir on purpose: inside a nested worktree dotfiles_dir is
-# .claude/worktrees/<name>, whose sibling is not the private repo, so a
-# sibling-derived path would silently skip the guard exactly when working on a
-# branch. Override per machine with DOTFILES_PRIVATE_DIR.
+# Companion repo paths. Anchored to $HOME rather than derived from dotfiles_dir
+# on purpose: inside a nested worktree dotfiles_dir is .claude/worktrees/<name>,
+# whose sibling is not the private repo, so a sibling-derived path would
+# silently skip the keyword guard exactly when working on a branch.
 #
-# Scope: `lint-via-private` only — see #215 before widening it. `rcrc` and
-# `cleanup-symlinks` still hardcode the paths, for two unrelated reasons:
-#   - `rcrc` is a one-liner. rcm sources it as shell, so it can read the env var
-#     directly. It is unwired only to keep #214 scoped, so until then setting the
-#     override points the keyword guard at a private repo `rcup` never merges.
-#   - `cleanup-symlinks` is the hard one: rcm records absolute symlink targets, so
-#     links into a *former* checkout path must keep matching, and a prefix built
-#     from the current paths cannot see them.
+# DOTFILES_DIR / DOTFILES_PRIVATE_DIR are the shared contract across all three
+# consumers — `lint-via-private` here, `DOTFILES_DIRS` + `EXCLUDES` in `rcrc`,
+# and the repo list in `_scan-stale-symlinks`. Setting one moves all three
+# together; previously it moved only this one, so an operator who set it pointed
+# the keyword guard at a private repo `rcup` never merged.
+#
+# The two defaults below are duplicated in `rcrc` on purpose — it is shell
+# sourced by rcm, these are justfile-load-time variables, and neither can read
+# the other's without a fragile bridge. Change one, change both.
+public_dir := env("DOTFILES_DIR", env("HOME") / "Workspace/tgautier/dotfiles")
 private_dir := env("DOTFILES_PRIVATE_DIR", env("HOME") / "Workspace/tgautier/dotfiles-private")
 private_justfile := private_dir / "justfile"
 
@@ -490,28 +491,145 @@ set-default-editor:
     echo "Word (.doc/.docx), Pages (.pages), and web content (.html/.svg)"
     echo "intentionally left untouched so the browser keeps http/https links."
 
-# Remove stale symlinks in $HOME that point into dotfiles dirs
-cleanup-symlinks:
+# Exercise `_scan-stale-symlinks` against a fixture tree. The recipe it tests
+# ends in `rm` (via `cleanup-symlinks`), so both halves of the union predicate
+# and — critically — the SURVIVAL case get pinned: a broken symlink that points
+# nowhere near a dotfiles checkout must NOT be reported. A deletion test without
+# a survival case only proves the sweeper deletes something.
+#
+# Each case re-invokes `just` as a subprocess because public_dir/private_dir are
+# `env()` variables resolved at justfile load, so varying them requires a fresh
+# process rather than an in-recipe assignment.
+[doc("Test the stale-symlink scanner against fixtures (positive and negative)")]
+lint-cleanup-symlinks:
     #!/usr/bin/env zsh
-    # Derive nested dirs from the dotfiles repos themselves
-    dotfiles_repos=("$HOME/Workspace/tgautier/dotfiles" "$HOME/Workspace/tgautier/dotfiles-private")
+    set -eu
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    fake_home="$tmp/home"
+    # An override whose basename is deliberately NOT `dotfiles*`, which is the
+    # case the segment predicate alone cannot see.
+    override="$tmp/dots-private"
+    mkdir -p "$fake_home" "$override" "$tmp/public"
+
+    # 1. broken link into the override checkout -> prefix predicate must fire
+    ln -s "$override/zshrc" "$fake_home/.zshrc"
+    # 2. broken link into a FORMER checkout path -> segment predicate must fire.
+    #    Nothing configured points here; only `*/dotfiles/*` matches it.
+    ln -s "$tmp/former/checkout/dotfiles/gitconfig" "$fake_home/.gitconfig"
+    # 3. an unrelated broken link -> must SURVIVE (the boundary case)
+    ln -s "$tmp/somewhere-else/thing" "$fake_home/.unrelated"
+
+    scan() {
+        DOTFILES_DIR="$tmp/public" DOTFILES_PRIVATE_DIR="$1" \
+            CLEANUP_HOME="$fake_home" just _scan-stale-symlinks
+    }
+
+    assert_scan() {
+        local label=$1 out=$2
+        if ! grep -q '/.zshrc ->' <<<"$out"; then
+            echo "ERROR [$label]: prefix predicate missed a link into a non-dotfiles-named override" >&2
+            echo "$out" >&2; exit 1
+        fi
+        if ! grep -q '/.gitconfig ->' <<<"$out"; then
+            echo "ERROR [$label]: segment predicate missed a link into a former checkout path" >&2
+            echo "$out" >&2; exit 1
+        fi
+        if grep -q '/.unrelated ->' <<<"$out"; then
+            echo "ERROR [$label]: swept an unrelated broken symlink — the survival case failed" >&2
+            echo "$out" >&2; exit 1
+        fi
+    }
+
+    assert_scan "plain override" "$(scan "$override")"
+    # Shell completion appends a trailing slash routinely; `:a` must absorb it,
+    # or the derived prefix becomes `…//*` and matches no single-slash target.
+    assert_scan "trailing-slash override" "$(scan "$override/")"
+
+    # An absent configured dir must be a no-op, not fatal — `rcrc` already
+    # treats a missing private repo that way. Dropping `(N)` from the repos glob
+    # makes zsh abort the scan with "no matches found" instead, which this case
+    # catches: the scan must still run, still fire the segment predicate, and
+    # still spare the unrelated link.
+    out=$(scan "$tmp/nonexistent-private")
+    if ! grep -q '/.gitconfig ->' <<<"$out"; then
+        echo "ERROR: an absent configured dir broke the scan or the segment predicate" >&2
+        echo "$out" >&2; exit 1
+    fi
+    if grep -q '/.unrelated ->' <<<"$out"; then
+        echo "ERROR: an absent configured dir widened the predicate past the survival case" >&2
+        echo "$out" >&2; exit 1
+    fi
+    echo "cleanup-symlinks scanner OK (union predicate, trailing slash, absent dir, survival case)"
+
+# Print every stale symlink (broken, and pointing into a dotfiles checkout) as
+# a `link -> target` line. No removal — `cleanup-symlinks` owns that, so this
+# recipe is safe to drive from the fixtures in `lint-cleanup-symlinks`.
+#
+# CLEANUP_HOME overrides the tree to scan (default $HOME). It is honoured HERE
+# ONLY, never by `cleanup-symlinks`: a stray export must not be able to redirect
+# an `rm` into an unexpected tree.
+#
+# The predicate is a UNION of two matches, because neither subsumes the other:
+#
+#   1. Basename-segment match on the literal `dotfiles` / `dotfiles-private`
+#      path components. rcm records ABSOLUTE targets, so after a checkout is
+#      moved or renamed the leftover links still name the OLD path — which is
+#      the main thing a stale sweeper is for. A prefix built from the CURRENT
+#      paths cannot see those, and setting the override to the new location
+#      does not help, because the stale targets name the old one.
+#   2. Prefix match against the configured dirs, which is what catches a
+#      checkout whose basename is not `dotfiles*` at all (DOTFILES_PRIVATE_DIR
+#      pointed at e.g. ~/dev/dots-private).
+#
+# #214 replaced (1) with (2) and lost the moved-checkout case; this keeps both.
+_scan-stale-symlinks:
+    #!/usr/bin/env zsh
+    set -u
+    scan_home="${CLEANUP_HOME:-$HOME}"
+
+    # `:a` absolutises and cleans, so a trailing slash (shell completion adds
+    # one routinely), a doubled slash, or a `..` segment can't produce a prefix
+    # that matches nothing while glob-based discovery still succeeds. NOT `:A`,
+    # which also resolves symlinks: rcm recorded whatever DOTFILES_DIRS said, so
+    # resolving could stop matching the targets actually on disk.
+    repos=("{{ public_dir }}"(N:a) "{{ private_dir }}"(N:a))
+    # (N) above drops a configured dir that doesn't exist on this machine, so an
+    # absent private repo contributes no prefix. Without it zsh aborts the whole
+    # scan with "no matches found" (verified), making an absent private repo
+    # fatal rather than the no-op `rcrc` already treats it as.
+
+    # Discovery of nested link dirs needs the repos to exist; the prefix
+    # predicate does not. Keep them independent so a moved checkout is still
+    # swept even when no configured dir is present.
     nested=()
-    for repo in "${dotfiles_repos[@]}"; do
-        [[ -d "$repo" ]] || continue
+    for repo in "${repos[@]}"; do
         for d in "$repo"/*(N/); do
             name=${d:t}
             # Skip repo-only dirs that rcm doesn't symlink
             [[ "$name" == .* || "$name" == README* || "$name" == CLAUDE* ]] && continue
-            candidate="$HOME/.$name"
+            candidate="$scan_home/.$name"
             [[ -d "$candidate" ]] && nested+=("$candidate")
         done
     done
+
+    is_stale() {
+        local target=$1 repo
+        # (1) former-or-current checkout, matched by path segment
+        [[ "$target" == */dotfiles/* || "$target" == */dotfiles-private/* ]] && return 0
+        # (2) configured checkout under any basename
+        for repo in "${repos[@]}"; do
+            [[ "$target" == "$repo"/* ]] && return 0
+        done
+        return 1
+    }
+
     stale=()
     # Top-level dotfiles (non-recursive)
-    for f in $HOME/.[!.]*(N@); do
+    for f in $scan_home/.[^.]*(N@); do
         [[ -e "$f" ]] && continue
         target=$(readlink "$f")
-        [[ "$target" == *"/dotfiles/"* || "$target" == *"/dotfiles-private/"* ]] && stale+=("$f -> $target")
+        is_stale "$target" && stale+=("$f -> $target")
     done
     # Nested dirs (recursive)
     for dir in "${nested[@]}"; do
@@ -519,9 +637,30 @@ cleanup-symlinks:
         for f in "$dir"/**/*(N@); do
             [[ -e "$f" ]] && continue
             target=$(readlink "$f")
-            [[ "$target" == *"/dotfiles/"* || "$target" == *"/dotfiles-private/"* ]] && stale+=("$f -> $target")
+            is_stale "$target" && stale+=("$f -> $target")
         done
     done
+    (( ${#stale} == 0 )) && exit 0
+    printf '%s\n' "${stale[@]}"
+
+# Remove stale symlinks in $HOME that point into dotfiles dirs
+[doc("Remove stale $HOME symlinks pointing into a dotfiles checkout")]
+cleanup-symlinks:
+    #!/usr/bin/env zsh
+    set -u
+    # Always the real $HOME: CLEANUP_HOME is deliberately not forwarded, so no
+    # environment setting can point this recipe's `rm` at another tree.
+    #
+    # Check the scan's status explicitly. A bare `stale=("${(@f)$(scan)}")` would
+    # turn a failed scan into empty output and then report "No stale symlinks
+    # found" — announcing a clean tree on the strength of a crash.
+    if ! out=$(CLEANUP_HOME= just _scan-stale-symlinks); then
+        echo "cleanup-symlinks: the stale-symlink scan failed; nothing removed." >&2
+        exit 1
+    fi
+    stale=("${(@f)out}")
+    # A single empty element is what $(…) yields for no output; treat as none.
+    [[ ${#stale} -eq 1 && -z "${stale[1]}" ]] && stale=()
     if (( ${#stale} == 0 )); then
         echo "No stale symlinks found."
         exit 0

--- a/Justfile
+++ b/Justfile
@@ -5,24 +5,44 @@ zsh_excludes := "SC1036,SC1087,SC1090,SC2128,SC2145,SC2154,SC2155,SC2168,SC2179,
 # Run all CI checks
 ci: lint-shell lint-markdown lint-brewfile lint-mise lint-just lint-rcrc lint-cleanup-symlinks lint-via-private
 
-# Assert `rcrc` resolves DOTFILES_DIRS the way README documents. This is the one
-# half of the override contract that reaches the operator's real $HOME through
-# rcm — a stray trailing slash becomes a doubled separator and rcm derives a
-# wrongly-named link from it — so the documented cases are pinned rather than
-# asserted. Sourcing rcrc is side-effect-free: it only assigns, and its one
-# external touch is a `2>/dev/null`-guarded grep.
-[doc("Check rcrc resolves DOTFILES_DIRS and normalises the override paths")]
+# Assert `rcrc` resolves the way README documents, on both halves of the
+# override contract: DOTFILES_DIRS, which reaches the operator's real $HOME
+# through rcm (a stray trailing slash becomes a doubled separator and rcm derives
+# a wrongly-named link from it), and EXCLUDES, whose private sourcing fails
+# silently behind a `2>/dev/null` when PRIVATE_DIR drifts. Both are pinned rather
+# than asserted. Sourcing rcrc is side-effect-free: it only assigns, and its one
+# external touch is that guarded grep.
+[doc("Check rcrc resolves DOTFILES_DIRS + EXCLUDES and normalises the paths")]
 lint-rcrc:
     #!/usr/bin/env bash
     set -euo pipefail
-    resolve() {
+    # One place that sources rcrc under a clean environment. `var` picks which
+    # resolved variable to read, so the DOTFILES_DIRS and EXCLUDES cases share
+    # this rather than each hand-rolling its own `env -u … sh -c`.
+    read_var() {
+        local var=$1; shift
         env -u DOTFILES_DIR -u DOTFILES_PRIVATE_DIR ${1:+"$@"} \
-            sh -c '. ./rcrc; printf "%s" "$DOTFILES_DIRS"'
+            sh -c '. ./rcrc; eval printf "%s" "\"\$$0\""' "$var"
     }
+    resolve() { read_var DOTFILES_DIRS ${1:+"$@"}; }
     expect() {
         local label=$1 want=$2 got=$3
         if [[ "$got" != "$want" ]]; then
             echo "ERROR [$label]: want [$want] got [$got]" >&2
+            exit 1
+        fi
+    }
+    expect_has() {
+        local label=$1 needle=$2 got=$3
+        if [[ "$got" != *"$needle"* ]]; then
+            echo "ERROR [$label]: expected to contain [$needle], got [$got]" >&2
+            exit 1
+        fi
+    }
+    expect_lacks() {
+        local label=$1 needle=$2 got=$3
+        if [[ "$got" == *"$needle"* ]]; then
+            echo "ERROR [$label]: expected NOT to contain [$needle], got [$got]" >&2
             exit 1
         fi
     }
@@ -55,26 +75,19 @@ lint-rcrc:
     # comment/blank-line filter together.
     tmp=$(mktemp -d)
     trap 'rm -rf "$tmp"' EXIT
-    printf '# a comment line\n\nsentinel-pattern\n' > "$tmp/rcm-excludes"
-    excludes=$(env -u DOTFILES_DIR DOTFILES_PRIVATE_DIR="$tmp" \
-                   sh -c '. ./rcrc; printf "%s" "$EXCLUDES"')
-    if [[ "$excludes" != *sentinel-pattern* ]]; then
-        echo "ERROR: EXCLUDES did not pick up the private rcm-excludes file" >&2
-        echo "       got [$excludes]" >&2
-        exit 1
-    fi
-    if [[ "$excludes" == *comment* ]]; then
-        echo "ERROR: EXCLUDES kept a comment line from rcm-excludes" >&2
-        echo "       got [$excludes]" >&2
-        exit 1
-    fi
+    # Two patterns, so the `tr '\n' ' '` join is exercised (with one, an
+    # unjoined embedded newline would still substring-match). An INDENTED comment
+    # alongside the column-0 one, so the filter's `[[:space:]]*` tolerance is
+    # exercised too — without it an indented comment leaks in as two bogus
+    # exclude patterns.
+    printf '# a comment line\n\t  # indented comment\n\nsentinel-pattern\nsecond-pattern\n' \
+        > "$tmp/rcm-excludes"
+    excludes=$(read_var EXCLUDES DOTFILES_PRIVATE_DIR="$tmp")
+    expect_has   "EXCLUDES sources the private file" "sentinel-pattern second-pattern" "$excludes"
+    expect_lacks "EXCLUDES drops comment lines"      "comment"                         "$excludes"
     # An absent private repo must leave the base excludes intact, not blank.
-    excludes=$(env -u DOTFILES_DIR DOTFILES_PRIVATE_DIR="$tmp/nope" \
-                   sh -c '. ./rcrc; printf "%s" "$EXCLUDES"')
-    if [[ "$excludes" != *CHANGELOG.md* ]]; then
-        echo "ERROR: an absent private repo emptied the base EXCLUDES: [$excludes]" >&2
-        exit 1
-    fi
+    excludes=$(read_var EXCLUDES DOTFILES_PRIVATE_DIR="$tmp/nope")
+    expect_has   "absent private repo keeps base EXCLUDES" "CHANGELOG.md" "$excludes"
 
     # The strip helper and its temp var must not leak into the sourcing shell.
     leaked=$(sh -c '. ./rcrc; printf "%s" "${_v-unset}"')
@@ -350,6 +363,7 @@ _ensure-profile:
 # (appears unused) is excluded for that file ONLY: setting variables for rcm to
 # read IS its purpose, so every assignment is consumed externally. Scoped to the
 # file rather than added to the shared zsh_excludes list.
+[doc("Lint shell scripts with ShellCheck")]
 lint-shell:
     shellcheck --severity=warning bin/op-ssh-sign bin/kshow bin/kseal
     shellcheck --severity=warning --shell=sh --exclude=SC2034 rcrc
@@ -707,6 +721,7 @@ lint-cleanup-symlinks:
 #      pointed at e.g. ~/dev/dots-private).
 #
 # #214 replaced (1) with (2) and lost the moved-checkout case; this keeps both.
+[doc("Print stale $HOME symlinks pointing into a dotfiles checkout (no removal)")]
 _scan-stale-symlinks:
     #!/usr/bin/env zsh
     set -u

--- a/Justfile
+++ b/Justfile
@@ -560,7 +560,23 @@ lint-cleanup-symlinks:
         echo "ERROR: an absent configured dir widened the predicate past the survival case" >&2
         echo "$out" >&2; exit 1
     fi
-    echo "cleanup-symlinks scanner OK (union predicate, trailing slash, absent dir, survival case)"
+    # The sweep half can't be driven against a fixture tree — it deliberately
+    # refuses CLEANUP_HOME so nothing can redirect its `rm`. But the line parsing
+    # that decides WHICH path gets removed is pure string work, so pin it here
+    # using the same expansion `cleanup-symlinks` applies.
+    extract() { local entry=$1; printf '%s' "${entry%% ->*}"; }
+    got=$(extract "$fake_home/.zshrc -> $override/zshrc")
+    if [[ "$got" != "$fake_home/.zshrc" ]]; then
+        echo "ERROR: link extraction returned '$got'" >&2; exit 1
+    fi
+    # A target may itself contain ' -> ' (a link to a link's printed form).
+    # `%%` strips the LONGEST match, so the link must survive intact; `%` would
+    # have kept part of the target and fed `rm` a path that does not exist.
+    got=$(extract "$fake_home/.zshrc -> $override/a -> b")
+    if [[ "$got" != "$fake_home/.zshrc" ]]; then
+        echo "ERROR: link extraction broke on a target containing ' -> ': '$got'" >&2; exit 1
+    fi
+    echo "cleanup-symlinks scanner OK (union predicate, trailing slash, absent dir, survival case, link parsing)"
 
 # Print every stale symlink (broken, and pointing into a dotfiles checkout) as
 # a `link -> target` line. No removal — `cleanup-symlinks` owns that, so this
@@ -593,7 +609,11 @@ _scan-stale-symlinks:
     # that matches nothing while glob-based discovery still succeeds. NOT `:A`,
     # which also resolves symlinks: rcm recorded whatever DOTFILES_DIRS said, so
     # resolving could stop matching the targets actually on disk.
-    repos=("{{ public_dir }}"(N:a) "{{ private_dir }}"(N:a))
+    # quote() not "…": double quotes protect spaces but not `$`, backtick or
+    # backslash, and this value gates an `rm`. Matches the convention already
+    # used for private_justfile and set-profile's argument. A glob qualifier
+    # after a single-quoted word is valid zsh.
+    repos=({{ quote(public_dir) }}(N:a) {{ quote(private_dir) }}(N:a))
     # (N) above drops a configured dir that doesn't exist on this machine, so an
     # absent private repo contributes no prefix. Without it zsh aborts the whole
     # scan with "no matches found" (verified), making an absent private repo

--- a/Justfile
+++ b/Justfile
@@ -79,19 +79,22 @@ lint-rcrc:
     # comment/blank-line filter together.
     tmp=$(mktemp -d)
     trap 'rm -rf "$tmp"' EXIT
-    # Every part of rcrc's `grep -hvE '^[[:space:]]*(#|$)' | tr '\n' ' '` is
-    # exercised by the single joined needle asserted below:
-    #   - two patterns          -> pins the `tr` join (with one, an unjoined
-    #                              embedded newline would still substring-match)
-    #   - an INDENTED comment   -> pins the `[[:space:]]*` tolerance; without it
-    #                              the line survives and contributes its words as
-    #                              exclude patterns
-    #   - a blank line BETWEEN  -> pins the `$` alternative. Placed between the
-    #     the two patterns          patterns on purpose: a leaked blank breaks the
-    #                              contiguity of "sentinel-pattern second-pattern",
-    #                              so the existing assertion catches it. Before
-    #                              the first pattern it would only add a space
-    #                              outside the needle and slip through.
+    # All four parts of rcrc's `grep -hvE '^[[:space:]]*(#|$)' | tr '\n' ' '` are
+    # pinned, but by DIFFERENT assertions — don't delete either one believing the
+    # other covers it:
+    #
+    #   fixture ingredient      pins                caught by
+    #   ----------------------  ------------------  ---------------------------
+    #   two patterns            the `tr` join       expect_has (joined needle)
+    #   blank line, mid-list    the `$` alternative expect_has (joined needle)
+    #   column-0 comment        the `#` alternative expect_lacks "comment"
+    #   indented comment        `[[:space:]]*`      expect_lacks "comment"
+    #
+    # The blank line sits BETWEEN the patterns on purpose: a leaked blank then
+    # breaks the contiguity of "sentinel-pattern second-pattern". Before the first
+    # pattern it would only add a space outside the needle and slip through.
+    # A leaked comment, by contrast, survives as leading tokens that don't break
+    # that contiguity, which is why it needs expect_lacks rather than the needle.
     printf '# a comment line\n\t  # indented comment\nsentinel-pattern\n\nsecond-pattern\n' \
         > "$tmp/rcm-excludes"
     excludes=$(read_var EXCLUDES DOTFILES_PRIVATE_DIR="$tmp")

--- a/README.md
+++ b/README.md
@@ -192,6 +192,11 @@ The `cd` matters: `~/.justfile` is a symlink to the private repo's justfile, so
 `just setup` also re-links, but it is the whole bootstrap — `just link` is the
 one step.
 
+Prefer it over a bare `rcup`. This repo's `rcrc` lives in-tree, and the recipe
+passes `RCRC=` explicitly, so it works on any machine — including one that has
+never been bootstrapped. A bare `rcup` reads the same config only *after* the
+first bootstrap, because `~/.rcrc` is itself one of the symlinks rcm creates.
+
 ### Custom checkout locations
 
 Both repos default to `~/Workspace/tgautier/`. Override per machine with two
@@ -205,12 +210,8 @@ consumer moves together:
 
 Export them before `just link` / `just setup` so `rcrc` sees them — rcm sources
 `rcrc` as shell, which is what lets it read the environment at all. A trailing
-slash is fine. An absent private repo is skipped, not fatal.
-
-Prefer it over a bare `rcup`. This repo's `rcrc` lives in-tree, and the recipe
-passes `RCRC=` explicitly, so it works on any machine — including one that has
-never been bootstrapped. A bare `rcup` reads the same config only *after* the
-first bootstrap, because `~/.rcrc` is itself one of the symlinks rcm creates.
+slash is fine: `rcrc` strips it and the scanner normalises with zsh's `:a`. An
+absent private repo is skipped, not fatal.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Individual targets:
 
 | Target                         | Description                                    |
 | ------------------------------ | ---------------------------------------------- |
-| `just lint-shell`              | ShellCheck on `bin/*` and zsh files            |
+| `just lint-shell`              | ShellCheck on `bin/*`, `rcrc`, and zsh files   |
 | `just lint-markdown`           | markdownlint-cli2                              |
 | `just lint-brewfile`           | Ruby syntax check on Brewfiles                 |
 | `just lint-mise`               | Validate mise config                           |

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ Individual targets:
 | `just lint-brewfile`           | Ruby syntax check on Brewfiles                 |
 | `just lint-mise`               | Validate mise config                           |
 | `just lint-just`               | Check in-body `just <recipe>` calls resolve    |
+| `just lint-rcrc`               | Check `rcrc` resolves + normalises the paths   |
 | `just lint-cleanup-symlinks`   | Fixture-test the stale-symlink scanner         |
 | `just lint-via-private`        | Keyword guard, delegated to the private repo   |
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,21 @@ The `cd` matters: `~/.justfile` is a symlink to the private repo's justfile, so
 `just setup` also re-links, but it is the whole bootstrap — `just link` is the
 one step.
 
+### Custom checkout locations
+
+Both repos default to `~/Workspace/tgautier/`. Override per machine with two
+environment variables, which are a single shared contract — set one and every
+consumer moves together:
+
+| Variable | Default | Used by |
+| --- | --- | --- |
+| `DOTFILES_DIR` | `~/Workspace/tgautier/dotfiles` | `DOTFILES_DIRS` in `rcrc`, the stale-symlink scanner |
+| `DOTFILES_PRIVATE_DIR` | `~/Workspace/tgautier/dotfiles-private` | the above, plus `EXCLUDES` in `rcrc` and `just lint-via-private` |
+
+Export them before `just link` / `just setup` so `rcrc` sees them — rcm sources
+`rcrc` as shell, which is what lets it read the environment at all. A trailing
+slash is fine. An absent private repo is skipped, not fatal.
+
 Prefer it over a bare `rcup`. This repo's `rcrc` lives in-tree, and the recipe
 passes `RCRC=` explicitly, so it works on any machine — including one that has
 never been bootstrapped. A bare `rcup` reads the same config only *after* the
@@ -253,14 +268,15 @@ just ci
 
 Individual targets:
 
-| Target                  | Description                                          |
-| ----------------------- | ---------------------------------------------------- |
-| `just lint-shell`       | ShellCheck on `bin/*` and zsh files                  |
-| `just lint-markdown`    | markdownlint-cli2                                    |
-| `just lint-brewfile`    | Ruby syntax check on Brewfiles                       |
-| `just lint-mise`        | Validate mise config                                 |
-| `just lint-just`        | Check in-body `just <recipe>` calls resolve          |
-| `just lint-via-private` | Keyword guard, delegated to the private repo         |
+| Target                         | Description                                    |
+| ------------------------------ | ---------------------------------------------- |
+| `just lint-shell`              | ShellCheck on `bin/*` and zsh files            |
+| `just lint-markdown`           | markdownlint-cli2                              |
+| `just lint-brewfile`           | Ruby syntax check on Brewfiles                 |
+| `just lint-mise`               | Validate mise config                           |
+| `just lint-just`               | Check in-body `just <recipe>` calls resolve    |
+| `just lint-cleanup-symlinks`   | Fixture-test the stale-symlink scanner         |
+| `just lint-via-private`        | Keyword guard, delegated to the private repo   |
 
 The pre-commit hook is enabled by the bootstrap (idempotent — safe to re-run):
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Individual targets:
 | `just lint-brewfile`           | Ruby syntax check on Brewfiles                 |
 | `just lint-mise`               | Validate mise config                           |
 | `just lint-just`               | Check in-body `just <recipe>` calls resolve    |
-| `just lint-rcrc`               | Check `rcrc` resolves + normalises the paths   |
+| `just lint-rcrc`               | Check `rcrc` dirs, excludes, normalisation     |
 | `just lint-cleanup-symlinks`   | Fixture-test the stale-symlink scanner         |
 | `just lint-via-private`        | Keyword guard, delegated to the private repo   |
 

--- a/rcrc
+++ b/rcrc
@@ -7,10 +7,12 @@
 # two variables are the contract shared with the Justfile's `private_dir` and
 # `_scan-stale-symlinks`, so overriding one here moves all three together.
 #
-# The two DEFAULTS below are duplicated in the Justfile (`public_dir`,
-# `private_dir`) on purpose: this file is shell evaluated by rcm, those are just
-# variables evaluated at justfile load, and neither can read the other's without
-# a fragile bridge. Change one, change both.
+# The two DEFAULTS below live in three places on purpose: here, the Justfile's
+# `public_dir` / `private_dir`, and `lint-rcrc`'s expected values. This file is
+# shell evaluated by rcm, those are justfile-load-time variables, and `lint-rcrc`
+# runs under `env -u` precisely so it cannot inherit either — so none can read
+# another's without a fragile bridge. Change one, change all three; `lint-rcrc`
+# fails loudly if you miss it, but only after the other two are already edited.
 PUBLIC_DIR="${DOTFILES_DIR:-${HOME}/Workspace/tgautier/dotfiles}"
 PRIVATE_DIR="${DOTFILES_PRIVATE_DIR:-${HOME}/Workspace/tgautier/dotfiles-private}"
 

--- a/rcrc
+++ b/rcrc
@@ -1,7 +1,18 @@
-# Private repo path, used by both EXCLUDES and DOTFILES_DIRS below. Single
-# source of truth: if it drifts, the exclude-sourcing would silently no-op
+# Repo paths, used by EXCLUDES and DOTFILES_DIRS below. Single source of truth
+# for the private path: if it drifts, the exclude-sourcing would silently no-op
 # (2>/dev/null) and rcup would resume hanging on the excluded directory.
-PRIVATE_DIR="${HOME}/Workspace/tgautier/dotfiles-private"
+#
+# DOTFILES_DIR / DOTFILES_PRIVATE_DIR override the defaults per machine. rcm
+# sources this file as shell, which is exactly why it can read them — the same
+# two variables are the contract shared with the Justfile's `private_dir` and
+# `_scan-stale-symlinks`, so overriding one here moves all three together.
+#
+# The two DEFAULTS below are duplicated in the Justfile (`public_dir`,
+# `private_dir`) on purpose: this file is shell evaluated by rcm, those are just
+# variables evaluated at justfile load, and neither can read the other's without
+# a fragile bridge. Change one, change both.
+PUBLIC_DIR="${DOTFILES_DIR:-${HOME}/Workspace/tgautier/dotfiles}"
+PRIVATE_DIR="${DOTFILES_PRIVATE_DIR:-${HOME}/Workspace/tgautier/dotfiles-private}"
 
 # Base excludes plus any private-only exclude patterns appended from
 # ${PRIVATE_DIR}/rcm-excludes. Sourced here (rcm reads rcrc as shell) so
@@ -14,5 +25,5 @@ PRIVATE_DIR="${HOME}/Workspace/tgautier/dotfiles-private"
 # HOMEBREW_BUNDLE_FILE=~/.Brewfile[.linux], so excluding them breaks bare
 # `brew bundle`.
 EXCLUDES="README.md .githooks Justfile CHANGELOG.md rcm-excludes $( { grep -hvE '^[[:space:]]*(#|$)' "${PRIVATE_DIR}/rcm-excludes" 2>/dev/null || true; } | tr '\n' ' ')"
-DOTFILES_DIRS="${HOME}/Workspace/tgautier/dotfiles ${PRIVATE_DIR}"
+DOTFILES_DIRS="${PUBLIC_DIR} ${PRIVATE_DIR}"
 SYMLINK_DIRS="claude/skills claude/rules claude/hooks"

--- a/rcrc
+++ b/rcrc
@@ -24,6 +24,11 @@ PRIVATE_DIR="${DOTFILES_PRIVATE_DIR:-${HOME}/Workspace/tgautier/dotfiles-private
 # Loops rather than a single `${VAR%/}`, which strips only ONE slash and would
 # leave `…/dots//` as `…/dots/`. Stops at `/` so a pathological root value can't
 # be reduced to the empty string, which would make DOTFILES_DIRS match anything.
+#
+# The `$( … )` call sites are what confine `_v` to a subshell — it never exists
+# in the shell that sources this file, so there is nothing to unset. Keep the
+# calls in command-substitution form; a rewrite to a plain call would start
+# leaking it. Covered by `just lint-rcrc`.
 _rcrc_strip_slashes() {
     _v="$1"
     while [ "$_v" != "/" ] && [ "$_v" != "${_v%/}" ]; do _v="${_v%/}"; done
@@ -31,7 +36,6 @@ _rcrc_strip_slashes() {
 }
 PUBLIC_DIR="$(_rcrc_strip_slashes "$PUBLIC_DIR")"
 PRIVATE_DIR="$(_rcrc_strip_slashes "$PRIVATE_DIR")"
-unset _v
 unset -f _rcrc_strip_slashes 2>/dev/null || true
 
 # Base excludes plus any private-only exclude patterns appended from

--- a/rcrc
+++ b/rcrc
@@ -14,6 +14,26 @@
 PUBLIC_DIR="${DOTFILES_DIR:-${HOME}/Workspace/tgautier/dotfiles}"
 PRIVATE_DIR="${DOTFILES_PRIVATE_DIR:-${HOME}/Workspace/tgautier/dotfiles-private}"
 
+# Strip trailing slashes (shell completion appends one routinely). rcm derives
+# each link's destination name by stripping the configured dir from the
+# discovered path, so a trailing slash here would feed it a doubled separator —
+# and the symptom would be a wrongly-named link in the operator's real $HOME.
+# The scanner normalises with zsh's `:a`; this is the same guarantee for rcm, so
+# "a trailing slash is fine" holds for every consumer rather than just one.
+#
+# Loops rather than a single `${VAR%/}`, which strips only ONE slash and would
+# leave `…/dots//` as `…/dots/`. Stops at `/` so a pathological root value can't
+# be reduced to the empty string, which would make DOTFILES_DIRS match anything.
+_rcrc_strip_slashes() {
+    _v="$1"
+    while [ "$_v" != "/" ] && [ "$_v" != "${_v%/}" ]; do _v="${_v%/}"; done
+    printf '%s' "$_v"
+}
+PUBLIC_DIR="$(_rcrc_strip_slashes "$PUBLIC_DIR")"
+PRIVATE_DIR="$(_rcrc_strip_slashes "$PRIVATE_DIR")"
+unset _v
+unset -f _rcrc_strip_slashes 2>/dev/null || true
+
 # Base excludes plus any private-only exclude patterns appended from
 # ${PRIVATE_DIR}/rcm-excludes. Sourced here (rcm reads rcrc as shell) so
 # bare `rcup` and `just setup` both honor them; an absent private repo is a


### PR DESCRIPTION
## Summary

`DOTFILES_DIR` / `DOTFILES_PRIVATE_DIR` now move **every** consumer together.
[#214](https://github.com/tgautier/dotfiles/pull/214) introduced `private_dir`
but scoped it to `lint-via-private`, so setting the override pointed the keyword
guard at a private repo `rcup` never merged — half-wiring being worse than none.

- **`rcrc`** reads both, for `DOTFILES_DIRS` and (via `PRIVATE_DIR`) `EXCLUDES`.
  It is sourced as shell by rcm, which is exactly why it can; #214's comment
  claimed the opposite.
- **`cleanup-symlinks` is split in two.** `_scan-stale-symlinks` finds and prints
  stale links; `cleanup-symlinks` confirms and removes. Only the scan honours a
  `CLEANUP_HOME` override, so no environment setting can redirect the `rm` at
  another tree.
- **The predicate is a union, not a replacement** — which is the defect that sank
  #214. rcm records *absolute* targets, so a moved or renamed checkout leaves
  links naming the **old** path; that's the main thing a stale sweeper is for,
  and a prefix built from the *current* paths cannot see it. Setting the override
  to the new location doesn't help, because the stale targets name the old one.
  So the `dotfiles`/`dotfiles-private` segment match stays, and derived prefixes
  are *added* for a checkout whose basename isn't `dotfiles*` at all.
- **Paths are normalised with zsh's `:a`**, absorbing the trailing slash shell
  completion appends routinely. Without it the derived prefix becomes `…//*` and
  matches no single-slash target while glob discovery still succeeds — a silent
  empty sweep from a benign typo. Deliberately `:a` not `:A`: `:A` also resolves
  symlinks, and rcm recorded whatever `DOTFILES_DIRS` said, so resolving could
  stop matching the targets actually on disk.

Also fixes a silent failure found while writing this: a bare
`stale=("${(@f)$(scan)}")` turns a failed scan into empty output and then reports
"No stale symlinks found" — announcing a clean tree on the strength of a crash.

## Tests

`just lint-cleanup-symlinks`, wired into `just ci`. This recipe ended in `rm`
with **no** coverage, so rather than trust a passing fixture, each assertion was
proven capable of failing by sabotaging the logic it covers:

| Sabotage | Result |
| --- | --- |
| Remove the segment predicate | RED — names the former-checkout case |
| Remove the prefix predicate | RED — names the non-`dotfiles`-override case |
| Drop `:a` normalisation | RED — on the trailing-slash case specifically |
| Force `is_stale` true | RED — names the **survival** case |
| Drop `(N)` from the repos glob | RED — zsh aborts, "no matches found" |
| Make the scan exit 3 | RED — "scan failed; nothing removed", exit 1 |

The survival case is the one that matters: an unrelated broken symlink must
**not** be swept. A deletion test without one only proves the sweeper deletes
something.

## Review history

Six rounds. Two genuine defects surfaced that no checklist would have caught:

- **The empty-match guard was dead code.** Under `set -euo pipefail` the plain
  `called=$(scan …)` assignment took the pipeline's status, so a no-match grep
  killed the recipe before the guard could report. It still exited 1, which is
  exactly why the hand-run fixture looked correct.
- **CI was red on an undeclared interpreter.** `lint-cleanup-symlinks` is the
  first `ci` leg with a zsh shebang, and `ubuntu-latest` doesn't ship zsh —
  `/usr/bin/env: 'zsh': No such file or directory`. It passed locally because zsh
  is the login shell.

Rounds 3-6 progressively narrowed a comment that claimed more coverage than its
assertions proved; the residual boundary (`-h` is not pinnable by this fixture)
is now stated in the comment itself rather than only in a commit message.

## Test plan

- [x] `just ci` passes (8 lints incl. the new `lint-rcrc` and scanner fixtures)
- [x] All six sabotages above produce RED with the specific expected assertion
- [x] `rcrc` honours each override independently and both together; defaults
      unchanged with no override set; `EXCLUDES` still sources the private list
- [x] `CLEANUP_HOME` cannot redirect `cleanup-symlinks` — a decoy link in a fake
      home is neither reported nor deleted
- [x] `cleanup-symlinks` lists real stale links and removes nothing when the
      prompt is declined
- [x] Scan finds three genuinely stale links in the real `$HOME` (a removed zsh
      function plus two private-repo paths)
- [x] zsh `(N:a)` behaviour verified directly: qualifier applies to a quoted
      word, a missing dir yields zero elements, and `:a` normalises both a
      trailing slash and a `..` segment
- [x] `lint-just` confirms the new `just _scan-stale-symlinks` call resolves
- [x] `rcrc` is now shellchecked (`--shell=sh`); `lint-rcrc` pins both halves of
      the contract — `DOTFILES_DIRS` and `EXCLUDES` — with every component of the
      exclude filter sabotage-verified against the assertion that catches it
- [x] The sweep's link parsing is bound to `cleanup-symlinks`' real body via
      `just --dump`, so weakening `%%` to `%` in the recipe fails the lint

## Notes

The two **default** paths live in three places: `rcrc`, the `Justfile` vars, and
`lint-rcrc`'s expected values. That's inherent — `rcrc` is shell sourced by rcm,
the vars are justfile-load-time, and `lint-rcrc` runs under `env -u` precisely so
it cannot inherit either, so none can read another's without a fragile bridge.
All three sites carry a cross-reference naming the other two; `lint-rcrc` fails
loudly if one is missed, though only after the other two are already edited.

`README.md` gains a "Custom checkout locations" section documenting the two
variables, their defaults, and which consumers read each.

Fixes #215
