### PR TITLE
feat(chezmoi): add tmux canary source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
           # `lint-cleanup-symlinks` in the "Run all checks" step below.
           sudo apt-get install -y shellcheck jq zsh
           npm install -g markdownlint-cli2
+          mise install chezmoi@2.72.0
+          mise use -g chezmoi@2.72.0
+          echo "$(mise where chezmoi@2.72.0)/bin" >> "$GITHUB_PATH"
 
       - name: Run all checks
         run: just ci

--- a/Justfile
+++ b/Justfile
@@ -3,7 +3,7 @@
 zsh_excludes := "SC1036,SC1087,SC1090,SC2128,SC2145,SC2154,SC2155,SC2168,SC2179,SC2206,SC2211,SC2296"
 
 # Run all CI checks
-ci: lint-shell lint-markdown lint-brewfile lint-mise lint-just lint-rcrc lint-cleanup-symlinks lint-via-private
+ci: lint-shell lint-markdown lint-brewfile lint-mise lint-just lint-rcrc lint-cleanup-symlinks test-chezmoi-canary lint-via-private
 
 # Assert `rcrc` resolves the way README documents, on both halves of the
 # override contract: DOTFILES_DIRS, which reaches the operator's real $HOME
@@ -128,6 +128,26 @@ lint-rcrc:
         exit 1
     fi
     echo "rcrc OK (defaults, both overrides, slash normalisation, root value, EXCLUDES sourcing, no leaks)"
+
+[doc("Render the chezmoi canary in an isolated HOME and verify source equivalence plus idempotence")]
+test-chezmoi-canary:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v chezmoi >/dev/null || { echo "chezmoi is required for the canary guard" >&2; exit 1; }
+    test -f home/dot_tmux.conf
+    cmp -s tmux.conf home/dot_tmux.conf
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    : > "$tmp/config.toml"
+    mkdir -p "$tmp/home"
+    chezmoi --config "$tmp/config.toml" --source "$PWD/home" --destination "$tmp/home" apply
+    cmp -s tmux.conf "$tmp/home/.tmux.conf"
+    diff_output=$(chezmoi --config "$tmp/config.toml" --source "$PWD/home" --destination "$tmp/home" diff)
+    test -z "$diff_output"
+    chezmoi --config "$tmp/config.toml" --source "$PWD/home" --destination "$tmp/home" apply
+    diff_output=$(chezmoi --config "$tmp/config.toml" --source "$PWD/home" --destination "$tmp/home" diff)
+    test -z "$diff_output"
+    echo "chezmoi canary OK (equivalent render, second apply is a no-op)"
 
 # Assert every in-body `just <recipe>` call names a recipe that exists here.
 # Those calls are opaque shell strings to just, so nothing else catches a typo:

--- a/docs/chezmoi-inventory.md
+++ b/docs/chezmoi-inventory.md
@@ -41,8 +41,13 @@ criteria are demonstrated.
 ## Evidence still required
 
 1. Capture the live rcm target map on each supported platform.
-2. Add one thematic source slice under `home/` and compare `chezmoi diff` with
-   the recorded rcm targets.
-3. Prove a second apply is a no-op in an isolated HOME.
-4. Record backup and rollback commands before changing `just link` or
+2. Record backup and rollback commands before changing `just link` or
    `just setup`.
+
+## Canary evidence
+
+The `tmux.conf` slice is represented by `home/dot_tmux.conf`. On 2026-08-07 it
+rendered byte-for-byte identical to the current rcm source in an isolated HOME,
+and a second `chezmoi apply` produced no changes. This is shadow evidence only;
+rcm remains the active deployment owner until the complete target set has
+equivalent evidence.

