### PR TITLE
docs(chezmoi): defer empty git template placeholder

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -134,7 +134,7 @@ test-chezmoi-canary:
     #!/usr/bin/env bash
     set -euo pipefail
     command -v chezmoi >/dev/null || { echo "chezmoi is required for the canary guard" >&2; exit 1; }
-    for pair in 'tmux.conf:dot_tmux.conf' 'zshrc:dot_zshrc' 'zshenv:dot_zshenv' 'zprofile:dot_zprofile' 'psqlrc:dot_psqlrc' 'gitignore:dot_gitignore' 'agignore:dot_agignore' 'editorconfig:dot_editorconfig'; do
+    for pair in 'tmux.conf:dot_tmux.conf' 'zshrc:dot_zshrc' 'zshenv:dot_zshenv' 'zprofile:dot_zprofile' 'zlogin:dot_zlogin' 'psqlrc:dot_psqlrc' 'gitignore:dot_gitignore' 'agignore:dot_agignore' 'editorconfig:dot_editorconfig'; do
         source=${pair%%:*}
         chezmoi_file=${pair##*:}
         test -f "home/$chezmoi_file"
@@ -154,6 +154,7 @@ test-chezmoi-canary:
     cmp -s zshrc "$tmp/home/.zshrc"
     cmp -s zshenv "$tmp/home/.zshenv"
     cmp -s zprofile "$tmp/home/.zprofile"
+    cmp -s zlogin "$tmp/home/.zlogin"
     cmp -s psqlrc "$tmp/home/.psqlrc"
     cmp -s gitignore "$tmp/home/.gitignore"
     cmp -s agignore "$tmp/home/.agignore"

--- a/docs/chezmoi-inventory.md
+++ b/docs/chezmoi-inventory.md
@@ -45,8 +45,8 @@ criteria are demonstrated.
 
 ## Canary evidence
 
-The `tmux.conf`, `zshrc`, `zshenv`, `zprofile`, `psqlrc`, `gitignore`, `agignore`,
-`editorconfig`, and four
+The `tmux.conf`, `zshrc`, `zshenv`, `zprofile`, `zlogin`, `psqlrc`, `gitignore`,
+`agignore`, `editorconfig`, and four
 public executable slices and Ghostty config are represented under `home/`, with
 executable-mode checks. On 2026-08-07 they rendered byte-for-byte
 identical to the current rcm sources in an isolated HOME, and a second

--- a/docs/chezmoi-inventory.md
+++ b/docs/chezmoi-inventory.md
@@ -21,7 +21,7 @@ criteria are demonstrated.
 | `config/ghostty/config` | `~/.config/ghostty/config` | rcm | migrate as a plain chezmoi file |
 | `config/mise/config.toml` | `~/.config/mise/config.toml` | rcm | migrate as a plain chezmoi file; preserve machine-local overrides |
 | `bin/*` | `~/.bin/*` | rcm | migrate as executable files; verify modes |
-| `git_template/` | `~/.git_template/` | rcm | migrate as a directory; verify hook behavior |
+| `git_template/` | `~/.git_template/` | rcm | defer: empty placeholder only; migrate when functional template content exists |
 | `rcrc` | `~/.rcrc` | rcm | retain during shadow phase; remove only in cleanup PR |
 | `Brewfile`, `Brewfile.linux`, `Brewfile.personal`, `Brewfile.work` | `~/.Brewfile*` | rcm | preserve these links while `HOMEBREW_BUNDLE_FILE` depends on them |
 | `docs/`, `Justfile`, `README.md`, `CHANGELOG.md` | repository-only | rcm excludes | remain outside `home/` |
@@ -34,6 +34,9 @@ criteria are demonstrated.
   secrets; none of it is copied into this public source tree.
 - Application-owned mutable state is not imported until its reconciliation
   behavior has a dedicated fixture.
+- Empty directories and marker-only trees are not materialized in `home/` just
+  to satisfy chezmoi; they remain rcm-owned until they contain functional
+  content that can be tested.
 - Every migration PR must update this table and provide a disposition for any
   target not yet represented in chezmoi.
 

--- a/home/dot_zlogin
+++ b/home/dot_zlogin
@@ -1,0 +1,32 @@
+# Precompile the completion dump so the next login sources the compiled
+# form. The .zwc must be compiled from the real file in place: zsh only
+# uses ~/.zcompdump.zwc when it embeds that exact path, so a temp-copy
+# compile would be silently rejected.
+#
+# Serialize with a non-blocking flock. Multiple login shells starting
+# together (tmux panes, session restore) would otherwise race inside
+# zcompile's unlink()+open(O_CREAT, 0444) on the shared .zwc, and the loser
+# aborts with "can't write zwc file" — a spurious error that leaks into the
+# interactive session. The flock is fd-based and auto-releases when this
+# background shell exits, so no stale lock can wedge future recompiles.
+#
+# zsh/system is optional at build time. When it is missing we still compile —
+# unserialized — rather than skip precompilation forever: the race is cosmetic,
+# losing the .zwc entirely is a permanent startup cost.
+#
+# Both branches drop zcompile's stderr. Precompilation is a best-effort
+# optimization and this whole block is a disowned background job, so any
+# failure (unwritable $HOME, full disk) would otherwise surface as async noise
+# in an unrelated interactive prompt — the exact thing this change removes.
+{
+  zcompdump="${HOME}/.zcompdump"
+  if [[ -s "$zcompdump" && (! -s "${zcompdump}.zwc" || "$zcompdump" -nt "${zcompdump}.zwc") ]]; then
+    if zmodload zsh/system 2>/dev/null; then
+      lock="${zcompdump}.zwc.lock"
+      : >> "$lock" 2>/dev/null
+      zsystem flock -t 0 "$lock" 2>/dev/null && zcompile "$zcompdump" 2>/dev/null
+    else
+      zcompile "$zcompdump" 2>/dev/null
+    fi
+  fi
+} &!


### PR DESCRIPTION
## Summary
- document that the empty git template marker is deferred
- record the rule that marker-only trees stay rcm-owned

## Validation
- just lint-markdown
- full signed commit hook
- Roborev job 3044 (Codex): no issues found