### PR TITLE
docs(just): name -E in lint-rcrc's boundary, move the redundant row to prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,6 +252,17 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Fixed
 
+- `lint-rcrc`'s coverage comment now names every flag in the filter it describes.
+  It closed the set with `-v` and `-h` but omitted `-E`, which is pinned on the
+  same footing as `-v` — drop it and the pattern becomes a BRE where `(`, `)` and
+  `|` are literal, so nothing is filtered. The `column-0 comment` table row also
+  moved into the boundary prose, since it names a redundant ingredient rather
+  than an assertion and was the only row whose `caught by` column didn't answer
+  its own header. Verified by sabotage: dropping `-E` or `-v` fails the
+  joined-needle assertion, dropping `-h` changes nothing — and the claim that
+  *both* assertions fire was itself wrong, since the first one exits, so the
+  wording now says which one
+  ([#221](https://github.com/tgautier/dotfiles/pull/221) follow-up).
 - **`kfw` and `kxec` were silently truncated to bare `kubectl`.** `zsh/zaliases`
   defined them unquoted (`alias kfw=kubectl port-forward`), and zsh's `alias`
   builtin treats each whitespace-separated token as its own `name[=value]`

--- a/Justfile
+++ b/Justfile
@@ -87,17 +87,20 @@ lint-rcrc:
     #   ----------------------  ------------------  ---------------------------
     #   two patterns            the `tr` join       expect_has (joined needle)
     #   blank line, mid-list    the `$` alternative expect_has (joined needle)
-    #   indented comment        `[[:space:]]*`      expect_lacks "comment"
-    #                           and the `#` alt.
-    #   column-0 comment        nothing on its own  — belt and braces; the
-    #                                                 indented line already
-    #                                                 pins both
+    #   indented comment        `#` alt + `[[:space:]]*`  expect_lacks "comment"
     #
-    # Boundary, so the table isn't read as totality over the whole pipeline:
-    # `-v` is pinned incidentally (drop it and BOTH assertions fire, since only
-    # the comment and blank lines survive). `-h` is NOT pinned and structurally
-    # cannot be here — grep only prefixes filenames for multiple inputs or `-H`,
-    # and rcrc passes exactly one file, so dropping it changes nothing observable.
+    # Boundary, so the table isn't read as totality over the whole pipeline.
+    # `-v` and `-E` are pinned incidentally — drop either and the joined-needle
+    # assertion fails (it runs first and exits, so the expect_lacks case is never
+    # reached): without `-v` only the comment and blank lines survive, and without
+    # `-E` the pattern is a BRE where `(`, `)` and `|` are literal, so nothing
+    # matches and every line survives. `-h` is NOT pinned and cannot be here:
+    # grep only prefixes filenames for multiple inputs or `-H`, and rcrc passes
+    # exactly one file, so dropping it changes nothing observable.
+    #
+    # The fixture's column-0 comment pins nothing on its own — drop the `#`
+    # alternative and the INDENTED comment still survives `^[[:space:]]*$`, so
+    # expect_lacks fires from it alone. It stays as belt and braces.
     #
     # The blank line sits BETWEEN the patterns on purpose: a leaked blank then
     # breaks the contiguity of "sentinel-pattern second-pattern". Before the first

--- a/Justfile
+++ b/Justfile
@@ -83,10 +83,10 @@ lint-rcrc:
     # are each pinned, but by DIFFERENT assertions — don't delete either one
     # believing the other covers it:
     #
-    #   fixture ingredient      pins                caught by
-    #   ----------------------  ------------------  ---------------------------
-    #   two patterns            the `tr` join       expect_has (joined needle)
-    #   blank line, mid-list    the `$` alternative expect_has (joined needle)
+    #   fixture ingredient      pins                      caught by
+    #   ----------------------  ------------------------  ---------------------------
+    #   two patterns            the `tr` join             expect_has (joined needle)
+    #   blank line, mid-list    the `$` alternative       expect_has (joined needle)
     #   indented comment        `#` alt + `[[:space:]]*`  expect_lacks "comment"
     #
     # Boundary, so the table isn't read as totality over the whole pipeline.


### PR DESCRIPTION
## Summary

The two P2 findings deferred when #221 merged.

**`-E` was missing from the boundary paragraph.** That paragraph exists precisely
to close the set of flags the coverage table does *not* tabulate, and it named
`-v` and `-h` but not `-E` — which is pinned on exactly the same footing as `-v`.

**The `column-0 comment` row moved into the prose.** It names a redundant
ingredient rather than an assertion: drop the `#` alternative and the *indented*
comment still survives `^[[:space:]]*$`, so `expect_lacks` fires from it alone. It
was the only row whose `caught by` column couldn't answer its own header, and the
only three-line row in a four-row table.

## A third thing fell out

The phrasing I inherited from the review said "drop either and **both** assertions
fire". Only one does — `expect_has` runs first and exits, so `expect_lacks` is
never reached (`grep -c ERROR` = 1 in both cases). Corrected to name the assertion
that actually fails. A claim copied from a reviewer needs the same verification as
one I wrote myself, which is the point of undoing the deferral rather than
dropping it.

## Test plan

- [x] `just ci` passes
- [x] Sabotage-verified, each flag against the claim now made about it:

      drop -E → exit 1, joined-needle assertion fails (BRE: `(`, `)`, `|` become
                literal, so nothing is filtered and every line survives)
      drop -v → exit 1, same assertion
      drop -h → exit 0, genuinely not pinnable here (single input file, so grep
                never prefixes filenames)

- [x] `grep -c ERROR` = 1 for both the `-E` and `-v` cases, which is what
      falsified the "both assertions fire" wording

## Notes

Together the table (four ingredients) and the boundary prose (three flags) now
account for every token in `grep -hvE '^[[:space:]]*(#|$)' | tr '\n' ' '`.

Addresses the P2s recorded at #221.