### PR TITLE
feat(chezmoi): add psqlrc and gitignore canaries

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -134,7 +134,7 @@ test-chezmoi-canary:
     #!/usr/bin/env bash
     set -euo pipefail
     command -v chezmoi >/dev/null || { echo "chezmoi is required for the canary guard" >&2; exit 1; }
-    for pair in 'tmux.conf:dot_tmux.conf' 'zshrc:dot_zshrc' 'zshenv:dot_zshenv' 'zprofile:dot_zprofile'; do
+    for pair in 'tmux.conf:dot_tmux.conf' 'zshrc:dot_zshrc' 'zshenv:dot_zshenv' 'zprofile:dot_zprofile' 'psqlrc:dot_psqlrc' 'gitignore:dot_gitignore'; do
         source=${pair%%:*}
         chezmoi_file=${pair##*:}
         test -f "home/$chezmoi_file"
@@ -149,6 +149,8 @@ test-chezmoi-canary:
     cmp -s zshrc "$tmp/home/.zshrc"
     cmp -s zshenv "$tmp/home/.zshenv"
     cmp -s zprofile "$tmp/home/.zprofile"
+    cmp -s psqlrc "$tmp/home/.psqlrc"
+    cmp -s gitignore "$tmp/home/.gitignore"
     diff_output=$(chezmoi --config "$tmp/config.toml" --source "$PWD/home" --destination "$tmp/home" diff)
     test -z "$diff_output"
     chezmoi --config "$tmp/config.toml" --source "$PWD/home" --destination "$tmp/home" apply

--- a/docs/chezmoi-inventory.md
+++ b/docs/chezmoi-inventory.md
@@ -46,8 +46,9 @@ criteria are demonstrated.
 
 ## Canary evidence
 
-The `tmux.conf`, `zshrc`, `zshenv`, and `zprofile` slices are represented under
-`home/`. On 2026-08-07 they rendered byte-for-byte identical to the current rcm
-sources in an isolated HOME, and a second `chezmoi apply` produced no changes.
-This is shadow evidence only; rcm remains the active deployment owner until the
-complete target set has equivalent evidence.
+The `tmux.conf`, `zshrc`, `zshenv`, `zprofile`, `psqlrc`, and `gitignore` slices
+are represented under `home/`. On 2026-08-07 they rendered byte-for-byte
+identical to the current rcm sources in an isolated HOME, and a second
+`chezmoi apply` produced no changes. This is shadow evidence only; rcm remains
+the active deployment owner until the complete target set has equivalent
+evidence.

--- a/home/dot_gitignore
+++ b/home/dot_gitignore
@@ -1,0 +1,26 @@
+# OS
+*.DS_Store
+Thumbs.db
+
+# Editors
+*.swp
+*.swo
+*~
+.idea/
+.vscode/
+*.sublime-workspace
+*.sublime-project
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# Secrets & certificates
+*.pem
+*.key
+*.p12
+*.pfx
+
+# Claude Code
+.claude/settings.local.json

--- a/home/dot_psqlrc
+++ b/home/dot_psqlrc
@@ -1,0 +1,9 @@
+\set QUIET 1
+\pset border 2
+\pset linestyle unicode
+\pset null ¤
+\set PROMPT1 '%[%033[33;1m%]%x%[%033[0m%]%[%033[1m%]%/%[%033[0m%]%R%# '
+\pset pager off
+\timing
+\pset format wrapped
+\set QUIET 0


### PR DESCRIPTION
Extends the chezmoi shadow migration for #232 with exact psqlrc and gitignore sources.

- Expands isolated-HOME equivalence and no-op checks
- Keeps rcm as active owner

Validation:
- Enforced signed pre-commit hook passed
- just test-chezmoi-canary passed
- Roborev job 3013 (codex): no issues found

Addresses #232