### PR TITLE
feat(chezmoi): add agignore and editorconfig canaries

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -134,7 +134,7 @@ test-chezmoi-canary:
     #!/usr/bin/env bash
     set -euo pipefail
     command -v chezmoi >/dev/null || { echo "chezmoi is required for the canary guard" >&2; exit 1; }
-    for pair in 'tmux.conf:dot_tmux.conf' 'zshrc:dot_zshrc' 'zshenv:dot_zshenv' 'zprofile:dot_zprofile' 'psqlrc:dot_psqlrc' 'gitignore:dot_gitignore'; do
+    for pair in 'tmux.conf:dot_tmux.conf' 'zshrc:dot_zshrc' 'zshenv:dot_zshenv' 'zprofile:dot_zprofile' 'psqlrc:dot_psqlrc' 'gitignore:dot_gitignore' 'agignore:dot_agignore' 'editorconfig:dot_editorconfig'; do
         source=${pair%%:*}
         chezmoi_file=${pair##*:}
         test -f "home/$chezmoi_file"
@@ -156,6 +156,8 @@ test-chezmoi-canary:
     cmp -s zprofile "$tmp/home/.zprofile"
     cmp -s psqlrc "$tmp/home/.psqlrc"
     cmp -s gitignore "$tmp/home/.gitignore"
+    cmp -s agignore "$tmp/home/.agignore"
+    cmp -s editorconfig "$tmp/home/.editorconfig"
     for name in kshow kseal op-ssh-sign obsidian; do
         cmp -s "bin/$name" "$tmp/home/.bin/$name"
         test -x "$tmp/home/.bin/$name"

--- a/docs/chezmoi-inventory.md
+++ b/docs/chezmoi-inventory.md
@@ -45,7 +45,8 @@ criteria are demonstrated.
 
 ## Canary evidence
 
-The `tmux.conf`, `zshrc`, `zshenv`, `zprofile`, `psqlrc`, `gitignore`, and four
+The `tmux.conf`, `zshrc`, `zshenv`, `zprofile`, `psqlrc`, `gitignore`, `agignore`,
+`editorconfig`, and four
 public executable slices and Ghostty config are represented under `home/`, with
 executable-mode checks. On 2026-08-07 they rendered byte-for-byte
 identical to the current rcm sources in an isolated HOME, and a second

--- a/home/dot_agignore
+++ b/home/dot_agignore
@@ -1,0 +1,5 @@
+.git/
+bower_components/
+build/
+node_modules/
+deps/

--- a/home/dot_editorconfig
+++ b/home/dot_editorconfig
@@ -1,0 +1,19 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab
+
+# Git config uses tabs by convention
+[gitconfig]
+indent_style = tab


### PR DESCRIPTION
Adds exact chezmoi sources for agignore and editorconfig and extends the isolated-HOME canary checks.

Validation: signed hook, just test-chezmoi-canary, Roborev job 3040.