--- a/home/dot_tmux.conf
+++ b/home/dot_tmux.conf
@@ -1,0 +1,140 @@
+# Prefix: Ctrl-a (more ergonomic than default Ctrl-b)
+unbind C-b
+set -g prefix C-a
+bind C-a send-prefix
+
+# True color and 256-color support
+if-shell 'infocmp -x tmux-256color >/dev/null 2>&1' \
+  'set -g default-terminal "tmux-256color"' \
+  'set -g default-terminal "screen-256color"'
+set -ag terminal-overrides ",xterm-256color:RGB"
+set -ag terminal-overrides ",xterm-ghostty:RGB"
+
+# Start windows and panes at 1 (matches keyboard layout)
+set -g base-index 1
+setw -g pane-base-index 1
+
+# Renumber windows when one is closed
+set -g renumber-windows on
+
+# Increase scrollback
+set -g history-limit 50000
+
+# Faster escape time (better for vim/neovim)
+set -sg escape-time 0
+
+# Longer display time for messages
+set -g display-time 2000
+
+# Enable mouse support
+set -g mouse on
+
+# Vi mode for copy
+setw -g mode-keys vi
+bind -T copy-mode-vi v send-keys -X begin-selection
+bind -T copy-mode-vi C-v send-keys -X rectangle-toggle
+
+# Platform-aware clipboard: macOS=pbcopy, WSL=clip.exe, Linux=xclip
+if-shell "uname | grep -q Darwin" \
+  "bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel 'pbcopy'" \
+  ""
+if-shell "grep -qi microsoft /proc/version 2>/dev/null" \
+  "bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel 'clip.exe'" \
+  ""
+if-shell "uname | grep -q Linux && ! grep -qi microsoft /proc/version 2>/dev/null" \
+  "bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel 'xclip -in -selection clipboard'" \
+  ""
+
+# Intuitive splits (open in current path)
+bind | split-window -h -c "#{pane_current_path}"
+bind - split-window -v -c "#{pane_current_path}"
+unbind '"'
+unbind %
+
+# New windows open in current path
+bind c new-window -c "#{pane_current_path}"
+
+# Vi-style pane navigation
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R
+
+# Pane resizing (repeatable)
+bind -r H resize-pane -L 5
+bind -r J resize-pane -D 5
+bind -r K resize-pane -U 5
+bind -r L resize-pane -R 5
+
+# Window navigation
+bind -r C-h previous-window
+bind -r C-l next-window
+
+# Swap windows
+bind -r "<" swap-window -d -t -1
+bind -r ">" swap-window -d -t +1
+
+# Quick reload
+bind r source-file ~/.tmux.conf \; display "Config reloaded"
+
+# Session switching
+bind s choose-tree -sZ
+
+# Break pane to new window / join pane from another window
+bind B break-pane
+bind M choose-window "join-pane -h -s '%%'"
+
+# Toggle synchronize panes (type in all panes at once)
+bind S setw synchronize-panes
+
+# Focus events (for vim autoread etc.)
+set -g focus-events on
+
+# Activity monitoring (subtle, no bell)
+setw -g monitor-activity on
+set -g visual-activity off
+
+# ── Status bar ──────────────────────────────────────────────────────
+
+set -g status-position top
+set -g status-interval 5
+set -g status-justify left
+
+# Minimal, clean aesthetic
+set -g status-style "bg=default"
+set -g message-style "bg=default,fg=yellow"
+set -g message-command-style "bg=default,fg=yellow"
+
+# Left: session name
+set -g status-left-length 40
+set -g status-left "#[fg=blue,bold] #S #[fg=brightblack,nobold]"
+
+# Right: git branch + time
+set -g status-right-length 60
+set -g status-right "#[fg=brightblack]#(cd #{q:pane_current_path} && git rev-parse --abbrev-ref HEAD 2>/dev/null) #[fg=white]%H:%M "
+
+# Window tabs
+setw -g window-status-format "#[fg=brightblack] #I #W "
+setw -g window-status-current-format "#[fg=cyan,bold] #I #W "
+setw -g window-status-activity-style "fg=yellow"
+setw -g window-status-separator ""
+
+# ── Pane styling ────────────────────────────────────────────────────
+
+set -g pane-border-style "fg=brightblack"
+set -g pane-active-border-style "fg=blue"
+set -g pane-border-lines heavy
+
+# Dim inactive panes slightly
+set -g window-style "fg=colour245"
+set -g window-active-style "fg=white"
+
+# ── Popup / display ────────────────────────────────────────────────
+
+# Popup scratch terminal (prefix + t)
+bind t display-popup -E -w 80% -h 80% -d "#{pane_current_path}"
+
+# Popup lazygit (prefix + g)
+bind g if-shell "command -v lazygit >/dev/null 2>&1" \
+  'display-popup -E -w 90% -h 90% -d "#{pane_current_path}" "lazygit"' \
+  'display-message "lazygit not installed (required for prefix+g)"'


### PR DESCRIPTION
Implements the first shadow-apply canary for #232.

- Adds an exact chezmoi source for tmux.conf under home/
- Adds isolated-HOME equivalence and no-op apply checks to just ci
- Installs pinned chezmoi in CI through mise
- Records the canary evidence without changing rcm ownership

The gitconfig canary was intentionally rejected because it would duplicate private signing identity data in the public source.

Validation:
- Full enforced pre-commit hook passed
- just test-chezmoi-canary passed
- Roborev job 3005 (codex): no issues found

Addresses #232