### PR TITLE
docs(readme): add reference tables; fix unquoted kfw/kxec aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ grouped by **date** rather than by semantic version. Newest first.
   than from memory — which caught two claims that would have shipped wrong: `bin/`
   reaches `PATH` as `~/.bin` via `zshenv`, not `~/bin`, and the functions are
   autoloaded because `zsh/zcompletion` prepends `~/.zsh/functions` to `fpath`.
+  Review of the tables then caught three more: `git_template/` is linked but
+  never wired to `init.templateDir`, `load_env_kops` exports AWS credentials
+  rather than merely checking a variable, and the load-order block omitted
+  `~/.zshrc.local` — the one hook a reader would use for machine-local config,
+  which matters more now that `CLAUDE.md` defers here instead of keeping its own
+  copy. Plus the two markdownlint configs, missing from a `Structure` block whose
+  commit message had claimed exhaustiveness; the block now states its own
+  exclusion rule so the two remaining omissions read as deliberate.
   The `Structure` block is refreshed for everything it had drifted past —
   `zlogin`, `.githooks/`, `.claude/`, `Brewfile.work` / `Brewfile.personal`,
   `CHANGELOG.md`, `.roborev.toml`, `gitignore`, `git_template/`, `agignore`,
@@ -241,6 +249,16 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Fixed
 
