### PR TITLE
feat(chezmoi): add ghostty config canary

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -144,6 +144,7 @@ test-chezmoi-canary:
         test -x "bin/$name"
         cmp -s "bin/$name" "home/dot_bin/executable_$name"
     done
+    cmp -s config/ghostty/config home/dot_config/ghostty/config
     tmp=$(mktemp -d)
     trap 'rm -rf "$tmp"' EXIT
     : > "$tmp/config.toml"
@@ -159,6 +160,7 @@ test-chezmoi-canary:
         cmp -s "bin/$name" "$tmp/home/.bin/$name"
         test -x "$tmp/home/.bin/$name"
     done
+    cmp -s config/ghostty/config "$tmp/home/.config/ghostty/config"
     diff_output=$(chezmoi --config "$tmp/config.toml" --source "$PWD/home" --destination "$tmp/home" diff)
     test -z "$diff_output"
     chezmoi --config "$tmp/config.toml" --source "$PWD/home" --destination "$tmp/home" apply

--- a/docs/chezmoi-inventory.md
+++ b/docs/chezmoi-inventory.md
@@ -47,8 +47,8 @@ criteria are demonstrated.
 ## Canary evidence
 
 The `tmux.conf`, `zshrc`, `zshenv`, `zprofile`, `psqlrc`, `gitignore`, and four
-public executable slices are represented under `home/`, with executable-mode
-checks. On 2026-08-07 they rendered byte-for-byte
+public executable slices and Ghostty config are represented under `home/`, with
+executable-mode checks. On 2026-08-07 they rendered byte-for-byte
 identical to the current rcm sources in an isolated HOME, and a second
 `chezmoi apply` produced no changes. This is shadow evidence only; rcm remains
 the active deployment owner until the complete target set has equivalent

--- a/home/dot_config/ghostty/config
+++ b/home/dot_config/ghostty/config
@@ -1,0 +1,36 @@
+# Font
+font-family = Fira Code
+font-size = 13
+font-feature = -liga
+font-feature = -dlig
+font-feature = -calt
+
+# Theme — auto light/dark switching
+theme = light:iTerm2 Solarized Light,dark:iTerm2 Solarized Dark
+
+# Window
+window-height = 50
+window-width = 180
+window-padding-x = 4
+window-padding-y = 4
+window-decoration = auto
+
+# New windows/tabs/splits open in $HOME instead of inheriting the current directory
+window-inherit-working-directory = false
+tab-inherit-working-directory = false
+split-inherit-working-directory = false
+working-directory = home
+
+# Cursor
+cursor-style = block
+
+# Shell integration (built-in for zsh, no-cursor preserves block cursor)
+shell-integration = zsh
+shell-integration-features = no-cursor
+
+# Input — Option key produces accents/special characters, not Alt escape sequences
+macos-option-as-alt = false
+
+# Keybindings — Alt+Left/Right for word navigation (explicit keybinds still work)
+keybind = alt+left=esc:b
+keybind = alt+right=esc:f


### PR DESCRIPTION
Extends the chezmoi shadow migration for #232 with the exact Ghostty config source.

- Adds home/dot_config/ghostty/config
- Verifies byte equivalence and isolated-HOME rendering
- Keeps rcm as active owner

Validation:
- Enforced signed pre-commit hook passed
- just test-chezmoi-canary passed
- Roborev job 3030 (codex): no issues found

Addresses #232