### PR TITLE
docs(homebrew): cover the cask Binary-artifact conflict; declare kimi-code

### DIFF
--- a/.claude/rules/brewfile.md
+++ b/.claude/rules/brewfile.md
@@ -25,7 +25,7 @@ Because the overlay is merged into the same `brew bundle` evaluation, both `brew
 - A package shared by **all** machines goes in the base (`Brewfile` for macOS, and also `Brewfile.linux` unless it's a cask/mas or platform-specific tool)
 - A package for **one Mac profile only** goes in `Brewfile.work` or `Brewfile.personal` — never in the shared `Brewfile` base
 - Casks (`cask`) and Mac App Store (`mas`) entries never appear in `Brewfile.linux` — they are not available on Linux
-- The macOS `Brewfile` base is organized into comment-delimited blocks: `# CLI Tools & Development`, `# Applications`, `# Fonts`, `# Mac App Store Applications`. The overlays use `# Applications` and `# Mac App Store Applications` blocks
+- The macOS `Brewfile` base is organized into comment-delimited blocks: `# CLI Tools & Development`, `# Applications`, `# Fonts`, `# Mac App Store Applications`. The overlays use the same block names in the same order, but carry only the blocks they need — a `brew` formula in an overlay goes under `# CLI Tools & Development`, never into `# Applications`
 - `Brewfile.linux` is organized into a `# CLI Tools & Development` block
 - Within each block in each file, entries are sorted alphabetically (a-z) by package name
 - Tap entries (`tap`) come before all blocks

--- a/Brewfile.personal
+++ b/Brewfile.personal
@@ -5,6 +5,9 @@
 # Keep entries sorted alphabetically within each block, per
 # .claude/rules/brewfile.md.
 
+# CLI Tools & Development
+brew "kimi-code"
+
 # Applications
 cask "adobe-creative-cloud"
 cask "audacity"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Added
 
