### PR TITLE
chore(mise): bump elixir 1.20.2 → 1.20.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,7 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Changed
 
+- Elixir 1.20.2 → 1.20.3 in `config/mise/config.toml`; OTP-29 suffix unchanged.
 - The stale-symlink sweep is split in two: `_scan-stale-symlinks` finds and
   prints stale links, `cleanup-symlinks` confirms and removes them. The scan
   honours a `CLEANUP_HOME` override so fixtures can drive it against a temp

--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -7,7 +7,7 @@ dart = { version = "3.12.2", url = "https://storage.googleapis.com/dart-archive/
 deno = "2.9.4"
 # elixir's -otp-N suffix must match erlang's OTP major. Bump these two as a
 # pair, never independently.
-elixir = "1.20.2-otp-29"
+elixir = "1.20.3-otp-29"
 erlang = "29.0"
 "vfox:mise-plugins/vfox-flutter" = "3.44.8"
 go = "1.26.5"


### PR DESCRIPTION
## Summary

- Bump Elixir from 1.20.2 to 1.20.3 in `config/mise/config.toml`; OTP-29 suffix unchanged, erlang stays at 29.0.

## Test plan

- [x] `just ci` passes
- [x] `mise install elixir` picks up 1.20.3