### PR TITLE
docs: add public repository privacy rule

### DIFF
--- a/.claude/rules/public-repo-hygiene.md
+++ b/.claude/rules/public-repo-hygiene.md
@@ -1,0 +1,24 @@
+# Public repository privacy
+
+This repository is public. Treat every file, commit message, issue, pull
+request, comment, screenshot, and generated artifact as permanently public.
+
+Before writing or publishing content here:
+
+- Never add credentials, tokens, private keys, personal secrets, or cookies.
+- Never add identity-bearing or machine-sensitive configuration unless it is
+  explicitly public and required by this repository.
+- Never add employer, client, colleague, financial, location, internal-project,
+  or private-session information.
+- Route sensitive workstation content to the verified private companion
+  repository (`dotfiles-private`).
+- Verify the target repository's visibility before GitHub writes. If visibility
+  cannot be verified, treat the target as public.
+- Scan authored content before writing it, including issue and pull-request
+  titles and bodies. A draft is still public-repository content.
+- If classification is uncertain, stop and ask; do not rely on a later review
+  to catch a leak.
+
+The detailed sensitive-term list and credential-specific policy remain private
+and must not be copied into this repository. Use the private repository's
+hygiene checks when they are available.

--- a/docs/chezmoi-inventory.md
+++ b/docs/chezmoi-inventory.md
@@ -7,7 +7,7 @@ criteria are demonstrated.
 
 | Current source | Target | Current owner | Phase 1 disposition |
 | --- | --- | --- | --- |
-| `gitconfig` | `~/.gitconfig` | rcm | migrate as a plain chezmoi file |
+| `gitconfig` | `~/.gitconfig` | rcm | defer: identity-bearing; split public defaults from private identity/signing overlay |
 | `gitignore` | `~/.gitignore` | rcm | migrate as a plain chezmoi file |
 | `agignore` | `~/.agignore` | rcm | migrate as a plain chezmoi file |
 | `editorconfig` | `~/.editorconfig` | rcm | migrate as a plain chezmoi file |
@@ -32,6 +32,9 @@ criteria are demonstrated.
   recipes, tests, and changelog files stay at the repository root.
 - The private repository remains the owner of private Claude configuration and
   secrets; none of it is copied into this public source tree.
+- Identity-bearing Git configuration remains private. Public Git defaults may
+  be extracted later, but `user.*`, signing keys, and account-specific
+  credential wiring must be supplied by the private overlay.
 - Application-owned mutable state is not imported until its reconciliation
   behavior has a dedicated fixture.
 - Empty directories and marker-only trees are not materialized in `home/` just


### PR DESCRIPTION
## Summary
- add an explicit public-repository privacy boundary
- route sensitive workstation content to the private companion repository
- keep detailed sensitive-term and credential policy private

## Validation
- just lint-markdown
- full signed commit hook
- Roborev job 3052 (Codex): no issues found