+- **`kfw` and `kxec` were silently truncated to bare `kubectl`.** `zsh/zaliases`
+  defined them unquoted (`alias kfw=kubectl port-forward`), and zsh's `alias`
+  builtin treats each whitespace-separated token as its own `name[=value]`
+  argument — so it defined `kfw=kubectl` and then tried to *look up* aliases
+  named `port-forward`, `exec` and `-it`. `kfw` therefore ran bare `kubectl`
+  (printing help) instead of forwarding a port, and `kxec` likewise. Now quoted,
+  matching the already-quoted `ll` / `la` / `ls`. Found by writing the alias
+  reference table for [#219](https://github.com/tgautier/dotfiles/issues/219):
+  documenting the intended expansion is what exposed that zsh never produced it
+  ([#219](https://github.com/tgautier/dotfiles/issues/219)).
 - `docs/homebrew.md`'s cask-recovery runbook drops the bundle check instead of
   dressing it up. It asked the operator to confirm `/Applications/<App>.app` was
   "present and non-empty" while nothing branched on the answer — the prescribed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,18 +23,18 @@ grouped by **date** rather than by semantic version. Newest first.
   rather than merely checking a variable, and the load-order block omitted
   `~/.zshrc.local` — the one hook a reader would use for machine-local config,
   which matters more now that `CLAUDE.md` defers here instead of keeping its own
-  copy. Its position is documented precisely: `zshrc` sources it *near* the end,
-  with zsh-syntax-highlighting and `mise activate zsh` after it, so mise's
-  runtimes win for the tools listed in `config/mise/config.toml` while a `PATH`
-  entry for anything else survives. Plus the two markdownlint configs, missing from a `Structure` block whose
-  commit message had claimed exhaustiveness; the block now states its own
+  copy. `~/.zshrc.local`'s position is documented precisely: `zshrc` sources it
+  *near* the end, with zsh-syntax-highlighting and `mise activate zsh` after it,
+  so mise wins for any runtime it manages while a `PATH` entry for anything else
+  survives. Plus the two markdownlint configs, missing from a `Structure` block
+  whose commit message had claimed exhaustiveness; the block now states its own
   exclusion rule so the two remaining omissions read as deliberate.
   The `Structure` block is refreshed for everything it had drifted past —
   `zlogin`, `.githooks/`, `.claude/`, `CLAUDE.md`, `Brewfile.work` /
   `Brewfile.personal`, `CHANGELOG.md`, `.roborev.toml`, `gitignore`,
-  `git_template/`, `agignore`, `editorconfig`, `psqlrc` and `iterm2/`. `CLAUDE.md`'s load-order line gains the
-  missing `zlogin` step and now defers to the README section instead of carrying
-  a second partial copy
+  `git_template/`, `agignore`, `editorconfig`, `psqlrc` and `iterm2/`.
+  `CLAUDE.md`'s load-order line gains the missing `zlogin` step and now defers to
+  the README section instead of carrying a second partial copy
   ([#219](https://github.com/tgautier/dotfiles/issues/219)).
 - `DOTFILES_DIR` / `DOTFILES_PRIVATE_DIR` are now honoured by every consumer,
   not just `lint-via-private`. `rcrc` reads them for both `DOTFILES_DIRS` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Added
 
+- `README.md` reference tables for the executable and configuration surface,
+  which was previously discoverable only by `ls`: **Scripts (`bin/`)** (4),
+  **Shell functions (`zsh/functions/`)** (10), **Aliases (`zsh/zaliases`)**,
+  **Git hooks (`.githooks/`)** (3), **Configuration files**, and a **Shell load
+  order** block. Every row was enumerated from the tree at authoring time rather
+  than from memory — which caught two claims that would have shipped wrong: `bin/`
+  reaches `PATH` as `~/.bin` via `zshenv`, not `~/bin`, and the functions are
+  autoloaded because `zsh/zcompletion` prepends `~/.zsh/functions` to `fpath`.
+  The `Structure` block is refreshed for everything it had drifted past —
+  `zlogin`, `.githooks/`, `.claude/`, `Brewfile.work` / `Brewfile.personal`,
+  `CHANGELOG.md`, `.roborev.toml`, `gitignore`, `git_template/`, `agignore`,
+  `editorconfig`, `psqlrc` and `iterm2/`. `CLAUDE.md`'s load-order line gains the
+  missing `zlogin` step and now defers to the README section instead of carrying
+  a second partial copy
+  ([#219](https://github.com/tgautier/dotfiles/issues/219)).
 - `DOTFILES_DIR` / `DOTFILES_PRIVATE_DIR` are now honoured by every consumer,
   not just `lint-via-private`. `rcrc` reads them for both `DOTFILES_DIRS` and
   `EXCLUDES` (it is sourced as shell by rcm, which is exactly why it can), and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,16 @@ grouped by **date** rather than by semantic version. Newest first.
   rather than merely checking a variable, and the load-order block omitted
   `~/.zshrc.local` — the one hook a reader would use for machine-local config,
   which matters more now that `CLAUDE.md` defers here instead of keeping its own
-  copy. Plus the two markdownlint configs, missing from a `Structure` block whose
+  copy. Its position is documented precisely: `zshrc` sources it *near* the end,
+  with zsh-syntax-highlighting and `mise activate zsh` after it, so mise's
+  runtimes win for the tools listed in `config/mise/config.toml` while a `PATH`
+  entry for anything else survives. Plus the two markdownlint configs, missing from a `Structure` block whose
   commit message had claimed exhaustiveness; the block now states its own
   exclusion rule so the two remaining omissions read as deliberate.
   The `Structure` block is refreshed for everything it had drifted past —
-  `zlogin`, `.githooks/`, `.claude/`, `Brewfile.work` / `Brewfile.personal`,
-  `CHANGELOG.md`, `.roborev.toml`, `gitignore`, `git_template/`, `agignore`,
-  `editorconfig`, `psqlrc` and `iterm2/`. `CLAUDE.md`'s load-order line gains the
+  `zlogin`, `.githooks/`, `.claude/`, `CLAUDE.md`, `Brewfile.work` /
+  `Brewfile.personal`, `CHANGELOG.md`, `.roborev.toml`, `gitignore`,
+  `git_template/`, `agignore`, `editorconfig`, `psqlrc` and `iterm2/`. `CLAUDE.md`'s load-order line gains the
   missing `zlogin` step and now defers to the README section instead of carrying
   a second partial copy
   ([#219](https://github.com/tgautier/dotfiles/issues/219)).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,9 +63,14 @@ This repo targets **three platforms**: macOS, Linux, and WSL2. Every change must
 
 ### Shell Configuration Load Order
 
-`zshenv` → `zprofile` → `zshrc` → `zsh/zaliases` + `zsh/zcompletion`
+`zshenv` → `zprofile` → `zshrc` (sources `zsh/zaliases` + `zsh/zcompletion`) →
+`zlogin`. The last is a pure optimisation — it precompiles `~/.zcompdump` in the
+background for the *next* login. `README.md` → Shell load order has the
+per-file detail; don't duplicate that list here.
 
-Custom functions live in `zsh/functions/` and are autoloaded. Scripts in `bin/` are added to PATH automatically.
+Custom functions live in `zsh/functions/`, which `zsh/zcompletion` prepends to
+`fpath` and autoloads. Scripts in `bin/` are linked by rcm into `~/.bin`, which
+`zshenv` puts on `PATH`.
 
 ### Tool Version Management (mise)
 

--- a/README.md
+++ b/README.md
@@ -252,10 +252,15 @@ Justfile                # Bootstrap, CI and update recipes
 .githooks/              # pre-commit, post-commit, post-rewrite (enabled by just setup)
 .claude/                # Repo-local Claude Code rules (see CLAUDE.md)
 .roborev.toml           # Review-tool scope context
+.markdownlint.yml       # markdownlint rules (used by just lint-markdown)
+.markdownlint-cli2.yaml # markdownlint file globs
 docs/                   # Detailed guides and cheat sheets
 CHANGELOG.md            # Date-based rolling changelog
 .github/workflows/ci.yml
 ```
+
+Every tracked top-level entry appears above except `README.md` and `.gitignore`,
+which are self-describing.
 
 ## Scripts (`bin/`)
 
@@ -274,18 +279,18 @@ rcm links each script into `~/.bin`, which `zshenv` adds to `PATH` (alongside
 `zsh/zcompletion` prepends `~/.zsh/functions` to `fpath` and autoloads each
 file, so every one is available as a command.
 
-| Function            | Description                                                       |
-| ------------------- | ----------------------------------------------------------------- |
-| `api_key`           | Random hex key via `openssl rand`, default 16 bytes               |
-| `b64_decode`        | Base64-decode arguments (GNU and BSD compatible)                  |
-| `b64_encode`        | Base64-encode arguments                                           |
-| `cdroot`            | `cd` to the repository root (`git root`)                          |
-| `current_tt`        | Set the terminal title to the current directory's name            |
-| `load_env_kops`     | Verify `KOPS_STATE_STORE` is set before using kops                |
-| `load_env_kubectl`  | Source `kubectl` and `helm` completions on demand                 |
-| `plantuml`          | Render a PlantUML source file to PNG                              |
-| `tt`                | Set the terminal title to an arbitrary string                     |
-| `uuid`              | Lowercase UUID via `uuidgen`, with a fallback                     |
+| Function            | Description                                                          |
+| ------------------- | -------------------------------------------------------------------- |
+| `api_key`           | Random hex key via `openssl rand`, default 16 bytes                  |
+| `b64_decode`        | Base64-decode arguments (GNU and BSD compatible)                     |
+| `b64_encode`        | Base64-encode arguments                                              |
+| `cdroot`            | `cd` to the repository root (`git root`)                             |
+| `current_tt`        | Set the terminal title to the current directory's name               |
+| `load_env_kops`     | Guard `KOPS_STATE_STORE`, then export AWS creds from `aws configure` |
+| `load_env_kubectl`  | Source `kubectl` and `helm` completions on demand                    |
+| `plantuml`          | Render a PlantUML source file to PNG                                 |
+| `tt`                | Set the terminal title to an arbitrary string                        |
+| `uuid`              | Lowercase UUID via `uuidgen`, with a fallback                        |
 
 ## Aliases (`zsh/zaliases`)
 
@@ -318,7 +323,7 @@ per-clone installation.
 | ------------------------- | ---------- | ----------------------------------------------------------------- |
 | `gitconfig`               | Git        | SSH signing via 1Password, `pull.ff=only`, `gh` credential helper |
 | `gitignore`               | Git        | Global ignores — OS, editor and build noise                       |
-| `git_template/`           | Git        | Template dir applied to `git init`                                |
+| `git_template/`           | Git        | Init template dir — linked, but not wired to `init.templateDir`   |
 | `tmux.conf`               | tmux       | `C-a` prefix, vi copy mode, platform-aware clipboard              |
 | `editorconfig`            | Editors    | UTF-8, LF, 2-space indent; tabs for `Makefile`                    |
 | `psqlrc`                  | psql       | Unicode borders, timing, `¤` for null, coloured prompt            |
@@ -331,12 +336,17 @@ per-clone installation.
 ## Shell load order
 
 ```text
-zshenv     # always — $PLATFORM, env vars, PATH, SSH agent
-zprofile   # login — Homebrew init, completion cache, ~/.local/bin, cargo
-zshrc      # interactive — prompt, keybindings, history, mise; sources
-           #   zsh/zaliases and zsh/zcompletion
-zlogin     # login, after zshrc — precompiles ~/.zcompdump in the background
+zshenv          # always — $PLATFORM, env vars, PATH, SSH agent
+zprofile        # login — Homebrew init, completion cache, ~/.local/bin, cargo
+zshrc           # interactive — prompt, keybindings, history, mise; sources
+                #   zsh/zaliases and zsh/zcompletion
+~/.zshrc.local  # sourced last by zshrc, if present — machine-local overrides,
+                #   kept in dotfiles-private rather than here
+zlogin          # login, after zshrc — precompiles ~/.zcompdump in the background
 ```
+
+`~/.zshrc.local` is the hook for anything machine-specific or private: it is
+sourced at the end of `zshrc` when readable, and this repo never tracks it.
 
 `zlogin` runs last and is a pure optimisation: it compiles the completion dump
 so the *next* login sources the compiled form. Guard platform-specific code with

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Brewfile.personal       # macOS personal-only casks/apps
 Brewfile.linux          # Linux Homebrew packages
 Justfile                # Bootstrap, CI and update recipes
 .githooks/              # pre-commit, post-commit, post-rewrite (enabled by just setup)
-CLAUDE.md               # Repo guidance for Claude Code, incl. the concern map
+CLAUDE.md               # Repo guidance for Claude Code (see Project-Local Rules)
 .claude/                # Repo-local Claude Code rules
 .roborev.toml           # Review-tool scope context
 .markdownlint.yml       # markdownlint rules (used by just lint-markdown)
@@ -343,15 +343,17 @@ zshrc           # interactive — prompt, keybindings, history, mise; sources
                 #   zsh/zaliases and zsh/zcompletion
 ~/.zshrc.local  # sourced near the end of zshrc, if present — machine-local
                 #   overrides, kept in dotfiles-private rather than here
-                #   NB: zsh-syntax-highlighting and `mise activate` run AFTER it
+                #   NB: zsh-syntax-highlighting and `mise activate` run AFTER it,
+                #   so mise's runtimes win for the tools it manages
 zlogin          # login, after zshrc — precompiles ~/.zcompdump in the background
 ```
 
 `~/.zshrc.local` is the hook for anything machine-specific or private: `zshrc`
 sources it when readable, and this repo never tracks it. It is *not* the last
-thing to run — zsh-syntax-highlighting and `mise activate zsh` follow it, and
-mise prepends its shim directory to `PATH`, so a `PATH` override placed there is
-overridden by mise rather than winning.
+thing to run — zsh-syntax-highlighting and `mise activate zsh` follow it. `mise
+activate` prepends the bin directories of the runtimes it manages, so for a tool
+listed in `config/mise/config.toml` mise's version wins over a `PATH` entry added
+there; entries for anything mise doesn't manage survive and still take effect.
 
 `zlogin` runs last and is a pure optimisation: it compiles the completion dump
 so the *next* login sources the compiled form. Guard platform-specific code with

--- a/README.md
+++ b/README.md
@@ -250,7 +250,8 @@ Brewfile.personal       # macOS personal-only casks/apps
 Brewfile.linux          # Linux Homebrew packages
 Justfile                # Bootstrap, CI and update recipes
 .githooks/              # pre-commit, post-commit, post-rewrite (enabled by just setup)
-.claude/                # Repo-local Claude Code rules (see CLAUDE.md)
+CLAUDE.md               # Repo guidance for Claude Code, incl. the concern map
+.claude/                # Repo-local Claude Code rules
 .roborev.toml           # Review-tool scope context
 .markdownlint.yml       # markdownlint rules (used by just lint-markdown)
 .markdownlint-cli2.yaml # markdownlint file globs
@@ -340,13 +341,17 @@ zshenv          # always — $PLATFORM, env vars, PATH, SSH agent
 zprofile        # login — Homebrew init, completion cache, ~/.local/bin, cargo
 zshrc           # interactive — prompt, keybindings, history, mise; sources
                 #   zsh/zaliases and zsh/zcompletion
-~/.zshrc.local  # sourced last by zshrc, if present — machine-local overrides,
-                #   kept in dotfiles-private rather than here
+~/.zshrc.local  # sourced near the end of zshrc, if present — machine-local
+                #   overrides, kept in dotfiles-private rather than here
+                #   NB: zsh-syntax-highlighting and `mise activate` run AFTER it
 zlogin          # login, after zshrc — precompiles ~/.zcompdump in the background
 ```
 
-`~/.zshrc.local` is the hook for anything machine-specific or private: it is
-sourced at the end of `zshrc` when readable, and this repo never tracks it.
+`~/.zshrc.local` is the hook for anything machine-specific or private: `zshrc`
+sources it when readable, and this repo never tracks it. It is *not* the last
+thing to run — zsh-syntax-highlighting and `mise activate zsh` follow it, and
+mise prepends its shim directory to `PATH`, so a `PATH` override placed there is
+overridden by mise rather than winning.
 
 `zlogin` runs last and is a pure optimisation: it compiles the completion dump
 so the *next* login sources the compiled form. Guard platform-specific code with

--- a/README.md
+++ b/README.md
@@ -343,19 +343,19 @@ zshrc           # interactive — prompt, keybindings, history, mise; sources
                 #   zsh/zaliases and zsh/zcompletion
 ~/.zshrc.local  # sourced near the end of zshrc, if present — machine-local
                 #   overrides, kept in dotfiles-private rather than here
-                #   NB: zsh-syntax-highlighting and `mise activate` run AFTER it,
-                #   so mise's runtimes win for the tools it manages
+                #   NB: zsh-syntax-highlighting and `mise activate` run AFTER
+                #   it — mise wins for what it manages, other PATH entries stay
 zlogin          # login, after zshrc — precompiles ~/.zcompdump in the background
 ```
 
 `~/.zshrc.local` is the hook for anything machine-specific or private: `zshrc`
 sources it when readable, and this repo never tracks it. It is *not* the last
 thing to run — zsh-syntax-highlighting and `mise activate zsh` follow it. `mise
-activate` prepends the bin directories of the runtimes it manages, so for any
-runtime mise manages — `config/mise/config.toml` plus any trusted project-level
-`mise.toml` under `trusted_config_paths` — mise's version wins over a `PATH`
-entry added there. Entries for anything mise doesn't manage survive and still
-take effect.
+activate` prepends the bin directories of every runtime it manages, so mise's
+version wins over a `PATH` entry added there for those tools; entries for
+anything mise doesn't manage survive and still take effect. Which runtimes those
+are is mise's business, not this repo's: `config/mise/config.toml` plus whatever
+project-level config is in scope.
 
 `zlogin` runs last and is a pure optimisation: it compiles the completion dump
 so the *next* login sources the compiled form. Guard platform-specific code with

--- a/README.md
+++ b/README.md
@@ -203,9 +203,9 @@ Both repos default to `~/Workspace/tgautier/`. Override per machine with two
 environment variables, which are a single shared contract — set one and every
 consumer moves together:
 
-| Variable | Default | Used by |
-| --- | --- | --- |
-| `DOTFILES_DIR` | `~/Workspace/tgautier/dotfiles` | `DOTFILES_DIRS` in `rcrc`, the stale-symlink scanner |
+| Variable               | Default                                 | Used by                                                          |
+| ---------------------- | --------------------------------------- | ---------------------------------------------------------------- |
+| `DOTFILES_DIR`         | `~/Workspace/tgautier/dotfiles`         | `DOTFILES_DIRS` in `rcrc`, the stale-symlink scanner             |
 | `DOTFILES_PRIVATE_DIR` | `~/Workspace/tgautier/dotfiles-private` | the above, plus `EXCLUDES` in `rcrc` and `just lint-via-private` |
 
 Export them before `just link` / `just setup` so `rcrc` sees them — rcm sources
@@ -223,9 +223,10 @@ Detailed guides live in the `docs/` folder:
 ## Structure
 
 ```text
-zshenv                  # Platform detection, environment variables, PATH
-zprofile                # Homebrew init, compinit
-zshrc                   # Prompt, keybindings, mise activation, sources aliases/completions
+zshenv                  # Platform detection ($PLATFORM), environment variables, PATH
+zprofile                # Homebrew init, completion cache, ~/.local/bin, Rust/cargo
+zshrc                   # Prompt, keybindings, history, mise activation, sources aliases/completions
+zlogin                  # Async zcompdump precompilation (see Shell load order)
 zsh/
   zaliases              # Shell aliases
   zcompletion           # Completion paths, autoloads functions
@@ -233,16 +234,113 @@ zsh/
 bin/                    # Scripts added to PATH
 config/
   mise/config.toml      # Pinned tool versions (node, python, ruby, go, etc.)
-  ghostty/config
+  ghostty/config        # Ghostty terminal config
+iterm2/                 # iTerm2 preferences plist
 tmux.conf               # tmux config (C-a prefix, vi mode, platform clipboard)
 gitconfig               # SSH signing via 1Password, rebase-based pulls
-rcrc                    # rcm config (DOTFILES_DIRS, EXCLUDES)
-Brewfile                # macOS Homebrew packages
+gitignore               # Global gitignore (OS, editor, build noise)
+git_template/           # Git init template directory
+agignore                # ack/ag ignore patterns
+editorconfig            # Cross-editor whitespace defaults
+psqlrc                  # psql prompt and output defaults
+rcrc                    # rcm config (DOTFILES_DIRS, EXCLUDES, SYMLINK_DIRS)
+Brewfile                # macOS shared base + profile-overlay tail
+Brewfile.work           # macOS work-only casks/apps
+Brewfile.personal       # macOS personal-only casks/apps
 Brewfile.linux          # Linux Homebrew packages
-Justfile                # CI and update recipes
+Justfile                # Bootstrap, CI and update recipes
+.githooks/              # pre-commit, post-commit, post-rewrite (enabled by just setup)
+.claude/                # Repo-local Claude Code rules (see CLAUDE.md)
+.roborev.toml           # Review-tool scope context
 docs/                   # Detailed guides and cheat sheets
+CHANGELOG.md            # Date-based rolling changelog
 .github/workflows/ci.yml
 ```
+
+## Scripts (`bin/`)
+
+rcm links each script into `~/.bin`, which `zshenv` adds to `PATH` (alongside
+`~/.bin.local` for machine-local scripts that stay out of this repo).
+
+| Script          | Description                                                               |
+| --------------- | ------------------------------------------------------------------------- |
+| `kseal`         | Seal a value (stdin or prompt) with `kubeseal --raw`, cluster-wide scope  |
+| `kshow`         | Print ConfigMap/Secret `.data`, base64-decoding secret values (`-n` ns)   |
+| `obsidian`      | macOS-only wrapper proxying to the CLI bundled in `Obsidian.app` (v1.12+) |
+| `op-ssh-sign`   | Cross-platform 1Password SSH signing (WSL delegates to `op-ssh-sign-wsl`) |
+
+## Shell functions (`zsh/functions/`)
+
+`zsh/zcompletion` prepends `~/.zsh/functions` to `fpath` and autoloads each
+file, so every one is available as a command.
+
+| Function            | Description                                                       |
+| ------------------- | ----------------------------------------------------------------- |
+| `api_key`           | Random hex key via `openssl rand`, default 16 bytes               |
+| `b64_decode`        | Base64-decode arguments (GNU and BSD compatible)                  |
+| `b64_encode`        | Base64-encode arguments                                           |
+| `cdroot`            | `cd` to the repository root (`git root`)                          |
+| `current_tt`        | Set the terminal title to the current directory's name            |
+| `load_env_kops`     | Verify `KOPS_STATE_STORE` is set before using kops                |
+| `load_env_kubectl`  | Source `kubectl` and `helm` completions on demand                 |
+| `plantuml`          | Render a PlantUML source file to PNG                              |
+| `tt`                | Set the terminal title to an arbitrary string                     |
+| `uuid`              | Lowercase UUID via `uuidgen`, with a fallback                     |
+
+## Aliases (`zsh/zaliases`)
+
+| Alias  | Expands to                | Notes                            |
+| ------ | ------------------------- | -------------------------------- |
+| `k`    | `kubectl`                 |                                  |
+| `kctx` | `kubectx`                 |                                  |
+| `kns`  | `kubens`                  |                                  |
+| `kxec` | `kubectl exec -it`        |                                  |
+| `kfw`  | `kubectl port-forward`    |                                  |
+| `ll`   | `ls -lh`                  |                                  |
+| `la`   | `ls -lah`                 |                                  |
+| `ls`   | `ls -G` / `ls --color`    | BSD flag on macOS, GNU elsewhere |
+| `ts`   | Tailscale.app CLI binary  | macOS only                       |
+
+## Git hooks (`.githooks/`)
+
+`just setup` points `core.hooksPath` here, so they are repo-local and need no
+per-clone installation.
+
+| Hook            | Runs                                                              |
+| --------------- | ----------------------------------------------------------------- |
+| `pre-commit`    | `mise x -- just ci` — every lint, skipped if `just` is absent     |
+| `post-commit`   | Queues a roborev review of the new commit                         |
+| `post-rewrite`  | Remaps roborev reviews after a rebase or amend                    |
+
+## Configuration files
+
+| File                      | Configures | Highlights                                                        |
+| ------------------------- | ---------- | ----------------------------------------------------------------- |
+| `gitconfig`               | Git        | SSH signing via 1Password, `pull.ff=only`, `gh` credential helper |
+| `gitignore`               | Git        | Global ignores — OS, editor and build noise                       |
+| `git_template/`           | Git        | Template dir applied to `git init`                                |
+| `tmux.conf`               | tmux       | `C-a` prefix, vi copy mode, platform-aware clipboard              |
+| `editorconfig`            | Editors    | UTF-8, LF, 2-space indent; tabs for `Makefile`                    |
+| `psqlrc`                  | psql       | Unicode borders, timing, `¤` for null, coloured prompt            |
+| `agignore`                | ack/ag     | Skip `.git`, `node_modules`, build output                         |
+| `rcrc`                    | rcm        | `DOTFILES_DIRS`, `EXCLUDES`, `SYMLINK_DIRS`                       |
+| `config/mise/config.toml` | mise       | Pinned runtimes — node, python, ruby, go, erlang, elixir, …       |
+| `config/ghostty/config`   | Ghostty    | Font, auto light/dark theme, window size                          |
+| `iterm2/`                 | iTerm2     | Preferences plist                                                 |
+
+## Shell load order
+
+```text
+zshenv     # always — $PLATFORM, env vars, PATH, SSH agent
+zprofile   # login — Homebrew init, completion cache, ~/.local/bin, cargo
+zshrc      # interactive — prompt, keybindings, history, mise; sources
+           #   zsh/zaliases and zsh/zcompletion
+zlogin     # login, after zshrc — precompiles ~/.zcompdump in the background
+```
+
+`zlogin` runs last and is a pure optimisation: it compiles the completion dump
+so the *next* login sources the compiled form. Guard platform-specific code with
+`$PLATFORM` in any of these files.
 
 ## Platform Detection
 

--- a/README.md
+++ b/README.md
@@ -351,9 +351,11 @@ zlogin          # login, after zshrc — precompiles ~/.zcompdump in the backgro
 `~/.zshrc.local` is the hook for anything machine-specific or private: `zshrc`
 sources it when readable, and this repo never tracks it. It is *not* the last
 thing to run — zsh-syntax-highlighting and `mise activate zsh` follow it. `mise
-activate` prepends the bin directories of the runtimes it manages, so for a tool
-listed in `config/mise/config.toml` mise's version wins over a `PATH` entry added
-there; entries for anything mise doesn't manage survive and still take effect.
+activate` prepends the bin directories of the runtimes it manages, so for any
+runtime mise manages — `config/mise/config.toml` plus any trusted project-level
+`mise.toml` under `trusted_config_paths` — mise's version wins over a `PATH`
+entry added there. Entries for anything mise doesn't manage survive and still
+take effect.
 
 `zlogin` runs last and is a pure optimisation: it compiles the completion dump
 so the *next* login sources the compiled form. Guard platform-specific code with

--- a/zsh/zaliases
+++ b/zsh/zaliases
@@ -1,8 +1,8 @@
 alias k=kubectl
 alias kctx=kubectx
-alias kfw=kubectl port-forward
+alias kfw='kubectl port-forward'
 alias kns=kubens
-alias kxec=kubectl exec -it
+alias kxec='kubectl exec -it'
 alias la='ls -lah'
 alias ll='ls -lh'
 


### PR DESCRIPTION
## Summary

The executable surface was discoverable only by `ls`. Four scripts land on `PATH`
and ten functions in the shell namespace of every machine that runs `just setup`,
and `README.md` named none of them. This adds:

- **Scripts (`bin/`)** — 4 rows
- **Shell functions (`zsh/functions/`)** — 10 rows
- **Aliases (`zsh/zaliases`)** — including the macOS/GNU `ls` branch and the
  macOS-only `ts`
- **Git hooks (`.githooks/`)** — 3 rows; `just setup` points `core.hooksPath`
  here, so they need no per-clone install
- **Configuration files** — file → what it configures → highlights
- **Shell load order** — the `zshenv` → `zprofile` → `zshrc` → `zlogin` chain,
  which previously had to be inferred from `Structure` comments

## It found a real bug

`zsh/zaliases` defined two aliases unquoted:

```sh
alias kfw=kubectl port-forward
alias kxec=kubectl exec -it
```

zsh's `alias` builtin treats each whitespace-separated token as its own
`name[=value]` argument, so this defined `kfw=kubectl` and then tried to *look up*
aliases named `port-forward`, `exec` and `-it`. Measured:

```console
$ zsh -f -c 'alias kfw=kubectl port-forward; alias kfw'
kfw=kubectl
```

So `kfw` ran bare `kubectl` (printing help) instead of forwarding a port, and
`kxec` the same — for as long as those aliases have existed. Now quoted, matching
the already-quoted `ll` / `la` / `ls`. Writing the reference table is what
surfaced it: documenting the intended expansion made it checkable, and it failed.

## Every row came from the tree, not from memory

The issue asked for this explicitly, because the dropped branch that first
attempted these tables documented a `claude` shell function that no longer
exists. That discipline caught two claims that would otherwise have shipped
wrong:

- `bin/` reaches `PATH` as **`~/.bin`** (`zshenv:67`, alongside `~/.bin.local`
  for machine-local scripts) — not `~/bin`, which is what I first wrote.
- The functions autoload because **`zsh/zcompletion` prepends
  `~/.zsh/functions` to `fpath`** — "autoloaded by `zcompletion`" understated the
  mechanism.

## Structure block

Rebuilt from `git ls-files` rather than edited, so it cannot have missed a
tracked entry. It had drifted past `zlogin`, `.githooks/`, `.claude/`,
`Brewfile.work`, `Brewfile.personal`, `CHANGELOG.md`, `.roborev.toml`,
`gitignore`, `git_template/`, `agignore`, `editorconfig`, `psqlrc` and `iterm2/`.

`CLAUDE.md`'s load-order line omitted `zlogin` entirely. Fixed, and pointed at
the README section rather than carrying a second partial copy — the same
single-enumeration decision this repo made for the lint-targets table in #220,
where three copies of one list drifted apart across three review rounds.

Issue #219's third problem (the CI targets table missing `lint-via-private`) was
already fixed in #220; that table now carries all seven lints.

## Test plan

- [x] `just ci` passes (7 lints, including MD060 table alignment)
- [x] Every table row traced to source: `kseal` (`kubeseal --raw`, cluster-wide),
      `kshow` (`-n` flag, base64-decode for secrets), `obsidian` (macOS-only,
      `.app`-bundled CLI), `op-ssh-sign` (`op-ssh-sign-wsl` delegation), all 10
      functions, all 9 aliases, all 3 hooks (`pre-commit` = `mise x -- just ci`)
- [x] Config highlights verified by grep: `gitconfig` (`op-ssh-sign`, `ff = only`,
      `!gh auth git-credential`), `tmux.conf` (`C-a`, `mode-keys vi`, platform
      clipboard), `config/ghostty/config` (Fira Code, light/dark Solarized,
      180×50), `psqlrc`, `editorconfig`, `agignore`
- [x] `Structure` block cross-checked against `git ls-files`
- [x] Literal tallies re-derived mechanically at push time, not trusted from
      authoring: `ls bin` → 4, `ls zsh/functions` → 10, `ls .githooks` → 3, and
      the rendered README row counts match (4 / 10 / 3)
- [x] Table alignment normalised by script rather than by hand — hand padding
      produced two MD060 failures earlier in the day; the script is idempotent,
      so a re-run reports zero changes

## Review history

Five rounds. Beyond the alias bug, review caught four claims in my first draft
that the tree contradicted: `git_template/` is linked but never wired to
`init.templateDir`, `load_env_kops` exports AWS credentials rather than merely
checking a variable, `CLAUDE.md` has no "concern map", and the mise/`PATH` note
named the shim mechanism (unused here) instead of `mise activate`'s install-bin-dir
prepending. It also caught three of my own **broken checkers**, each of which
reported success while testing nothing — a failing process substitution that made
every entry report missing, a substring match satisfied by a mention inside a
comment, and one asserting only a known-present case. Every completeness check
here now asserts a present *and* an absent case before its verdict counts.

The final round returned **No issues found**.

## Notes

Kept in `README.md` rather than split into `docs/`, per the issue's out-of-scope
note: the tables are short and belong next to `Structure`, while `docs/` holds
the longer-form guides.

Fixes #219
