### PR TITLE
feat(chezmoi): add zshrc canary source

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -134,14 +134,19 @@ test-chezmoi-canary:
     #!/usr/bin/env bash
     set -euo pipefail
     command -v chezmoi >/dev/null || { echo "chezmoi is required for the canary guard" >&2; exit 1; }
-    test -f home/dot_tmux.conf
-    cmp -s tmux.conf home/dot_tmux.conf
+    for pair in 'tmux.conf:dot_tmux.conf' 'zshrc:dot_zshrc'; do
+        source=${pair%%:*}
+        chezmoi_file=${pair##*:}
+        test -f "home/$chezmoi_file"
+        cmp -s "$source" "home/$chezmoi_file"
+    done
     tmp=$(mktemp -d)
     trap 'rm -rf "$tmp"' EXIT
     : > "$tmp/config.toml"
     mkdir -p "$tmp/home"
     chezmoi --config "$tmp/config.toml" --source "$PWD/home" --destination "$tmp/home" apply
     cmp -s tmux.conf "$tmp/home/.tmux.conf"
+    cmp -s zshrc "$tmp/home/.zshrc"
     diff_output=$(chezmoi --config "$tmp/config.toml" --source "$PWD/home" --destination "$tmp/home" diff)
     test -z "$diff_output"
     chezmoi --config "$tmp/config.toml" --source "$PWD/home" --destination "$tmp/home" apply

--- a/docs/chezmoi-inventory.md
+++ b/docs/chezmoi-inventory.md
@@ -46,8 +46,8 @@ criteria are demonstrated.
 
 ## Canary evidence
 
-The `tmux.conf` slice is represented by `home/dot_tmux.conf`. On 2026-08-07 it
-rendered byte-for-byte identical to the current rcm source in an isolated HOME,
-and a second `chezmoi apply` produced no changes. This is shadow evidence only;
-rcm remains the active deployment owner until the complete target set has
-equivalent evidence.
+The `tmux.conf` and `zshrc` slices are represented by `home/dot_tmux.conf` and
+`home/dot_zshrc`. On 2026-08-07 they rendered byte-for-byte identical to the
+current rcm sources in an isolated HOME, and a second `chezmoi apply` produced
+no changes. This is shadow evidence only; rcm remains the active deployment
+owner until the complete target set has equivalent evidence.

--- a/home/dot_zshrc
+++ b/home/dot_zshrc
@@ -1,0 +1,73 @@
+GPG_TTY=$(tty)
+export GPG_TTY
+
+setopt EXTENDED_HISTORY
+setopt INC_APPEND_HISTORY
+setopt SHARE_HISTORY
+
+bindkey -e
+autoload -U edit-command-line;
+zle -N edit-command-line;
+bindkey '^F' edit-command-line # Edit current line with C-f
+bindkey '^[[1;9D' backward-word # Alt-Left
+bindkey '^[[1;9C' forward-word # Alt-Right
+bindkey '^[[3~' delete-char # Delete
+bindkey '^[[Z' reverse-menu-complete # Shift-Tab
+bindkey '^[[A' up-line-or-search # Arrow up
+bindkey '^[[B' down-line-or-search # Arrow down
+
+_currentEnvironmentName() {
+  if [ -z "${CURRENT_ENVIRONMENT_NAME}" ]; then
+    echo ""
+  else
+    echo "%{\e[38;5;250m%}[${CURRENT_ENVIRONMENT_NAME}]%{\e[39m%} "
+  fi
+}
+
+# Cache kubectl context to avoid expensive checks on every prompt render
+_kube_context_cache=""
+_kube_context_cache_time=0
+
+_currentKubernetesContextName() {
+  local current_time
+  current_time=$(date +%s)
+  local cache_age=$((current_time - _kube_context_cache_time))
+
+  # Refresh cache every 30 seconds
+  if [[ $cache_age -gt 30 ]]; then
+    _kube_context_cache=$(kubectl config current-context 2> /dev/null)
+    _kube_context_cache_time=$current_time
+  fi
+
+  if [ -z "${_kube_context_cache}" ] || [ "${_kube_context_cache}" = "docker-desktop" ]; then
+    echo ""
+  else
+    echo "%{%F{1}%} ${_kube_context_cache}%{%f%} "
+  fi
+}
+
+setopt PROMPT_SUBST
+export PROMPT='%B%c%b%f$(_currentKubernetesContextName)$(_currentEnvironmentName) %(?.%F{24}❯%f.%F{198}❯%f) '
+
+source ${HOME}/.zsh/zaliases
+source ${HOME}/.zsh/zcompletion
+
+# WSL-specific optimizations
+if [[ $PLATFORM == "wsl" ]]; then
+  # Disable Windows PATH pollution (optional - uncomment if needed)
+  # This can significantly speed up shell startup in WSL
+  # export PATH=$(echo $PATH | tr ':' '\n' | grep -v "/mnt/" | tr '\n' ':' | sed 's/:$//')
+
+  # Set umask for better Windows interop
+  umask 022
+fi
+
+[[ -r ${HOME}/.zshrc.local ]] && source ${HOME}/.zshrc.local
+[[ -r ${HOME}/.config/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh ]] && source ${HOME}/.config/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+
+# Initialize mise (version manager) if available
+if command -v mise &> /dev/null; then
+  eval "$(mise activate zsh)"
+elif [[ -x "${HOME}/.local/bin/mise" ]]; then
+  eval "$($HOME/.local/bin/mise activate zsh)"
+fi


### PR DESCRIPTION
Extends the chezmoi shadow migration for #232 with an exact zshrc source.

- Adds home/dot_zshrc
- Extends isolated-HOME equivalence and no-op checks to zshrc
- Keeps rcm as the active owner; no setup/link cutover

Validation:
- Enforced signed pre-commit hook passed
- just test-chezmoi-canary passed
- Roborev job 3009 (codex): no issues found

Addresses #232