### PR TITLE
feat(chezmoi): add zlogin canary

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -134,7 +134,7 @@ test-chezmoi-canary:
     #!/usr/bin/env bash
     set -euo pipefail
     command -v chezmoi >/dev/null || { echo "chezmoi is required for the canary guard" >&2; exit 1; }
-    for pair in 'tmux.conf:dot_tmux.conf' 'zshrc:dot_zshrc' 'zshenv:dot_zshenv' 'zprofile:dot_zprofile' 'psqlrc:dot_psqlrc' 'gitignore:dot_gitignore' 'agignore:dot_agignore' 'editorconfig:dot_editorconfig'; do
+    for pair in 'tmux.conf:dot_tmux.conf' 'zshrc:dot_zshrc' 'zshenv:dot_zshenv' 'zprofile:dot_zprofile' 'zlogin:dot_zlogin' 'psqlrc:dot_psqlrc' 'gitignore:dot_gitignore' 'agignore:dot_agignore' 'editorconfig:dot_editorconfig'; do
         source=${pair%%:*}
         chezmoi_file=${pair##*:}
         test -f "home/$chezmoi_file"
@@ -154,6 +154,7 @@ test-chezmoi-canary:
     cmp -s zshrc "$tmp/home/.zshrc"
     cmp -s zshenv "$tmp/home/.zshenv"
     cmp -s zprofile "$tmp/home/.zprofile"
+    cmp -s zlogin "$tmp/home/.zlogin"
     cmp -s psqlrc "$tmp/home/.psqlrc"
     cmp -s gitignore "$tmp/home/.gitignore"
     cmp -s agignore "$tmp/home/.agignore"

--- a/docs/chezmoi-inventory.md
+++ b/docs/chezmoi-inventory.md
@@ -45,8 +45,8 @@ criteria are demonstrated.
 
 ## Canary evidence
 
-The `tmux.conf`, `zshrc`, `zshenv`, `zprofile`, `psqlrc`, `gitignore`, `agignore`,
-`editorconfig`, and four
+The `tmux.conf`, `zshrc`, `zshenv`, `zprofile`, `zlogin`, `psqlrc`, `gitignore`,
+`agignore`, `editorconfig`, and four
 public executable slices and Ghostty config are represented under `home/`, with
 executable-mode checks. On 2026-08-07 they rendered byte-for-byte
 identical to the current rcm sources in an isolated HOME, and a second

--- a/home/dot_zlogin
+++ b/home/dot_zlogin
@@ -1,0 +1,32 @@
+# Precompile the completion dump so the next login sources the compiled
+# form. The .zwc must be compiled from the real file in place: zsh only
+# uses ~/.zcompdump.zwc when it embeds that exact path, so a temp-copy
+# compile would be silently rejected.
+#
+# Serialize with a non-blocking flock. Multiple login shells starting
+# together (tmux panes, session restore) would otherwise race inside
+# zcompile's unlink()+open(O_CREAT, 0444) on the shared .zwc, and the loser
+# aborts with "can't write zwc file" — a spurious error that leaks into the
+# interactive session. The flock is fd-based and auto-releases when this
+# background shell exits, so no stale lock can wedge future recompiles.
+#
+# zsh/system is optional at build time. When it is missing we still compile —
+# unserialized — rather than skip precompilation forever: the race is cosmetic,
+# losing the .zwc entirely is a permanent startup cost.
+#
+# Both branches drop zcompile's stderr. Precompilation is a best-effort
+# optimization and this whole block is a disowned background job, so any
+# failure (unwritable $HOME, full disk) would otherwise surface as async noise
+# in an unrelated interactive prompt — the exact thing this change removes.
+{
+  zcompdump="${HOME}/.zcompdump"
+  if [[ -s "$zcompdump" && (! -s "${zcompdump}.zwc" || "$zcompdump" -nt "${zcompdump}.zwc") ]]; then
+    if zmodload zsh/system 2>/dev/null; then
+      lock="${zcompdump}.zwc.lock"
+      : >> "$lock" 2>/dev/null
+      zsystem flock -t 0 "$lock" 2>/dev/null && zcompile "$zcompdump" 2>/dev/null
+    else
+      zcompile "$zcompdump" 2>/dev/null
+    fi
+  fi
+} &!


### PR DESCRIPTION
## Summary
- add the zlogin source to the chezmoi shadow tree
- verify source/render equivalence and idempotent apply
- record zlogin in the migration evidence

## Validation
- `just test-chezmoi-canary`
- signed commit hook / full local lint suite
- Roborev job 3042 (Codex): no issues found