+- `brew "kimi-code"` (Moonshot's terminal coding agent) in `Brewfile.personal`,
+  under a new `# CLI Tools & Development` block — the first formula in an
+  overlay, which until now carried only `# Applications` and Mac App Store
+  entries. It had been installed by hand and was therefore uninstalled by the
+  `brew bundle cleanup --force` in `update-brew`, which is the pipeline working
+  as designed: undeclared packages do not survive. `.claude/rules/brewfile.md`
+  now states where a `brew` entry goes in an overlay, rather than enumerating
+  two blocks as if they were the whole set
+  ([#226](https://github.com/tgautier/dotfiles/issues/226)).
 - `README.md` reference tables for the executable and configuration surface,
   which was previously discoverable only by `ls`: **Scripts (`bin/`)** (4),
   **Shell functions (`zsh/functions/`)** (10), **Aliases (`zsh/zaliases`)**,
@@ -252,6 +261,22 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Fixed
 
+- `docs/homebrew.md` covers the second `just update` cask failure, "there is
+  already a **Binary** at `<prefix>/bin/<name>`" — hit on obsidian 1.12.7 →
+  1.13.4 ([#225](https://github.com/tgautier/dotfiles/issues/225)). A cask that
+  ships a CLI beside its app has two artifacts, and
+  Homebrew replays the *installed* version's recorded artifact list to uninstall
+  it; obsidian 1.12.7's held only App and Zap, so the upgrade never unlinked
+  `/opt/homebrew/bin/obsidian` and the new version refused to overwrite it. The
+  fix is to drop the stale symlink and install, not to reinstall. Also corrects
+  the existing App-conflict section, which sold `brew reinstall --cask` as the
+  near-universal remedy for a wedged cask: its uninstall replays that same
+  recorded list, so against this failure it removes the app and *then* fails at
+  the identical point — verified the hard way before the real fix landed. A new
+  section explains why an `auto_updates` cask is upgraded at all, since
+  `brew outdated --cask` lists nothing while `just update` dies on one:
+  non-greedy checks skip such casks *unless* the installed app bundle is behind
+  the tap, which Homebrew acts on by default.
 - `lint-rcrc`'s coverage comment now names every flag in the filter it describes.
   It closed the set with `-v` and `-h` but omitted `-E`, which is pinned on the
   same footing as `-v` — drop it and the pattern becomes a BRE where `(`, `)` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,9 +275,11 @@ grouped by **date** rather than by semantic version. Newest first.
   the identical point — verified the hard way before the real fix landed. A new
   section explains why an `auto_updates` cask — an app that updates itself — is
   upgraded at all: non-greedy checks skip such casks *unless* the installed app
-  bundle is behind the tap, which Homebrew upgrades by default. `brew outdated
-  --cask` runs that same predicate, so it previews the failure rather than
-  disagreeing with it; the greedy-vs-non-greedy gap is the only real contrast.
+  bundle is behind the tap, which Homebrew upgrades by default.
+  `brew outdated --cask` runs that same predicate absent the greedy env vars, so
+  it previews the failure rather than disagreeing with it; where it does stay
+  quiet, `brew update && brew outdated --cask` separates a self-update from a
+  stale tap.
 - `lint-rcrc`'s coverage comment now names every flag in the filter it describes.
   It closed the set with `-v` and `-h` but omitted `-E`, which is pinned on the
   same footing as `-v` — drop it and the pattern becomes a BRE where `(`, `)` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,9 +264,9 @@ grouped by **date** rather than by semantic version. Newest first.
 - `docs/homebrew.md` covers the second `just update` cask failure, "there is
   already a **Binary** at `<prefix>/bin/<name>`" — hit on obsidian 1.12.7 →
   1.13.4 ([#225](https://github.com/tgautier/dotfiles/issues/225)). A cask that
-  ships a CLI beside its app has two artifacts, and
-  Homebrew replays the *installed* version's recorded artifact list to uninstall
-  it; obsidian 1.12.7's held only App and Zap, so the upgrade never unlinked
+  ships a CLI beside its app carries a Binary artifact in addition to the App,
+  and Homebrew replays the *installed* version's recorded artifact list to
+  uninstall it; obsidian 1.12.7's held only App and Zap, so it never unlinked
   `/opt/homebrew/bin/obsidian` and the new version refused to overwrite it. The
   fix is to drop the stale symlink and install, not to reinstall. Also corrects
   the existing App-conflict section, which sold `brew reinstall --cask` as the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -273,10 +273,11 @@ grouped by **date** rather than by semantic version. Newest first.
   near-universal remedy for a wedged cask: its uninstall replays that same
   recorded list, so against this failure it removes the app and *then* fails at
   the identical point — verified the hard way before the real fix landed. A new
-  section explains why an `auto_updates` cask is upgraded at all, since
-  `brew outdated --cask` lists nothing while `just update` dies on one:
-  non-greedy checks skip such casks *unless* the installed app bundle is behind
-  the tap, which Homebrew acts on by default.
+  section explains why an `auto_updates` cask — an app that updates itself — is
+  upgraded at all: non-greedy checks skip such casks *unless* the installed app
+  bundle is behind the tap, which Homebrew upgrades by default. `brew outdated
+  --cask` runs that same predicate, so it previews the failure rather than
+  disagreeing with it; the greedy-vs-non-greedy gap is the only real contrast.
 - `lint-rcrc`'s coverage comment now names every flag in the filter it describes.
   It closed the set with `-v` and `-h` but omitted `-E`, which is pinned on the
   same footing as `-v` — drop it and the pattern becomes a BRE where `(`, `)` and

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -60,6 +60,21 @@ fails is listed there too. (Set either variable and it stops being a preview:
 greedier than `outdated` for that one cask. If you ever see the three disagree,
 those are the two places to look.)
 
+Add `--greedy` and, for `auto_updates` casks, the list grows by every one whose
+bundle is current and whose Homebrew metadata is merely stale. Those are the
+ones `just update` leaves alone. (`--greedy` widens other classes too — notably
+`version :latest` casks whose downloaded artifact changed — on rules of their
+own.) Within `update-brew`, whose `upgrade` and `bundle` passes name no casks,
+the contrast is only ever between greedy and non-greedy, not between `outdated`
+and the update itself. Naming a cask changes that, but only for the verbs that
+act: `brew install --cask <cask>` and `brew upgrade --cask <cask>` check a named
+cask greedily, so either can upgrade one `brew outdated --cask` never listed.
+What does *not* change `outdated` is naming a cask: `brew outdated --cask
+<cask>` runs the same non-greedy predicate as the bare form. Only a greedy
+invocation makes it look harder — `--greedy`, the narrower `--greedy-latest` /
+`--greedy-auto-updates`, `HOMEBREW_UPGRADE_GREEDY`, or
+`HOMEBREW_UPGRADE_GREEDY_CASKS`.
+
 A cask that fails the update while `brew outdated --cask` stays quiet has two
 possible causes, and one command tells them apart:
 
@@ -74,19 +89,6 @@ beforehand answers from whatever the last refresh left behind. The cask really
 is outdated and `just update` will fail again on it, so go to the matching
 section below — read the artifact word in the error, `App` or `Binary` — rather
 than re-running the update.
-
-Add `--greedy` and, for `auto_updates` casks, the list grows by every one whose
-bundle is current and whose Homebrew metadata is merely stale. Those are the
-ones `just update` leaves alone. (`--greedy` widens other classes too — notably
-`version :latest` casks whose downloaded artifact changed — on rules of their
-own.) Within `update-brew`, whose `upgrade` and `bundle` passes name no casks,
-the contrast is only ever between greedy and non-greedy, not between `outdated`
-and the update itself. Naming a cask changes that, but only for the verbs that
-act: `brew install --cask <cask>` and `brew upgrade --cask <cask>` check a named
-cask greedily, so either can upgrade one `brew outdated --cask` never listed.
-What does *not* change `outdated` is naming a cask: `brew outdated --cask
-<cask>` runs the same non-greedy predicate as the bare form. Only `--greedy` or
-the two variables above make it look harder.
 
 ## Troubleshooting
 
@@ -221,7 +223,8 @@ fails at the identical point, and the app is gone. That prohibition is about
 running it *first*; once the link is cleared it becomes useful again, at the end
 of this section.
 
-**Run this only while `just update` is actually failing with the Binary error.**
+**Run this only while the Binary error is live** — from `just update`, or from a
+`brew reinstall --cask` you already tried.
 Everything below assumes that error is on your screen right now. If it is not —
 you already ran the fix, or you are reading ahead — there is nothing to clear,
 and deleting a healthy link would leave you worse off than when you started:
@@ -285,15 +288,15 @@ your own `rm` has landed, there is genuinely nothing to delete — skip to the
 install.
 
 `readlink` would also answer the arrow question, but it prints nothing for both
-a regular file and a missing path — one stops the recovery and the other does
-not, and `ls -l` is what separates them.
+a regular file and a missing path. The first stops the recovery outright; the
+second needs the reading above. `ls -l` at least tells those two apart.
 
 With the link cleared or absent:
 
 ```sh
 rm "<the path the error printed>"         # skip if there was nothing to delete
 brew install --cask <cask>
-brew list --cask --versions <cask>        # expect the version update wanted
+brew list --cask --versions <cask>        # expect the version the update wanted
 ls -l "<the path the error printed>"      # expect the link back
 ```
 

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -71,9 +71,8 @@ act: `brew install --cask <cask>` and `brew upgrade --cask <cask>` check a named
 cask greedily, so either can upgrade one `brew outdated --cask` never listed.
 What does *not* change `outdated` is naming a cask:
 `brew outdated --cask <cask>` runs the same non-greedy predicate as the bare
-form. Only a greedy
-invocation makes it look harder — `--greedy`, the narrower `--greedy-latest` /
-`--greedy-auto-updates`, `HOMEBREW_UPGRADE_GREEDY`, or
+form. Only a greedy invocation makes it look harder — `--greedy`, the narrower
+`--greedy-latest` / `--greedy-auto-updates`, `HOMEBREW_UPGRADE_GREEDY`, or
 `HOMEBREW_UPGRADE_GREEDY_CASKS`.
 
 A cask that fails the update while `brew outdated --cask` stays quiet has two
@@ -192,11 +191,13 @@ macOS only, and distinct from the App conflict above despite the near-identical
 wording — **the remedy above makes this one worse**. Read the artifact word in
 the error: `App` or `Binary`.
 
-Scope: this assumes the CLI ships *inside* the app bundle — the shape
-`brew info --cask <cask>` shows as an absolute source path under Artifacts, and
-the only shape the recovery below is written for. A cask whose `binary` stanza
-names a source relative to the staged path links out of the Caskroom instead,
-and its stale link needs a different comparison than the one used here.
+Scope: the recovery below is written for a CLI that ships *inside* the app
+bundle — the shape `brew info --cask <cask>` shows as an absolute source path
+under Artifacts. A cask whose `binary` stanza names a source relative to the
+staged path links out of the Caskroom instead, and `brew info` prints that
+relative string bare. Only the comparison changes: check the `ls -l` arrow
+against `$(brew --prefix)/Caskroom/<cask>/<version>/<the source brew info
+prints>`, and the rest of the section applies unaltered.
 
 **Symptom** — `just update` dies in `update-brew`, and the upgrade rolls itself
 back first:
@@ -233,13 +234,14 @@ running it *first*; once the link is cleared it becomes useful again, at the end
 of this section.
 
 **Run this only while the Binary error is live** — from `just update`, or from a
-`brew reinstall --cask` you already tried.
-Everything below assumes that error is on your screen right now. If it is not —
-you already ran the fix, or you are reading ahead — there is nothing to clear,
-and deleting a healthy link would leave you worse off than when you started:
-the install below does not recreate it, because Homebrew skips a cask already
-at the tap version. (If you already did delete it, the first bullet under *Read
-both confirmations* is the way back.)
+`brew reinstall --cask` you already tried. Everything below assumes that error
+is on your screen right now, and the link you would delete is a healthy one if
+it is not. Having already run the fix, that link is the one the fix created, and
+deleting it leaves you worse off than when you started: the install below will
+not recreate it, because Homebrew skips a cask already at the tap version. Only
+reading ahead, it is the healthy link for the version you have, and there is
+nothing here to fix yet. (If you already did delete it, the first bullet under
+*Read both confirmations* is the way back.)
 
 Given that, one command decides the whole thing. Run it on the path the error
 printed, not a rebuilt one: that is usually `$(brew --prefix)/bin/<name>`, but a
@@ -269,13 +271,14 @@ your `ls -l` arrow points *at* is the one on the **left** of the `brew info`
 arrow. Comparing the two right-hand sides gives you a path against a bare token
 and reads a perfectly good cask link as foreign.
 
-Whatever the rule does not select stops the recovery — a regular file, another
-tool's shim, a hand-made `ln -s`. Do not look for a second test to settle those:
-the error cannot, because Homebrew raises for anything that *resolves* at that
-path, the cask's own stale link included — which is why you are here — excepting
-only a target resolving inside `$(brew --cellar)`, which it attributes to a
-formula, warns about, and skips. Nor can "is it a symlink". The arrow is the
-test, and it is the only one.
+At a path that exists, whatever the rule does not select stops the recovery — a
+regular file, another tool's shim, a hand-made `ln -s`. Do not look for a second
+test to settle those: the error cannot, because Homebrew raises for anything
+that *resolves* at that path, the cask's own stale link included — which is why
+you are here — excepting only a target resolving inside `$(brew --cellar)`,
+which it attributes to a formula, warns about, and skips. Nor can "is it a
+symlink". For a path that exists, the arrow is the only test. An empty `ls -l`
+is a different question, read further down.
 
 A **dangling** arrow does not change it either. `ls -l` never follows the arrow,
 so it prints the same line whether or not the target exists — read where the

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -225,30 +225,45 @@ ls -l "$(brew --prefix)/bin/<name>"
 ```
 
 **Delete it only if the arrow points at the artifact `brew info --cask <cask>`
-lists under Artifacts** — for the app-plus-CLI casks this failure applies to,
-that is a path inside the app bundle. Compare the two; do not pattern-match the
-shape from memory.
+lists under Artifacts** — for the app-plus-CLI casks this failure applies to, a
+path inside the app bundle. Compare the two rather than pattern-matching the
+shape from memory, and mind that they print in opposite senses:
+
+```text
+ls -l      <prefix>/bin/<name> -> /Applications/<App>.app/.../<tool>
+brew info  /Applications/<App>.app/.../<tool> -> <name> (Binary)
+```
+
+`ls -l` runs link → source; `brew info` runs source → link name. So the path
+your `ls -l` arrow points *at* is the one on the **left** of the `brew info`
+arrow. Comparing the two right-hand sides gives you a path against a bare token
+and reads a perfectly good cask link as foreign.
 
 Anything else belongs to something other than this cask and stops the recovery:
 a regular file, or a symlink pointing anywhere else — another tool's shim, a
 hand-made `ln -s`. Homebrew raises this error for any target it does not own,
-excepting only one it can attribute to a formula of the same name, which it
-warns about and skips instead. So "it is a symlink" is not the test. The arrow
-is.
+excepting only one that resolves inside `$(brew --cellar)`, which it attributes
+to a formula, warns about, and skips. So "it is a symlink" is not the test. The
+arrow is.
 
-**`No such file or directory` has two causes with opposite answers, and the
-error on your screen tells you which.** Homebrew raises only when something
-*resolves* at that target, so while the error is live there IS a link and an
-empty `ls -l` means you are looking at the wrong path — check the binary's
-target name in `brew info --cask <cask>` and re-run the `ls -l`. Going on to
-the install would leave the blocker untouched and reproduce the same error.
-Only if your own `rm` already landed is there genuinely nothing to delete; skip
-to the install.
+A **dangling** arrow is still the cask's link and still has to go. It is what
+the earlier reinstall misstep leaves — app deleted, arrow pointing at nothing —
+and it is tempting to think Homebrew will just replace it. It will not: the App
+artifact is installed before the Binary one, so the bundle is back in place
+before the link is tested, the arrow resolves again, and you get the identical
+error. `ls -l` never follows the arrow anyway, so this looks exactly like the
+delete-it case, which is what it is.
 
-The same "must resolve" rule means a **dangling** link is not a blocker at all:
-Homebrew overwrites it. If the earlier reinstall misstep left one behind — app
-gone, arrow pointing at nothing — the install alone is enough, though clearing
-it first is harmless.
+**`No such file or directory` has two causes with opposite answers.** Both look
+the same on screen — the failed `just update` is still in your scrollback either
+way — so the discriminator is where you are in this fix, not what you can see.
+**Before** you have run the `rm` below, an empty `ls -l` means you are on the
+wrong path: Homebrew raises only when something resolves at that target, so
+while the error stands there is something there. Copy the path out of the error
+itself, which prints it verbatim, and re-run the `ls -l` on that. Going on to
+the install would leave the blocker untouched and reproduce the error. **After**
+your own `rm` has landed, there is genuinely nothing to delete — skip to the
+install.
 
 `readlink` would also answer the arrow question, but it prints nothing for both
 a regular file and a missing path — one stops the recovery and the other does

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -39,8 +39,10 @@ something else breaks.
 Both failures below were observed on casks marked `auto_updates`
 (`brew info --cask <cask>` prints it next to the version), which raises the
 obvious question — those apps update themselves, so why is Homebrew touching
-them at all? It is a precondition for the Binary conflict; the App conflict has
-other triggers too, listed in its own section.
+them at all? Neither failure *requires* the flag: the App conflict lists
+interruption triggers in its own section, and the Binary conflict turns on a
+stale recorded artifact list. This explains why these casks were being upgraded
+at all, not why the upgrades failed.
 
 Because a non-greedy check skips an `auto_updates` cask *unless* the version
 inside the installed app bundle is behind the tap, which Homebrew upgrades by
@@ -76,8 +78,11 @@ Add `--greedy` and, for `auto_updates` casks, the list grows by every one whose
 bundle is current and whose Homebrew metadata is merely stale. Those are the
 ones `just update` leaves alone. (`--greedy` widens other classes too — notably
 `version :latest` casks whose downloaded artifact changed — on rules of their
-own.) The contrast is only ever between greedy and non-greedy, not between
-`outdated` and the update itself.
+own.) Within `update-brew`, whose `upgrade` and `bundle` passes name no casks,
+the contrast is only ever between greedy and non-greedy, not between `outdated`
+and the update itself. A cask you name explicitly is a different matter: it is
+checked greedily either way, so `brew install --cask <cask>` can upgrade one
+that `brew outdated --cask` never listed.
 
 ## Troubleshooting
 
@@ -244,11 +249,11 @@ and reads a perfectly good cask link as foreign.
 Anything else belongs to something other than this cask and stops the recovery:
 a regular file, or a symlink pointing anywhere else — another tool's shim, a
 hand-made `ln -s`. The error says nothing about which of these you have:
-Homebrew raises for *anything* already sitting at that path, the cask's own
-stale link included — which is why you are here — excepting only a target that
-resolves inside `$(brew --cellar)`, which it attributes to a formula, warns
-about, and skips. So "it is a symlink" is not the test, and neither is the error
-itself. The arrow is.
+Homebrew raises for anything that *resolves* at that path, the cask's own stale
+link included — which is why you are here — excepting only a target resolving
+inside `$(brew --cellar)`, which it attributes to a formula, warns about, and
+skips. So "it is a symlink" is not the test, and neither is the error itself.
+The arrow is.
 
 A **dangling** arrow is still the cask's link and still has to go. It is what
 the earlier reinstall misstep leaves — app deleted, arrow pointing at nothing —
@@ -276,11 +281,15 @@ not, and `ls -l` is what separates them.
 With the link cleared or absent:
 
 ```sh
-rm "$(brew --prefix)/bin/<name>"          # skip if there was nothing to delete
+rm "<the path the error printed>"         # skip if there was nothing to delete
 brew install --cask <cask>
 brew list --cask --versions <cask>        # expect the version update wanted
-ls -l "$(brew --prefix)/bin/<name>"       # expect the link back
+ls -l "<the path the error printed>"      # expect the link back
 ```
+
+That path is usually `$(brew --prefix)/bin/<name>`, which is what the `ls -l`
+above assumes — but the Binary artifact's directory is configurable
+(`--binarydir`), so take it from the error rather than rebuilding it.
 
 `brew install --cask` is right whether or not the app survived — for a named
 cask already installed it routes through the upgrade path, absent

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -51,10 +51,12 @@ rather than a second opinion: the cask that fails the update is listed there
 too. If it is *not* listed, the app self-updated between the two runs — re-run
 `just update` rather than hunting a discrepancy that isn't one.
 
-Add `--greedy` and the list grows by every cask whose bundle is current and
-whose Homebrew metadata is merely stale. Those are the ones `just update`
-leaves alone, and the contrast is only ever between greedy and non-greedy — not
-between `outdated` and the update itself.
+Add `--greedy` and, for `auto_updates` casks, the list grows by every one whose
+bundle is current and whose Homebrew metadata is merely stale. Those are the
+ones `just update` leaves alone. (`--greedy` widens other classes too — notably
+`version :latest` casks whose downloaded artifact changed — on rules of their
+own.) The contrast is only ever between greedy and non-greedy, not between
+`outdated` and the update itself.
 
 ## Troubleshooting
 
@@ -192,20 +194,33 @@ bundle, not the CLI itself, so removing it loses nothing and the install
 recreates it:
 
 ```sh
-readlink "$(brew --prefix)/bin/<name>"   # expect: .../<App>.app/Contents/MacOS/<tool>
+ls -l "$(brew --prefix)/bin/<name>"      # inspect BEFORE deleting — see below
 rm "$(brew --prefix)/bin/<name>"
 brew install --cask <cask>
+brew list --cask --versions <cask>       # confirm the new version landed
+ls -l "$(brew --prefix)/bin/<name>"      # confirm the link came back
 ```
 
-Confirm what `readlink` prints before deleting — the fix assumes a symlink the
-cask owns. A path into the app bundle is that. A real file is not, and is
-someone else's install to investigate rather than delete. A path under
-`$(brew --cellar)` means a formula owns the name, which Homebrew detects and
-warns past instead of failing on, so it cannot be what produced this error.
+**Read the `ls -l` before running the `rm`** — the fix assumes a symlink the
+cask owns, and only one of these three outputs is that:
 
-Use `brew upgrade --cask <cask>` in place of the install if the app is still
-there; `brew list --cask --versions <cask>` says which. After the reinstall
-misstep above it is gone, and `install` is the right call.
+| `ls -l` shows | Meaning | Action |
+| --- | --- | --- |
+| `l...  <name> -> /Applications/<App>.app/...` | the cask's own link | delete it, continue |
+| `-...  <name>` (a regular file) | not a symlink — someone else's install | stop and investigate |
+| `No such file or directory` | wrong path, or already cleared | stop; re-read the error |
+
+`ls -l` rather than `readlink` on purpose: `readlink` prints nothing and exits 1
+for BOTH a regular file and a missing path, so it cannot tell the delete-it case
+from the two stop cases — and the next line in the block deletes.
+
+A link under `$(brew --cellar)` is a fourth shape, but not one this error can
+produce: a formula owning the name makes Homebrew warn and skip the link rather
+than fail.
+
+`brew install --cask` is correct whether or not the app survived the failure —
+for an explicitly named cask that is already installed, it routes through the
+upgrade path — so there is no need to check first and pick a different verb.
 
 **Finish the update.** As with the App conflict, the rest of `update-brew` never
 ran — re-run `just update` so the direct `brew` calls stay a one-off.

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -39,15 +39,16 @@ something else breaks.
 Both failures below were observed on casks marked `auto_updates`
 (`brew info --cask <cask>` prints it next to the version), which raises the
 obvious question — those apps update themselves, so why is Homebrew touching
-them at all? Neither failure *requires* the flag: the App conflict lists
-interruption triggers in its own section, and the Binary conflict turns on a
-stale recorded artifact list. The flag explains why these casks were in an
-upgrade at all — not why the upgrades then failed.
+them at all? The flag is why the upgrade is *surprising*, not why it happened —
+and not why it then failed either. Neither failure requires it: the App conflict
+lists interruption triggers in its own section, and the Binary conflict turns on
+a stale recorded artifact list.
 
-Because a non-greedy check skips an `auto_updates` cask *unless* the version
-inside the installed app bundle is behind the tap, which Homebrew upgrades by
-default (opt out with `HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS`). So one reaches
-an upgrade exactly when the app has *not* self-updated.
+What puts one of these casks in an upgrade is a version lag. A non-greedy check
+suppresses an `auto_updates` cask *unless* the version inside the installed app
+bundle is behind the tap, which Homebrew upgrades by default (opt out with
+`HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS`). So one reaches an upgrade exactly
+when the app has *not* self-updated.
 
 Absent `HOMEBREW_UPGRADE_GREEDY` and `HOMEBREW_UPGRADE_GREEDY_CASKS`,
 `brew outdated --cask` runs the same non-greedy predicate as
@@ -83,8 +84,9 @@ the contrast is only ever between greedy and non-greedy, not between `outdated`
 and the update itself. Naming a cask changes that, but only for the verbs that
 act: `brew install --cask <cask>` and `brew upgrade --cask <cask>` check a named
 cask greedily, so either can upgrade one `brew outdated --cask` never listed.
-`brew outdated` itself stays non-greedy however you invoke it — narrowing it to
-`brew outdated --cask <cask>` does not make it look harder.
+What does *not* change `outdated` is naming a cask: `brew outdated --cask
+<cask>` runs the same non-greedy predicate as the bare form. Only `--greedy` or
+the two variables above make it look harder.
 
 ## Troubleshooting
 
@@ -314,9 +316,10 @@ that variable.
 - **Version still the old one** — the no-op above is not the explanation, and
   what the install printed tells you which case you are in. An error means it
   ran and failed, and the revert put the old version back: work from that error,
-  do not reinstall. *Nothing at all* printed means
-  `HOMEBREW_NO_INSTALL_UPGRADE`, named above — there is no error to hunt, and
-  the install never attempted the upgrade.
+  do not reinstall. *Nothing at all* printed means `HOMEBREW_NO_INSTALL_UPGRADE`,
+  named above — there is no error to hunt, the upgrade was never attempted, and
+  the link is still missing. Finish with `brew reinstall --cask <cask>`, which
+  does not consult that variable, or unset it and re-run the install.
 
 **Finish the update.** As with the App conflict, the rest of `update-brew` never
 ran — re-run `just update` so the direct `brew` calls stay a one-off.

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -80,9 +80,11 @@ ones `just update` leaves alone. (`--greedy` widens other classes too — notabl
 `version :latest` casks whose downloaded artifact changed — on rules of their
 own.) Within `update-brew`, whose `upgrade` and `bundle` passes name no casks,
 the contrast is only ever between greedy and non-greedy, not between `outdated`
-and the update itself. A cask you name explicitly is a different matter: it is
-checked greedily either way, so `brew install --cask <cask>` can upgrade one
-that `brew outdated --cask` never listed.
+and the update itself. Naming a cask changes that, but only for the verbs that
+act: `brew install --cask <cask>` and `brew upgrade --cask <cask>` check a named
+cask greedily, so either can upgrade one `brew outdated --cask` never listed.
+`brew outdated` itself stays non-greedy however you invoke it — narrowing it to
+`brew outdated --cask <cask>` does not make it look harder.
 
 ## Troubleshooting
 
@@ -309,9 +311,12 @@ that variable.
   installed. This is the state the precondition warns about, and
   `brew reinstall --cask <cask>` is the way out: it recreates the link, and is
   safe here because the blocker is already gone.
-- **Version still the old one** — the install ran and failed, and the revert put
-  the old version back. The no-op above is not the explanation, so do not
-  reinstall: scroll back for the error it printed and work from that.
+- **Version still the old one** — the no-op above is not the explanation, and
+  what the install printed tells you which case you are in. An error means it
+  ran and failed, and the revert put the old version back: work from that error,
+  do not reinstall. *Nothing at all* printed means
+  `HOMEBREW_NO_INSTALL_UPGRADE`, named above — there is no error to hunt, and
+  the install never attempted the upgrade.
 
 **Finish the update.** As with the App conflict, the rest of `update-brew` never
 ran — re-run `just update` so the direct `brew` calls stay a one-off.

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -36,9 +36,11 @@ something else breaks.
 
 ### Why an auto-updating cask is upgraded at all
 
-Both failures below hit casks marked `auto_updates` (`brew info --cask <cask>`
-prints it next to the version), which raises the obvious question — those apps
-update themselves, so why is Homebrew touching them at all?
+Both failures below were observed on casks marked `auto_updates`
+(`brew info --cask <cask>` prints it next to the version), which raises the
+obvious question — those apps update themselves, so why is Homebrew touching
+them at all? It is a precondition for the Binary conflict; the App conflict has
+other triggers too, listed in its own section.
 
 Because a non-greedy check skips an `auto_updates` cask *unless* the version
 inside the installed app bundle is behind the tap, which Homebrew upgrades by
@@ -241,10 +243,12 @@ and reads a perfectly good cask link as foreign.
 
 Anything else belongs to something other than this cask and stops the recovery:
 a regular file, or a symlink pointing anywhere else — another tool's shim, a
-hand-made `ln -s`. Homebrew raises this error for any target it does not own,
-excepting only one that resolves inside `$(brew --cellar)`, which it attributes
-to a formula, warns about, and skips. So "it is a symlink" is not the test. The
-arrow is.
+hand-made `ln -s`. The error says nothing about which of these you have:
+Homebrew raises for *anything* already sitting at that path, the cask's own
+stale link included — which is why you are here — excepting only a target that
+resolves inside `$(brew --cellar)`, which it attributes to a formula, warns
+about, and skips. So "it is a symlink" is not the test, and neither is the error
+itself. The arrow is.
 
 A **dangling** arrow is still the cask's link and still has to go. It is what
 the earlier reinstall misstep leaves — app deleted, arrow pointing at nothing —

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -203,102 +203,65 @@ the new version's install half refuses to overwrite an existing target. Every
 subsequent `just update` repeats it, because the failure leaves the same
 leftover behind.
 
-**Do not run `brew reinstall --cask` here.** Its uninstall replays the same
-recorded artifact list (watch it print `Purging files for version
-<old-version>`), so the stale link survives, the install half fails at the same
-point — and the app is now uninstalled, leaving the link dangling. Observed on
-2026-08-02 with obsidian: recovering from that took the fix below anyway.
+**Fix** — clear the leftover link, then install.
 
-The prohibition is about running it *now*, while the link is still there.
-Reinstall becomes the right verb once the `rm` has cleared it — see the end of
-this section.
+**Run this only while `just update` is actually failing with the Binary error.**
+Everything below assumes that error is on your screen right now. If it is not —
+you already ran the fix, or you are reading ahead — there is nothing to clear,
+and deleting a healthy link would leave you worse off than when you started:
+the install below does not recreate it, because Homebrew skips a cask already
+at the tap version.
 
-**Fix** — drop the stale link, then install. It is a symlink *into* the app
-bundle, not the CLI itself, so removing it loses nothing and the install
-recreates it:
-
-Inspect first — this step is deliberately its own block, because the next one
-deletes:
+Given that, one command decides the whole thing:
 
 ```sh
 ls -l "$(brew --prefix)/bin/<name>"
 ```
 
-**Delete it only if the arrow points into the cask's own app bundle** — the
-exact path `brew info --cask <cask>` prints under Artifacts, of the form
-`/Applications/<App>.app/Contents/MacOS/<tool>`. That is the whole rule. It is
-stated as one condition rather than a list of outputs on purpose: this error
-fires for *any* resolving target Homebrew does not recognise as its own, so a
-list of the shapes you might see will always be missing one, and the shapes are
-easy to confuse at a glance.
+**Delete it only if the arrow points at the artifact `brew info --cask <cask>`
+lists under Artifacts** — for the app-plus-CLI casks this failure applies to,
+that is a path inside the app bundle. Compare the two; do not pattern-match the
+shape from memory.
 
-Anything else is someone else's file and stops the recovery — a regular file, or
-a symlink whose arrow points somewhere other than that bundle (another tool's
-shim, a hand-made `ln -s`). Both are as capable of producing this error as the
-stale cask link is, and only the arrow tells them apart.
+Anything else belongs to something other than this cask and stops the recovery:
+a regular file, or a symlink pointing anywhere else — another tool's shim, a
+hand-made `ln -s`. Homebrew raises this same error for any target it does not
+own, so "it is a symlink" is not the test. The arrow is.
 
-Two readings are not "something else", though, and neither changes the rule:
+Two outputs look like exceptions and are not. A **dangling** arrow still counts
+— `ls -l` never follows it, so the earlier `brew reinstall` misstep, which
+deletes the app and leaves the link, prints the same line and gets the same
+answer. And **`No such file or directory`** means there is nothing to delete:
+either the path is wrong, or your earlier `rm` already landed. Skip to the
+install.
 
-- **A dangling arrow still counts as the cask's link.** The reinstall misstep
-  above removes the app while leaving the link behind. `ls -l` never follows the
-  arrow, so it prints the same line whether or not the target exists — judge by
-  where the arrow points, not by whether it resolves.
-- **`No such file or directory` means there is nothing to delete.** On a first
-  attempt the path is wrong — stop and re-read the error. On a resumed run your
-  earlier `rm` landed and the install did not: skip the `rm` and run the rest.
+`readlink` would also answer the arrow question, but it prints nothing for both
+a regular file and a missing path — one stops the recovery and the other does
+not, and `ls -l` is what separates them.
 
-One more stop condition, unrelated to the output: if you are re-entering this
-block after a run whose two confirmations already passed, the link is the
-healthy one the fix just created. Deleting it now would not be undone by the
-install below, which no-ops on a cask already at the tap version.
-
-`ls -l` rather than `readlink` on purpose. `readlink` would answer the delete
-question — it prints the arrow target for a symlink and nothing for anything
-else — but the two "anything else" cases have *different* next steps here, and
-it renders them identically: a regular file and a missing path both print
-nothing and exit 1. `ls -l` separates them, which is what lets the two readings
-above be two readings rather than one shrug.
-
-A target under `$(brew --cellar)` is the one foreign shape this error cannot
-produce: a formula owning the name makes Homebrew warn and skip the link rather
-than fail. Stop for it anyway — the rule above is what you follow, not this
-footnote.
-
-Once the `ls -l` says the link is the cask's own, the rest runs together:
+With the link cleared or absent:
 
 ```sh
-rm "$(brew --prefix)/bin/<name>"
+rm "$(brew --prefix)/bin/<name>"          # skip if there was nothing to delete
 brew install --cask <cask>
-brew list --cask --versions <cask>       # confirm the new version landed
-ls -l "$(brew --prefix)/bin/<name>"      # confirm the link came back
+brew list --cask --versions <cask>        # expect the version update wanted
+ls -l "$(brew --prefix)/bin/<name>"       # expect the link back
 ```
 
-`brew install --cask` is correct whether or not the app survived the failure —
-for an explicitly named cask that is already installed, it routes through the
-upgrade path — so there is no need to check first and pick a different verb.
+`brew install --cask` is right whether or not the app survived — for a named
+cask already installed it routes through the upgrade path.
 
-**Read the two confirmations; they can fail quietly.** The version line should
-show the version the update was trying to install, and the `ls -l` should show
-the link again. They fail in two different ways, and the pair tells you which:
+**Read both confirmations.** They fail in two different ways:
 
-- **Version right, `ls -l` prints nothing** — the install no-opped. Homebrew
-  skips a cask already at the tap version (`Not upgrading <cask>, the latest
-  version is already installed`), and skipping means nothing was re-linked. The
-  version line still looks correct because it reports what is installed, which
-  in this state already equals the tap version.
-- **Version still the old one** — the install did not run at all, so the no-op
-  above is not the explanation. Scroll back through its output for the real
-  error before doing anything else.
-
-Either way, the link is recreated with:
-
-```sh
-brew reinstall --cask <cask>
-```
-
-Which is safe *here*, and only here. The prohibition further up applies before
-the `rm`, while the stale link is still blocking; once it is gone, reinstall has
-nothing to trip over.
+- **Version right, `ls -l` empty** — the install no-opped (`Not upgrading
+  <cask>, the latest version is already installed`) and re-linked nothing. The
+  version line looks correct because it reports what is installed, which here
+  already equals the tap version. `brew reinstall --cask <cask>` recreates the
+  link, and is safe now that the blocker is gone — the prohibition above applies
+  only while the stale link is still there.
+- **Version still the old one** — the install ran and failed, and the revert put
+  the old version back. The no-op above is not the explanation, so do not
+  reinstall: scroll back for the error it printed and work from that.
 
 **Finish the update.** As with the App conflict, the rest of `update-brew` never
 ran — re-run `just update` so the direct `brew` calls stay a one-off.

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -37,20 +37,24 @@ something else breaks.
 ### Why an auto-updating cask is upgraded at all
 
 Both failures below hit casks marked `auto_updates` (`brew info --cask <cask>`
-prints it next to the version), which is confusing: `brew outdated --cask` lists
-nothing while `just update` dies on one of them. They are not the same question.
+prints it next to the version), which raises the obvious question — those apps
+update themselves, so why is Homebrew touching them at all?
 
-`brew outdated --cask` and the `brew bundle install` / `brew upgrade` steps of
-`update-brew` all run **non-greedy**, and a non-greedy check skips an
-`auto_updates` cask — *unless* Homebrew sees the version inside the installed
-app bundle is behind the tap, which it acts on by default
-(`HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS`, disabled only by setting
-`HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS`).
+Because a non-greedy check skips an `auto_updates` cask *unless* the version
+inside the installed app bundle is behind the tap, which Homebrew upgrades by
+default (opt out with `HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS`). So one reaches
+an upgrade exactly when the app has *not* self-updated.
 
-So an `auto_updates` cask reaches an upgrade exactly when the app has *not*
-self-updated. That is why `--greedy` lists a pile of casks `just update` leaves
-alone — their bundles are current and only Homebrew's metadata is stale — while
-the one app that fell behind is the one that fails.
+`brew outdated --cask` runs the same non-greedy predicate as the `brew bundle
+install` and `brew upgrade` steps of `update-brew`, so it is a faithful preview
+rather than a second opinion: the cask that fails the update is listed there
+too. If it is *not* listed, the app self-updated between the two runs — re-run
+`just update` rather than hunting a discrepancy that isn't one.
+
+Add `--greedy` and the list grows by every cask whose bundle is current and
+whose Homebrew metadata is merely stale. Those are the ones `just update`
+leaves alone, and the contrast is only ever between greedy and non-greedy — not
+between `outdated` and the update itself.
 
 ## Troubleshooting
 

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -41,8 +41,8 @@ Both failures below were observed on casks marked `auto_updates`
 obvious question — those apps update themselves, so why is Homebrew touching
 them at all? Neither failure *requires* the flag: the App conflict lists
 interruption triggers in its own section, and the Binary conflict turns on a
-stale recorded artifact list. This explains why these casks were being upgraded
-at all, not why the upgrades failed.
+stale recorded artifact list. The flag explains why these casks were in an
+upgrade at all — not why the upgrades then failed.
 
 Because a non-greedy check skips an `auto_updates` cask *unless* the version
 inside the installed app bundle is behind the tap, which Homebrew upgrades by
@@ -225,14 +225,13 @@ the install below does not recreate it, because Homebrew skips a cask already
 at the tap version. (If you already did delete it, the first bullet under *Read
 both confirmations* is the way back.)
 
-Given that, one command decides the whole thing — run it on the path the error
-printed, not a rebuilt one. `$(brew --prefix)/bin/<name>` is the usual form and
-what this doc writes throughout, but a cask's `binary` stanza can name an
-absolute or `~`-rooted `target:`, which Homebrew uses verbatim instead of
-placing it under `bin/`:
+Given that, one command decides the whole thing. Run it on the path the error
+printed, not a rebuilt one: that is usually `$(brew --prefix)/bin/<name>`, but a
+cask's `binary` stanza can name an absolute or `~`-rooted `target:`, which
+Homebrew honours as written (expanding `~`) instead of placing it under `bin/`.
 
 ```sh
-ls -l "$(brew --prefix)/bin/<name>"      # or whatever path the error named
+ls -l "<the path the error printed>"     # usually $(brew --prefix)/bin/<name>
 ```
 
 **Delete it only if the arrow points at the artifact `brew info --cask <cask>`

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -203,14 +203,20 @@ the new version's install half refuses to overwrite an existing target. Every
 subsequent `just update` repeats it, because the failure leaves the same
 leftover behind.
 
-**Fix** — clear the leftover link, then install.
+**Fix** — clear the leftover link, then install. **Not `brew reinstall --cask`,
+which is the App conflict's remedy and the wrong move here**: its uninstall
+replays the same recorded artifact list, so the link survives, the install half
+fails at the identical point, and the app is gone. That prohibition is about
+running it *first*; once the link is cleared it becomes useful again, at the end
+of this section.
 
 **Run this only while `just update` is actually failing with the Binary error.**
 Everything below assumes that error is on your screen right now. If it is not —
 you already ran the fix, or you are reading ahead — there is nothing to clear,
 and deleting a healthy link would leave you worse off than when you started:
 the install below does not recreate it, because Homebrew skips a cask already
-at the tap version.
+at the tap version. (If you already did delete it, the first bullet under *Read
+both confirmations* is the way back.)
 
 Given that, one command decides the whole thing:
 
@@ -225,15 +231,24 @@ shape from memory.
 
 Anything else belongs to something other than this cask and stops the recovery:
 a regular file, or a symlink pointing anywhere else — another tool's shim, a
-hand-made `ln -s`. Homebrew raises this same error for any target it does not
-own, so "it is a symlink" is not the test. The arrow is.
+hand-made `ln -s`. Homebrew raises this error for any target it does not own,
+excepting only one it can attribute to a formula of the same name, which it
+warns about and skips instead. So "it is a symlink" is not the test. The arrow
+is.
 
-Two outputs look like exceptions and are not. A **dangling** arrow still counts
-— `ls -l` never follows it, so the earlier `brew reinstall` misstep, which
-deletes the app and leaves the link, prints the same line and gets the same
-answer. And **`No such file or directory`** means there is nothing to delete:
-either the path is wrong, or your earlier `rm` already landed. Skip to the
-install.
+**`No such file or directory` has two causes with opposite answers, and the
+error on your screen tells you which.** Homebrew raises only when something
+*resolves* at that target, so while the error is live there IS a link and an
+empty `ls -l` means you are looking at the wrong path — check the binary's
+target name in `brew info --cask <cask>` and re-run the `ls -l`. Going on to
+the install would leave the blocker untouched and reproduce the same error.
+Only if your own `rm` already landed is there genuinely nothing to delete; skip
+to the install.
+
+The same "must resolve" rule means a **dangling** link is not a blocker at all:
+Homebrew overwrites it. If the earlier reinstall misstep left one behind — app
+gone, arrow pointing at nothing — the install alone is enough, though clearing
+it first is harmless.
 
 `readlink` would also answer the arrow question, but it prints nothing for both
 a regular file and a missing path — one stops the recovery and the other does
@@ -249,16 +264,19 @@ ls -l "$(brew --prefix)/bin/<name>"       # expect the link back
 ```
 
 `brew install --cask` is right whether or not the app survived — for a named
-cask already installed it routes through the upgrade path.
+cask already installed it routes through the upgrade path, absent
+`HOMEBREW_NO_INSTALL_UPGRADE`. An install that prints nothing at all points at
+that variable.
 
 **Read both confirmations.** They fail in two different ways:
 
-- **Version right, `ls -l` empty** — the install no-opped (`Not upgrading
-  <cask>, the latest version is already installed`) and re-linked nothing. The
-  version line looks correct because it reports what is installed, which here
-  already equals the tap version. `brew reinstall --cask <cask>` recreates the
-  link, and is safe now that the blocker is gone — the prohibition above applies
-  only while the stale link is still there.
+- **Version right, `ls -l` empty** — you re-entered this fix after it had
+  already succeeded, so the cask was already at the tap version and the install
+  no-opped (`Not upgrading <cask>, the latest version is already installed`),
+  re-linking nothing. The version line looks correct because it reports what is
+  installed. This is the state the precondition warns about, and
+  `brew reinstall --cask <cask>` is the way out: it recreates the link, and is
+  safe here because the blocker is already gone.
 - **Version still the old one** — the install ran and failed, and the revert put
   the old version back. The no-op above is not the explanation, so do not
   reinstall: scroll back for the error it printed and work from that.

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -34,6 +34,24 @@ paper over it with `|| true` or `continue-on-error` — a red `just update` mean
 a package really is broken, and silencing it hides a half-installed app until
 something else breaks.
 
+### Why an auto-updating cask is upgraded at all
+
+Both failures below hit casks marked `auto_updates` (`brew info --cask <cask>`
+prints it next to the version), which is confusing: `brew outdated --cask` lists
+nothing while `just update` dies on one of them. They are not the same question.
+
+`brew outdated --cask` and the `brew bundle install` / `brew upgrade` steps of
+`update-brew` all run **non-greedy**, and a non-greedy check skips an
+`auto_updates` cask — *unless* Homebrew sees the version inside the installed
+app bundle is behind the tap, which it acts on by default
+(`HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS`, disabled only by setting
+`HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS`).
+
+So an `auto_updates` cask reaches an upgrade exactly when the app has *not*
+self-updated. That is why `--greedy` lists a pile of casks `just update` leaves
+alone — their bundles are current and only Homebrew's metadata is stale — while
+the one app that fell behind is the one that fails.
+
 ## Troubleshooting
 
 ### Cask upgrade fails with "there is already an App at"
@@ -72,8 +90,12 @@ cleared.
 brew reinstall --cask <cask>
 ```
 
-That is the whole remedy in nearly every case. Three properties make it the
-default rather than a fallback:
+That is the whole remedy **for this symptom**, and not a general fix for a
+wedged cask — read the error text before reaching for it. It does *not* resolve
+the Binary conflict documented below: there its uninstall leaves the blocker in
+place, so it fails at the same point having already removed the app.
+
+Three properties make it the default rather than a fallback here:
 
 - Its internal uninstall is **forced**, so the backup step overwrites the
   wedged staging directory instead of refusing — which is exactly what a plain
@@ -121,6 +143,68 @@ so the direct `brew` call stays a one-off:
 ```sh
 just update
 ```
+
+### Cask upgrade fails with "there is already a Binary at"
+
+macOS only, and distinct from the App conflict above despite the near-identical
+wording — **the remedy above makes this one worse**. Read the artifact word in
+the error: `App` or `Binary`.
+
+**Symptom** — `just update` dies in `update-brew`, and the upgrade rolls itself
+back first:
+
+```text
+==> Moving App '<App>.app' to '/Applications/<App>.app'
+Warning: Reverting upgrade for Cask <cask>
+==> Removing App '/Applications/<App>.app'
+==> Purging files for version <new-version> of Cask <cask>
+==> Moving App '<App>.app' to '/Applications/<App>.app'
+Error: <cask>: It seems there is already a Binary at '/opt/homebrew/bin/<name>'.
+```
+
+The app is back where it started — the revert is the *consequence*, not the
+problem. The Binary line is the one that matters.
+
+**Cause** — the cask ships a CLI alongside the app (`brew info --cask <cask>`
+lists it under Artifacts as `.../<App>.app/Contents/MacOS/<tool> -> <name>
+(Binary)`). Homebrew replays the *installed* version's artifact list to
+uninstall it, and that recorded list can be missing the Binary. Re-running with
+`--debug` prints the set it loaded; for obsidian 1.12.7 it held only
+`Cask::Artifact::App` and `Cask::Artifact::Zap`.
+
+So the upgrade's uninstall half never unlinks `/opt/homebrew/bin/<name>`, and
+the new version's install half refuses to overwrite an existing target. Every
+subsequent `just update` repeats it, because the failure leaves the same
+leftover behind.
+
+**Do not run `brew reinstall --cask` here.** Its uninstall replays the same
+recorded artifact list (watch it print `Purging files for version
+<old-version>`), so the stale link survives, the install half fails at the same
+point — and the app is now uninstalled. Observed on 2026-08-02 with obsidian:
+recovering from that took the fix below anyway.
+
+**Fix** — drop the stale link, then install. It is a symlink *into* the app
+bundle, not the CLI itself, so removing it loses nothing and the install
+recreates it:
+
+```sh
+readlink "$(brew --prefix)/bin/<name>"   # expect: .../<App>.app/Contents/MacOS/<tool>
+rm "$(brew --prefix)/bin/<name>"
+brew install --cask <cask>
+```
+
+Confirm what `readlink` prints before deleting — the fix assumes a symlink the
+cask owns. A path into the app bundle is that. A real file is not, and is
+someone else's install to investigate rather than delete. A path under
+`$(brew --cellar)` means a formula owns the name, which Homebrew detects and
+warns past instead of failing on, so it cannot be what produced this error.
+
+Use `brew upgrade --cask <cask>` in place of the install if the app is still
+there; `brew list --cask --versions <cask>` says which. After the reinstall
+misstep above it is gone, and `install` is the right call.
+
+**Finish the update.** As with the App conflict, the rest of `update-brew` never
+ran — re-run `just update` so the direct `brew` calls stay a one-off.
 
 ### `brew bundle` fails on a missing profile marker
 

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -45,11 +45,26 @@ inside the installed app bundle is behind the tap, which Homebrew upgrades by
 default (opt out with `HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS`). So one reaches
 an upgrade exactly when the app has *not* self-updated.
 
-`brew outdated --cask` runs the same non-greedy predicate as the `brew bundle
-install` and `brew upgrade` steps of `update-brew`, so it is a faithful preview
-rather than a second opinion: the cask that fails the update is listed there
-too. If it is *not* listed, the app self-updated between the two runs — re-run
-`just update` rather than hunting a discrepancy that isn't one.
+Absent `HOMEBREW_UPGRADE_GREEDY` and `HOMEBREW_UPGRADE_GREEDY_CASKS`,
+`brew outdated --cask` runs the same non-greedy predicate as
+the `brew bundle install` and `brew upgrade` steps of `update-brew` — so it
+previews the update rather than offering a second opinion, and the cask that
+fails is listed there too. (Set either variable and it stops being a preview:
+`outdated` and `upgrade` honour them, `brew bundle install` does not. If you
+ever see the three disagree, that is the place to look.)
+
+A cask that fails the update while `brew outdated --cask` stays quiet has two
+possible causes, and one command tells them apart:
+
+```sh
+brew update && brew outdated --cask
+```
+
+Still empty means the app self-updated between the two runs — re-run
+`just update`. Now listed means the earlier check read a stale tap:
+`update-brew` refreshes it with `brew update` first, so a bare `brew outdated`
+beforehand answers from whatever the last refresh left behind, and re-running
+`just update` on its own would just reproduce the crash.
 
 Add `--greedy` and, for `auto_updates` casks, the list grows by every one whose
 bundle is current and whose Homebrew metadata is merely stale. Those are the
@@ -101,7 +116,8 @@ wedged cask — read the error text before reaching for it. It does *not* resolv
 the Binary conflict documented below: there its uninstall leaves the blocker in
 place, so it fails at the same point having already removed the app.
 
-Three properties make it the default rather than a fallback here:
+Against a wedged *staging directory* specifically, three properties make it the
+default rather than a fallback:
 
 - Its internal uninstall is **forced**, so the backup step overwrites the
   wedged staging directory instead of refusing — which is exactly what a plain
@@ -208,7 +224,12 @@ cask owns, and only one of these three outputs is that:
 | --- | --- | --- |
 | `l...  <name> -> /Applications/<App>.app/...` | the cask's own link | delete it, continue |
 | `-...  <name>` (a regular file) | not a symlink — someone else's install | stop and investigate |
-| `No such file or directory` | wrong path, or already cleared | stop; re-read the error |
+| `No such file or directory`, fresh attempt | wrong path | stop; re-read the error |
+| `No such file or directory`, resumed run | you already deleted it, or reinstalled | skip the `rm`, run the rest |
+
+That last row is the common one on a second pass: the `rm` succeeded and the
+install didn't, or the reinstall misstep above already took the link with it.
+Nothing is wrong — go straight to `brew install --cask` and the two checks.
 
 `ls -l` rather than `readlink` on purpose: `readlink` prints nothing and exits 1
 for BOTH a regular file and a missing path, so it cannot tell the delete-it case

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -225,10 +225,14 @@ the install below does not recreate it, because Homebrew skips a cask already
 at the tap version. (If you already did delete it, the first bullet under *Read
 both confirmations* is the way back.)
 
-Given that, one command decides the whole thing:
+Given that, one command decides the whole thing — run it on the path the error
+printed, not a rebuilt one. `$(brew --prefix)/bin/<name>` is the usual form and
+what this doc writes throughout, but a cask's `binary` stanza can name an
+absolute or `~`-rooted `target:`, which Homebrew uses verbatim instead of
+placing it under `bin/`:
 
 ```sh
-ls -l "$(brew --prefix)/bin/<name>"
+ls -l "$(brew --prefix)/bin/<name>"      # or whatever path the error named
 ```
 
 **Delete it only if the arrow points at the artifact `brew info --cask <cask>`
@@ -255,13 +259,16 @@ inside `$(brew --cellar)`, which it attributes to a formula, warns about, and
 skips. So "it is a symlink" is not the test, and neither is the error itself.
 The arrow is.
 
-A **dangling** arrow is still the cask's link and still has to go. It is what
-the earlier reinstall misstep leaves — app deleted, arrow pointing at nothing —
-and it is tempting to think Homebrew will just replace it. It will not: the App
-artifact is installed before the Binary one, so the bundle is back in place
-before the link is tested, the arrow resolves again, and you get the identical
-error. `ls -l` never follows the arrow anyway, so this looks exactly like the
-delete-it case, which is what it is.
+A **dangling** arrow changes nothing about the test above — apply it exactly as
+written, because `ls -l` never follows the arrow and prints the same line either
+way. An arrow matching the `brew info` path is the cask's link and goes; one
+pointing elsewhere is still someone else's and still stops you, dangling or not.
+
+Danglingness is worth naming only because it is tempting to think it makes the
+link harmless. It does not. It is what the earlier reinstall misstep leaves —
+app deleted, arrow pointing at nothing — and the App artifact is installed
+before the Binary one, so the bundle is back in place before the link is tested,
+the arrow resolves again, and you get the identical error.
 
 **`No such file or directory` has two causes with opposite answers.** Both look
 the same on screen — the failed `just update` is still in your scrollback either
@@ -287,9 +294,7 @@ brew list --cask --versions <cask>        # expect the version update wanted
 ls -l "<the path the error printed>"      # expect the link back
 ```
 
-That path is usually `$(brew --prefix)/bin/<name>`, which is what the `ls -l`
-above assumes — but the Binary artifact's directory is configurable
-(`--binarydir`), so take it from the error rather than rebuilding it.
+Same path as the inspect command above — the one the error named.
 
 `brew install --cask` is right whether or not the app survived — for a named
 cask already installed it routes through the upgrade path, absent

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -69,8 +69,9 @@ the contrast is only ever between greedy and non-greedy, not between `outdated`
 and the update itself. Naming a cask changes that, but only for the verbs that
 act: `brew install --cask <cask>` and `brew upgrade --cask <cask>` check a named
 cask greedily, so either can upgrade one `brew outdated --cask` never listed.
-What does *not* change `outdated` is naming a cask: `brew outdated --cask
-<cask>` runs the same non-greedy predicate as the bare form. Only a greedy
+What does *not* change `outdated` is naming a cask:
+`brew outdated --cask <cask>` runs the same non-greedy predicate as the bare
+form. Only a greedy
 invocation makes it look harder — `--greedy`, the narrower `--greedy-latest` /
 `--greedy-auto-updates`, `HOMEBREW_UPGRADE_GREEDY`, or
 `HOMEBREW_UPGRADE_GREEDY_CASKS`.
@@ -86,9 +87,11 @@ Still empty means the app self-updated between the two runs — re-run
 `just update`. Now listed means the earlier check read a stale tap:
 `update-brew` refreshes it with `brew update` first, so a bare `brew outdated`
 beforehand answers from whatever the last refresh left behind. The cask really
-is outdated and `just update` will fail again on it, so go to the matching
-section below — read the artifact word in the error, `App` or `Binary` — rather
-than re-running the update.
+is outdated and `just update` will fail again on it, so work the failure rather
+than re-running the update. If the error names an artifact — `App` or `Binary` —
+go to the matching section below; a cask upgrade can also fail for reasons that
+name none (a checksum mismatch, quarantine, a `depends_on macos` bump), and
+those are worked from the error on its own terms.
 
 ## Troubleshooting
 
@@ -241,10 +244,14 @@ Homebrew honours as written (expanding `~`) instead of placing it under `bin/`.
 ls -l "<the path the error printed>"     # usually $(brew --prefix)/bin/<name>
 ```
 
-**Delete it only if the arrow points at the artifact `brew info --cask <cask>`
-lists under Artifacts** — for the app-plus-CLI casks this failure applies to, a
-path inside the app bundle. Compare the two rather than pattern-matching the
-shape from memory, and mind that they print in opposite senses:
+**Delete it only if the arrow points inside the cask's own app bundle** —
+normally the exact path `brew info --cask <cask>` lists under Artifacts, which
+is what to compare against rather than pattern-matching the shape from memory.
+Normally, because `brew info` describes the *tap* version while the stale link
+was made by whichever version last linked it: a cask that moved its binary
+between versions shows the old path in `ls -l` and the new one in `brew info`,
+and the bundle test is the one that survives that. Mind that the two print in
+opposite senses:
 
 ```text
 ls -l      <prefix>/bin/<name> -> /Applications/<App>.app/.../<tool>

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -202,42 +202,54 @@ leftover behind.
 **Do not run `brew reinstall --cask` here.** Its uninstall replays the same
 recorded artifact list (watch it print `Purging files for version
 <old-version>`), so the stale link survives, the install half fails at the same
-point — and the app is now uninstalled. Observed on 2026-08-02 with obsidian:
-recovering from that took the fix below anyway.
+point — and the app is now uninstalled, leaving the link dangling. Observed on
+2026-08-02 with obsidian: recovering from that took the fix below anyway.
 
 **Fix** — drop the stale link, then install. It is a symlink *into* the app
 bundle, not the CLI itself, so removing it loses nothing and the install
 recreates it:
 
+Inspect first — this step is deliberately its own block, because the next one
+deletes:
+
 ```sh
-ls -l "$(brew --prefix)/bin/<name>"      # inspect BEFORE deleting — see below
+ls -l "$(brew --prefix)/bin/<name>"
+```
+
+That prints one of two outputs, and only one of them is the symlink the cask
+owns:
+
+| `ls -l` shows | Meaning | Action |
+| --- | --- | --- |
+| `l...  <name> -> /Applications/<App>.app/...` | the cask's own link | delete it, continue below |
+| `-...  <name>` (a regular file) | not a symlink — someone else's install | stop and investigate |
+
+The arrow target may itself be gone — the reinstall misstep above removes the
+app but leaves this link behind, dangling. `ls -l` never follows the arrow, so
+it prints the same line either way and the action is unchanged.
+
+A third output, `No such file or directory`, is not a case the table covers
+because it depends on where you are rather than on what is on disk. On a first
+attempt it means the path is wrong — stop and re-read the error. On a resumed
+run it usually means your earlier `rm` landed and the install did not: skip the
+`rm` and run the rest.
+
+`ls -l` rather than `readlink` on purpose: `readlink` prints nothing and exits 1
+for BOTH a regular file and a missing path, so it cannot separate the delete-it
+case from either stop case.
+
+A link under `$(brew --cellar)` would be a further shape, but not one this error
+can produce: a formula owning the name makes Homebrew warn and skip the link
+rather than fail.
+
+Once the `ls -l` says the link is the cask's own, the rest runs together:
+
+```sh
 rm "$(brew --prefix)/bin/<name>"
 brew install --cask <cask>
 brew list --cask --versions <cask>       # confirm the new version landed
 ls -l "$(brew --prefix)/bin/<name>"      # confirm the link came back
 ```
-
-**Read the `ls -l` before running the `rm`** — the fix assumes a symlink the
-cask owns, and only one of these three outputs is that:
-
-| `ls -l` shows | Meaning | Action |
-| --- | --- | --- |
-| `l...  <name> -> /Applications/<App>.app/...` | the cask's own link | delete it, continue |
-| `-...  <name>` (a regular file) | not a symlink — someone else's install | stop and investigate |
-| `No such file or directory`, fresh attempt | wrong path | stop; re-read the error |
-| `No such file or directory`, resumed run | you already deleted it, or reinstalled | skip the `rm`, run the rest |
-
-That last row is the common one on a second pass: the `rm` succeeded and the
-install didn't, or the reinstall misstep above already took the link with it.
-Nothing is wrong — go straight to `brew install --cask` and the two checks.
-
-`ls -l` rather than `readlink` on purpose: `readlink` prints nothing and exits 1
-for BOTH a regular file and a missing path, so it cannot tell the delete-it case
-from the two stop cases — and the next line in the block deletes.
-
-A link under `$(brew --cellar)` is a fourth shape, but not one this error can
-produce: a formula owning the name makes Homebrew warn and skip the link rather
-than fail.
 
 `brew install --cask` is correct whether or not the app survived the failure —
 for an explicitly named cask that is already installed, it routes through the

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -192,6 +192,12 @@ macOS only, and distinct from the App conflict above despite the near-identical
 wording — **the remedy above makes this one worse**. Read the artifact word in
 the error: `App` or `Binary`.
 
+Scope: this assumes the CLI ships *inside* the app bundle — the shape
+`brew info --cask <cask>` shows as an absolute source path under Artifacts, and
+the only shape the recovery below is written for. A cask whose `binary` stanza
+names a source relative to the staged path links out of the Caskroom instead,
+and its stale link needs a different comparison than the one used here.
+
 **Symptom** — `just update` dies in `update-brew`, and the upgrade rolls itself
 back first:
 
@@ -263,19 +269,17 @@ your `ls -l` arrow points *at* is the one on the **left** of the `brew info`
 arrow. Comparing the two right-hand sides gives you a path against a bare token
 and reads a perfectly good cask link as foreign.
 
-Anything else belongs to something other than this cask and stops the recovery:
-a regular file, or a symlink pointing anywhere else — another tool's shim, a
-hand-made `ln -s`. The error says nothing about which of these you have:
-Homebrew raises for anything that *resolves* at that path, the cask's own stale
-link included — which is why you are here — excepting only a target resolving
-inside `$(brew --cellar)`, which it attributes to a formula, warns about, and
-skips. So "it is a symlink" is not the test, and neither is the error itself.
-The arrow is.
+Whatever the rule does not select stops the recovery — a regular file, another
+tool's shim, a hand-made `ln -s`. Do not look for a second test to settle those:
+the error cannot, because Homebrew raises for anything that *resolves* at that
+path, the cask's own stale link included — which is why you are here — excepting
+only a target resolving inside `$(brew --cellar)`, which it attributes to a
+formula, warns about, and skips. Nor can "is it a symlink". The arrow is the
+test, and it is the only one.
 
-A **dangling** arrow changes nothing about the test above — apply it exactly as
-written, because `ls -l` never follows the arrow and prints the same line either
-way. An arrow matching the `brew info` path is the cask's link and goes; one
-pointing elsewhere is still someone else's and still stops you, dangling or not.
+A **dangling** arrow does not change it either. `ls -l` never follows the arrow,
+so it prints the same line whether or not the target exists — read where the
+arrow points and apply the rule unchanged.
 
 Danglingness is worth naming only because it is tempting to think it makes the
 link harmless. It does not. It is what the earlier reinstall misstep leaves —

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -63,8 +63,10 @@ brew update && brew outdated --cask
 Still empty means the app self-updated between the two runs — re-run
 `just update`. Now listed means the earlier check read a stale tap:
 `update-brew` refreshes it with `brew update` first, so a bare `brew outdated`
-beforehand answers from whatever the last refresh left behind, and re-running
-`just update` on its own would just reproduce the crash.
+beforehand answers from whatever the last refresh left behind. The cask really
+is outdated and `just update` will fail again on it, so go to the matching
+section below — read the artifact word in the error, `App` or `Binary` — rather
+than re-running the update.
 
 Add `--greedy` and, for `auto_updates` casks, the list grows by every one whose
 bundle is current and whose Homebrew metadata is merely stale. Those are the
@@ -205,6 +207,10 @@ recorded artifact list (watch it print `Purging files for version
 point — and the app is now uninstalled, leaving the link dangling. Observed on
 2026-08-02 with obsidian: recovering from that took the fix below anyway.
 
+The prohibition is about running it *now*, while the link is still there.
+Reinstall becomes the right verb once the `rm` has cleared it — see the end of
+this section.
+
 **Fix** — drop the stale link, then install. It is a symlink *into* the app
 bundle, not the CLI itself, so removing it loses nothing and the install
 recreates it:
@@ -216,13 +222,19 @@ deletes:
 ls -l "$(brew --prefix)/bin/<name>"
 ```
 
-That prints one of two outputs, and only one of them is the symlink the cask
-owns:
+Two of the outputs it can print are in the table below, and only one of those is
+the symlink the cask owns:
 
 | `ls -l` shows | Meaning | Action |
 | --- | --- | --- |
 | `l...  <name> -> /Applications/<App>.app/...` | the cask's own link | delete it, continue below |
 | `-...  <name>` (a regular file) | not a symlink — someone else's install | stop and investigate |
+
+The first row assumes you are still recovering. If you are re-entering this
+block after a run whose two confirmations already passed, the link you are
+looking at is the healthy one the fix just created — stop here. Deleting it now
+would not be undone by the install below, which no-ops on a cask already at the
+tap version.
 
 The arrow target may itself be gone — the reinstall misstep above removes the
 app but leaves this link behind, dangling. `ls -l` never follows the arrow, so
@@ -254,6 +266,21 @@ ls -l "$(brew --prefix)/bin/<name>"      # confirm the link came back
 `brew install --cask` is correct whether or not the app survived the failure —
 for an explicitly named cask that is already installed, it routes through the
 upgrade path — so there is no need to check first and pick a different verb.
+
+**Read the two confirmations; they can fail quietly.** The version line should
+show the version the update was trying to install, and the `ls -l` should show
+the link again. If the version is unchanged, or the `ls -l` prints nothing, the
+install no-opped — Homebrew skips a cask already at the tap version
+(`Not upgrading <cask>, the latest version is already installed`), and skipping
+means nothing was re-linked. Recreate it with:
+
+```sh
+brew reinstall --cask <cask>
+```
+
+Which is safe *here*, and only here. The prohibition further up applies before
+the `rm`, while the stale link is still blocking; once it is gone, reinstall has
+nothing to trip over.
 
 **Finish the update.** As with the App conflict, the rest of `update-brew` never
 ran — re-run `just update` so the direct `brew` calls stay a one-off.

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -50,8 +50,10 @@ Absent `HOMEBREW_UPGRADE_GREEDY` and `HOMEBREW_UPGRADE_GREEDY_CASKS`,
 the `brew bundle install` and `brew upgrade` steps of `update-brew` — so it
 previews the update rather than offering a second opinion, and the cask that
 fails is listed there too. (Set either variable and it stops being a preview:
-`outdated` and `upgrade` honour them, `brew bundle install` does not. If you
-ever see the three disagree, that is the place to look.)
+`outdated` and `upgrade` honour them, `brew bundle install` does not. A
+`greedy: true` option on a Brewfile entry pulls the other way, making `bundle`
+greedier than `outdated` for that one cask. If you ever see the three disagree,
+those are the two places to look.)
 
 A cask that fails the update while `brew outdated --cask` stays quiet has two
 possible causes, and one command tells them apart:
@@ -222,37 +224,45 @@ deletes:
 ls -l "$(brew --prefix)/bin/<name>"
 ```
 
-Two of the outputs it can print are in the table below, and only one of those is
-the symlink the cask owns:
+**Delete it only if the arrow points into the cask's own app bundle** — the
+exact path `brew info --cask <cask>` prints under Artifacts, of the form
+`/Applications/<App>.app/Contents/MacOS/<tool>`. That is the whole rule. It is
+stated as one condition rather than a list of outputs on purpose: this error
+fires for *any* resolving target Homebrew does not recognise as its own, so a
+list of the shapes you might see will always be missing one, and the shapes are
+easy to confuse at a glance.
 
-| `ls -l` shows | Meaning | Action |
-| --- | --- | --- |
-| `l...  <name> -> /Applications/<App>.app/...` | the cask's own link | delete it, continue below |
-| `-...  <name>` (a regular file) | not a symlink — someone else's install | stop and investigate |
+Anything else is someone else's file and stops the recovery — a regular file, or
+a symlink whose arrow points somewhere other than that bundle (another tool's
+shim, a hand-made `ln -s`). Both are as capable of producing this error as the
+stale cask link is, and only the arrow tells them apart.
 
-The first row assumes you are still recovering. If you are re-entering this
-block after a run whose two confirmations already passed, the link you are
-looking at is the healthy one the fix just created — stop here. Deleting it now
-would not be undone by the install below, which no-ops on a cask already at the
-tap version.
+Two readings are not "something else", though, and neither changes the rule:
 
-The arrow target may itself be gone — the reinstall misstep above removes the
-app but leaves this link behind, dangling. `ls -l` never follows the arrow, so
-it prints the same line either way and the action is unchanged.
+- **A dangling arrow still counts as the cask's link.** The reinstall misstep
+  above removes the app while leaving the link behind. `ls -l` never follows the
+  arrow, so it prints the same line whether or not the target exists — judge by
+  where the arrow points, not by whether it resolves.
+- **`No such file or directory` means there is nothing to delete.** On a first
+  attempt the path is wrong — stop and re-read the error. On a resumed run your
+  earlier `rm` landed and the install did not: skip the `rm` and run the rest.
 
-A third output, `No such file or directory`, is not a case the table covers
-because it depends on where you are rather than on what is on disk. On a first
-attempt it means the path is wrong — stop and re-read the error. On a resumed
-run it usually means your earlier `rm` landed and the install did not: skip the
-`rm` and run the rest.
+One more stop condition, unrelated to the output: if you are re-entering this
+block after a run whose two confirmations already passed, the link is the
+healthy one the fix just created. Deleting it now would not be undone by the
+install below, which no-ops on a cask already at the tap version.
 
-`ls -l` rather than `readlink` on purpose: `readlink` prints nothing and exits 1
-for BOTH a regular file and a missing path, so it cannot separate the delete-it
-case from either stop case.
+`ls -l` rather than `readlink` on purpose. `readlink` would answer the delete
+question — it prints the arrow target for a symlink and nothing for anything
+else — but the two "anything else" cases have *different* next steps here, and
+it renders them identically: a regular file and a missing path both print
+nothing and exit 1. `ls -l` separates them, which is what lets the two readings
+above be two readings rather than one shrug.
 
-A link under `$(brew --cellar)` would be a further shape, but not one this error
-can produce: a formula owning the name makes Homebrew warn and skip the link
-rather than fail.
+A target under `$(brew --cellar)` is the one foreign shape this error cannot
+produce: a formula owning the name makes Homebrew warn and skip the link rather
+than fail. Stop for it anyway — the rule above is what you follow, not this
+footnote.
 
 Once the `ls -l` says the link is the cask's own, the rest runs together:
 
@@ -269,10 +279,18 @@ upgrade path — so there is no need to check first and pick a different verb.
 
 **Read the two confirmations; they can fail quietly.** The version line should
 show the version the update was trying to install, and the `ls -l` should show
-the link again. If the version is unchanged, or the `ls -l` prints nothing, the
-install no-opped — Homebrew skips a cask already at the tap version
-(`Not upgrading <cask>, the latest version is already installed`), and skipping
-means nothing was re-linked. Recreate it with:
+the link again. They fail in two different ways, and the pair tells you which:
+
+- **Version right, `ls -l` prints nothing** — the install no-opped. Homebrew
+  skips a cask already at the tap version (`Not upgrading <cask>, the latest
+  version is already installed`), and skipping means nothing was re-linked. The
+  version line still looks correct because it reports what is installed, which
+  in this state already equals the tap version.
+- **Version still the old one** — the install did not run at all, so the no-op
+  above is not the explanation. Scroll back through its output for the real
+  error before doing anything else.
+
+Either way, the link is recreated with:
 
 ```sh
 brew reinstall --cask <cask>


### PR DESCRIPTION
## Summary

- **`docs/homebrew.md` covers a second `just update` cask failure** — "there is
  already a **Binary** at `<prefix>/bin/<name>`" — hit on obsidian 1.12.7 →
  1.13.4. A cask shipping a CLI beside its app has a Binary artifact as well as
  an App; Homebrew replays the *installed* version's recorded artifact list to
  uninstall it, and obsidian 1.12.7's held only App and Zap, so the upgrade
  never unlinked `/opt/homebrew/bin/obsidian` and the new version refused to
  overwrite it.
- **Corrects the existing App-conflict section.** It sold `brew reinstall --cask`
  as the near-universal remedy for a wedged cask. Against this failure its
  uninstall replays that same recorded list, so it removes the app and *then*
  fails at the identical point — verified the hard way on this machine before
  the working fix (clear the stale link, then install) was found.
- **Explains why an `auto_updates` cask is upgraded at all**, since that is the
  surprising part: a non-greedy check suppresses one unless the installed app
  bundle is behind the tap, which Homebrew upgrades by default.
- **Declares `kimi-code` in `Brewfile.personal`** under a new
  `# CLI Tools & Development` block — it had been installed by hand, so
  `brew bundle cleanup --force` removed it on the next `just update`, which is
  the pipeline working as designed. `.claude/rules/brewfile.md` now says where a
  `brew` entry goes in an overlay rather than listing two blocks as the whole
  set.

## Test plan

- [x] `just update` completes end-to-end (exit 0, `brew doctor` clean) — it had
      been failing on obsidian on every run
- [x] obsidian at 1.13.4, `/Applications/Obsidian.app` Info.plist agrees, binary
      symlink recreated, `~/Obsidian` vault untouched
- [x] `just ci` green
- [x] `just lint-brewfile` reports `Brewfile merge OK: personal` with the new
      formula block; duplicate-entry guard still green
- [x] `brew bundle install` reinstalls kimi-code through the declarative path
- [x] Every command claim in the runbook executed or read from the Homebrew
      source rather than inferred — see below

## Verification of doc claims

Every mechanism claim was checked against the installed Homebrew source or run
directly. The ones that changed what the doc says:

| Claim | Established by |
| --- | --- |
| Installed 1.12.7's artifact set lacked Binary | `brew upgrade --cask --debug` ArtifactSet dump |
| `link` raises on a target that *resolves* | `cask/artifact/symlinked.rb`; `Pathname#exist?` false for a dangling link |
| A dangling in-bundle link still blocks | App sorts before Binary (7 vs 8), so the bundle returns before the link is tested |
| `reinstall` replays the installed list | observed: `Purging files for version 1.12.7`, app removed, error unchanged |
| `install --cask` routes to upgrade | `cmd/install.rb:233-241`, `cask/upgrade.rb:65` |
| `auto_updates` suppresses, the version lag causes | `cask/cask.rb#outdated_version` |
| `ls -l` and `brew info` print arrows in opposite senses | both outputs captured live |

## Review

20 rounds. Round 20 was dispositioned rather than fixed per the merge stop rule
in `claude/rules/finding-severity.md` — zero P0, and its single Medium is filed
as #227. The recurring finding class across the series was a claim stated more
broadly than its evidence; that lesson is captured as a new
"Verify every claim about behavior" row in the private `/documentation` skill.

Fixes #225
Fixes #226
