### PR TITLE
docs(homebrew): make the Caskroom fallback a membership test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,6 +261,18 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Fixed
 
+- `docs/homebrew.md`'s Caskroom fallback comparison is a membership test rather
+  than a versioned path
+  ([#227](https://github.com/tgautier/dotfiles/issues/227)). The Binary-conflict
+  section is scoped to casks whose CLI ships inside the app bundle; for the other
+  shape it pointed at
+  `$(brew --prefix)/Caskroom/<cask>/<version>/<source>`, which reintroduced the
+  version-lag trap the in-bundle rule exists to survive — the staged path carries
+  a version, `brew info` describes the tap version, and the stale link was made
+  by whichever version last linked it, so the reader would find no match and stop
+  on their own cask's link. It never said which version to substitute either. Now
+  `$(brew --caskroom)/<cask>/`, mirroring the in-bundle rule it parallels, which
+  is version-agnostic for the same reason.
 - `docs/homebrew.md` covers the second `just update` cask failure, "there is
   already a **Binary** at `<prefix>/bin/<name>`" — hit on obsidian 1.12.7 →
   1.13.4 ([#225](https://github.com/tgautier/dotfiles/issues/225)). A cask that

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -194,10 +194,13 @@ the error: `App` or `Binary`.
 Scope: the recovery below is written for a CLI that ships *inside* the app
 bundle — the shape `brew info --cask <cask>` shows as an absolute source path
 under Artifacts. A cask whose `binary` stanza names a source relative to the
-staged path links out of the Caskroom instead, and `brew info` prints that
-relative string bare. Only the comparison changes: check the `ls -l` arrow
-against `$(brew --prefix)/Caskroom/<cask>/<version>/<the source brew info
-prints>`, and the rest of the section applies unaltered.
+staged path links out of the Caskroom instead. Only the comparison changes:
+check that the `ls -l` arrow points inside `$(brew --caskroom)/<cask>/` — the
+same membership test, with the cask's Caskroom directory standing in for the app
+bundle — and the rest of the section applies unaltered. Membership rather than a
+full path for the same reason it is used above: the staged path carries a
+version, and the stale link was made by whichever version last linked it, not
+the one `brew info` describes.
 
 **Symptom** — `just update` dies in `update-brew`, and the upgrade rolls itself
 back first:

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -194,8 +194,9 @@ the error: `App` or `Binary`.
 Scope: the recovery below is written for a CLI that ships *inside* the app
 bundle — the shape `brew info --cask <cask>` shows as an absolute source path
 under Artifacts. A cask whose `binary` stanza names a source relative to the
-staged path links out of the Caskroom instead — you have that shape when the
-Artifacts source prints as a bare relative string rather than an absolute path.
+staged path links out of the Caskroom instead — you have that shape whenever the
+Artifacts source is anything other than a path inside the app bundle, whether a
+bare relative string or an absolute path under the Caskroom.
 Only the comparison changes: check that the `ls -l` arrow points inside
 `$(brew --caskroom)/<cask>/` — the same membership test, with the cask's
 Caskroom directory standing in for the app bundle — and the rest of the section

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -192,17 +192,16 @@ wording — **the remedy above makes this one worse**. Read the artifact word in
 the error: `App` or `Binary`.
 
 Scope: the recovery below is written for a CLI that ships *inside* the app
-bundle — the shape `brew info --cask <cask>` shows as an absolute source path
-under Artifacts. A cask whose `binary` stanza names a source relative to the
-staged path links out of the Caskroom instead — you have that shape whenever the
-Artifacts source is anything other than a path inside the app bundle, whether a
-bare relative string or an absolute path under the Caskroom.
-Only the comparison changes: check that the `ls -l` arrow points inside
-`$(brew --caskroom)/<cask>/` — the same membership test, with the cask's
-Caskroom directory standing in for the app bundle — and the rest of the section
-applies unaltered. Membership rather than a full path for the same reason the
-rule below uses it: the staged path carries a version, and the stale link was
-made by whichever version last linked it, not the one `brew info` describes.
+bundle — meaning the source path `brew info --cask <cask>` lists under Artifacts
+sits within `<App>.app`. Anything else links out of the Caskroom instead,
+whether it prints as a bare relative string or as an absolute path under
+`$(brew --caskroom)`. Only the comparison changes for those: check that the
+`ls -l` arrow points inside `$(brew --caskroom)/<cask>/`, the same membership
+test with the cask's Caskroom directory standing in for the app bundle, and the
+rest of the section applies unaltered. Membership rather than a full path for
+the same reason the rule below uses it: the staged path carries a version, and
+the stale link was made by whichever version last linked it, not the one
+`brew info` describes.
 
 **Symptom** — `just update` dies in `update-brew`, and the upgrade rolls itself
 back first:

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -194,13 +194,14 @@ the error: `App` or `Binary`.
 Scope: the recovery below is written for a CLI that ships *inside* the app
 bundle — the shape `brew info --cask <cask>` shows as an absolute source path
 under Artifacts. A cask whose `binary` stanza names a source relative to the
-staged path links out of the Caskroom instead. Only the comparison changes:
-check that the `ls -l` arrow points inside `$(brew --caskroom)/<cask>/` — the
-same membership test, with the cask's Caskroom directory standing in for the app
-bundle — and the rest of the section applies unaltered. Membership rather than a
-full path for the same reason it is used above: the staged path carries a
-version, and the stale link was made by whichever version last linked it, not
-the one `brew info` describes.
+staged path links out of the Caskroom instead — you have that shape when the
+Artifacts source prints as a bare relative string rather than an absolute path.
+Only the comparison changes: check that the `ls -l` arrow points inside
+`$(brew --caskroom)/<cask>/` — the same membership test, with the cask's
+Caskroom directory standing in for the app bundle — and the rest of the section
+applies unaltered. Membership rather than a full path for the same reason the
+rule below uses it: the staged path carries a version, and the stale link was
+made by whichever version last linked it, not the one `brew info` describes.
 
 **Symptom** — `just update` dies in `update-brew`, and the upgrade rolls itself
 back first:


### PR DESCRIPTION
## Summary

- **The Binary-conflict section's Caskroom fallback is a membership test**, not a
  versioned path. It pointed at
  `$(brew --prefix)/Caskroom/<cask>/<version>/<source>`, which reintroduced the
  version-lag trap the in-bundle rule exists to survive: the staged path carries
  a version, `brew info` describes the *tap* version, and the stale link was made
  by whichever version last linked it. A reader would find no match and stop on
  their own cask's link — and the paragraph never said which version to
  substitute. Now `$(brew --caskroom)/<cask>/`, which is version-agnostic for the
  same reason the in-bundle rule is.
- **The in-scope shape is defined once, by bundle membership.** It had been
  keyed on "an absolute source path", which a `binary "#{staged_path}/<tool>"`
  cask also prints — so that reader self-classified as in-scope, failed the
  app-bundle test, and stopped, even though the fallback in the same paragraph
  was what resolved them. The two printed forms are now examples rather than the
  test.

## Test plan

- [x] `just ci` green
- [x] `brew --caskroom` verified to exist and resolve to `/opt/homebrew/Caskroom`
      — run, not assumed
- [x] No stale reference to the versioned comparison anywhere in the tree
- [x] The paragraph states one discriminator, not two phrasings of one

## Review

Five rounds; the last two both returned "No issues found". The recurring finding
was the same restatement drift the parent PR hit — a criterion written in two
places, refined in one — and it settled the same way, by stating it once.

Fixes #227
