### PR TITLE
fix(ci): remove retired private guard call

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -41,7 +41,7 @@ SCOPE CONTEXT — understand before flagging:
 
 - rcup symlinks: tracked files are symlinked into $HOME by rcm based on `rcrc`. Both this repo and `dotfiles-private` are merged via `DOTFILES_DIRS`. Their paths default to `$HOME/Workspace/tgautier/` and are overridable with `DOTFILES_DIR` / `DOTFILES_PRIVATE_DIR`, a contract shared by `rcrc`, the `Justfile` vars, and `_scan-stale-symlinks`.
 - Versioning: SemVer and changelog policy are defined in the global Claude Code config (in `dotfiles-private`) and auto-load via rcm. Don't expect a `versioning.md` file in this repo's tree.
-- CI: `just ci` runs shell, markdown, Brewfile, mise, Justfile, rcrc and stale-symlink-scanner lints, plus the keyword guard delegated to the private repo — the same checks run in GitHub Actions.
+- CI: `just ci` runs shell, markdown, Brewfile, mise, Justfile, rcrc and stale-symlink-scanner lints, plus the chezmoi canary — the same checks run in GitHub Actions.
 
 DO NOT FLAG:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,13 +54,11 @@ grouped by **date** rather than by semantic version. Newest first.
   `CLAUDE.md`'s load-order line gains the missing `zlogin` step and now defers to
   the README section instead of carrying a second partial copy
   ([#219](https://github.com/tgautier/dotfiles/issues/219)).
-- `DOTFILES_DIR` / `DOTFILES_PRIVATE_DIR` are now honoured by every consumer,
-  not just `lint-via-private`. `rcrc` reads them for both `DOTFILES_DIRS` and
-  `EXCLUDES` (it is sourced as shell by rcm, which is exactly why it can), and
-  the stale-symlink scanner derives its repo list from them. Setting one moves
-  all three together; previously it moved only the keyword guard, so an operator
-  who set the override pointed that guard at a private repo `rcup` never merged.
-  Documented in `README.md` → Custom checkout locations
+- `DOTFILES_DIR` / `DOTFILES_PRIVATE_DIR` are now honoured by both remaining
+  consumers. `rcrc` reads them for `DOTFILES_DIRS` and `EXCLUDES` (it is sourced
+  as shell by rcm, which is exactly why it can), and the stale-symlink scanner
+  derives its repo list from them. Documented in `README.md` → Custom checkout
+  locations
   ([#215](https://github.com/tgautier/dotfiles/issues/215)).
 - `just lint-rcrc`, wired into `just ci` — pins both halves of the override
   contract. For `DOTFILES_DIRS`: defaults with no override, each override alone
@@ -114,8 +112,7 @@ grouped by **date** rather than by semantic version. Newest first.
   non-existent recipe, and a scan that matches nothing), each asserting the
   failure came from its own guard rather than from any incidental error — the
   convention `.claude/rules/brewfile.md` sets for guard logic. `jq` is now
-  installed explicitly in CI rather than assumed present in the runner image.
-  The README lint table also gains the `lint-via-private` row it was missing
+  installed explicitly in CI rather than assumed present in the runner image
   ([#213](https://github.com/tgautier/dotfiles/issues/213),
   partially [#219](https://github.com/tgautier/dotfiles/issues/219)).
 - `!.claude/worktrees/**` to the `markdownlint-cli2` globs, completing the
@@ -248,6 +245,9 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Removed
 
+- The retired private keyword-guard call from `just ci`. The public gate no
+  longer depends on a recipe that the companion repository does not provide
+  ([#247](https://github.com/tgautier/dotfiles/issues/247)).
 - Removed the obsolete iTerm2 cask, preferences plist, rcm inventory entry,
   and documentation references now that Ghostty is the supported terminal.
 

--- a/Justfile
+++ b/Justfile
@@ -3,7 +3,7 @@
 zsh_excludes := "SC1036,SC1087,SC1090,SC2128,SC2145,SC2154,SC2155,SC2168,SC2179,SC2206,SC2211,SC2296"
 
 # Run all CI checks
-ci: lint-shell lint-markdown lint-brewfile lint-mise lint-just lint-rcrc lint-cleanup-symlinks test-chezmoi-canary lint-via-private
+ci: lint-shell lint-markdown lint-brewfile lint-mise lint-just lint-rcrc lint-cleanup-symlinks test-chezmoi-canary
 
 # Assert `rcrc` resolves the way README documents, on both halves of the
 # override contract: DOTFILES_DIRS, which reaches the operator's real $HOME
@@ -297,21 +297,6 @@ lint-just:
     fi
     echo "lint-just empty-match detection OK"
 
-# Delegate to the private repo's justfile for checks that must not be defined
-# here (keyword lists etc.). Skips loudly when the private repo is absent —
-# notably on a CI runner, where it is never present, so this leg of the keyword
-# guard has never executed there. The enforcing copies are the two pre-commit
-# hooks (this repo's runs `just ci` with the private repo present; the private
-# repo's `ci-lint` includes `lint-public-no-arr`), so a skip here is a
-# defence-in-depth gap, not an unguarded invariant. Announce it either way: a
-# silent no-op reads as a pass.
-lint-via-private:
-    @if [ -f {{ quote(private_justfile) }} ]; then \
-        just -f {{ quote(private_justfile) }} lint-public-no-arr; \
-    else \
-        echo "⚠ lint-via-private: keyword guard SKIPPED — no private justfile at" {{ quote(private_justfile) }}; \
-    fi
-
 # Bootstrap this machine: profile, packages, symlinks, runtimes, hooks, tools (idempotent)
 setup: _ensure-profile
     #!/usr/bin/env bash
@@ -580,23 +565,19 @@ update: update-brew update-mas update-mise update-rust
 # Resolve through symlink so this works when just finds ~/.justfile
 dotfiles_dir := parent_directory(canonicalize(justfile()))
 
-# Companion repo paths. Anchored to $HOME rather than derived from dotfiles_dir
-# on purpose: inside a nested worktree dotfiles_dir is .claude/worktrees/<name>,
-# whose sibling is not the private repo, so a sibling-derived path would
-# silently skip the keyword guard exactly when working on a branch.
+# Companion repo paths. Anchor them to $HOME rather than deriving them from
+# dotfiles_dir. Inside a nested worktree, dotfiles_dir points at the worktree;
+# its sibling is not the configured private checkout.
 #
-# DOTFILES_DIR / DOTFILES_PRIVATE_DIR are the shared contract across all three
-# consumers — `lint-via-private` here, `DOTFILES_DIRS` + `EXCLUDES` in `rcrc`,
-# and the repo list in `_scan-stale-symlinks`. Setting one moves all three
-# together; previously it moved only this one, so an operator who set it pointed
-# the keyword guard at a private repo `rcup` never merged.
+# DOTFILES_DIR / DOTFILES_PRIVATE_DIR are the shared contract across the two
+# remaining consumers: `DOTFILES_DIRS` + `EXCLUDES` in `rcrc`, and the repo list
+# in `_scan-stale-symlinks`.
 #
 # The two defaults below live in three places on purpose — here, `rcrc`, and
 # `lint-rcrc`'s expected values (which run under `env -u`, so they cannot
 # inherit these). Change one, change all three; see the note in `rcrc`.
 public_dir := env("DOTFILES_DIR", env("HOME") / "Workspace/tgautier/dotfiles")
 private_dir := env("DOTFILES_PRIVATE_DIR", env("HOME") / "Workspace/tgautier/dotfiles-private")
-private_justfile := private_dir / "justfile"
 
 # Platform-specific Brewfile
 brewfile := dotfiles_dir / if os() == "macos" { "Brewfile" } else { "Brewfile.linux" }
@@ -840,8 +821,8 @@ _scan-stale-symlinks:
     # resolving could stop matching the targets actually on disk.
     # quote() not "…": double quotes protect spaces but not `$`, backtick or
     # backslash, and this value gates an `rm`. Matches the convention already
-    # used for private_justfile and set-profile's argument. A glob qualifier
-    # after a single-quoted word is valid zsh.
+    # used for set-profile's argument. A glob qualifier after a single-quoted
+    # word is valid zsh.
     repos=({{ quote(public_dir) }}(N:a) {{ quote(private_dir) }}(N:a))
     # (N) above drops a configured dir that doesn't exist on this machine, so an
     # absent private repo contributes no prefix. Without it zsh aborts the whole

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ consumer moves together:
 | Variable               | Default                                 | Used by                                                          |
 | ---------------------- | --------------------------------------- | ---------------------------------------------------------------- |
 | `DOTFILES_DIR`         | `~/Workspace/tgautier/dotfiles`         | `DOTFILES_DIRS` in `rcrc`, the stale-symlink scanner             |
-| `DOTFILES_PRIVATE_DIR` | `~/Workspace/tgautier/dotfiles-private` | the above, plus `EXCLUDES` in `rcrc` and `just lint-via-private` |
+| `DOTFILES_PRIVATE_DIR` | `~/Workspace/tgautier/dotfiles-private` | the above, plus `EXCLUDES` in `rcrc`                             |
 
 Export them before `just link` / `just setup` so `rcrc` sees them — rcm sources
 `rcrc` as shell, which is what lets it read the environment at all. A trailing
@@ -393,7 +393,6 @@ Individual targets:
 | `just lint-just`               | Check in-body `just <recipe>` calls resolve    |
 | `just lint-rcrc`               | Check `rcrc` dirs, excludes, normalisation     |
 | `just lint-cleanup-symlinks`   | Fixture-test the stale-symlink scanner         |
-| `just lint-via-private`        | Keyword guard, delegated to the private repo   |
 
 The pre-commit hook is enabled by the bootstrap (idempotent — safe to re-run):
 


### PR DESCRIPTION
## Summary

Restores a complete public local gate that behaves consistently with or without the optional companion checkout.

- Remove the retired `lint-via-private` recipe from `just ci`
- Remove its unused private-Justfile variable and stale implementation comments
- Reconcile the README, changelog, and reviewer context with the current gate

## Why

The public CI composite still called a companion recipe that no longer exists. A local run with the companion checkout present therefore failed near the end of the gate, while an environment without that checkout skipped the call. Removing the retired dependency makes the public repository own and execute its complete current gate in both checkout shapes.

## Plan and progress

- [x] Remove the retired recipe and dependency
- [x] Remove current documentation and configuration references
- [x] Preserve dated changelog history while reconciling current claims
- [x] Validate with the companion checkout present and absent
- [x] Review the exact branch tip with Codex

## Validation

- `PATH="$HOME/.local/bin:$PATH" just ci`: passed with the companion checkout present
- `test ! -e /tmp/dotfiles-private-absent-247 && PATH="$HOME/.local/bin:$PATH" DOTFILES_PRIVATE_DIR=/tmp/dotfiles-private-absent-247 just ci`: passed with the companion checkout absent
- `git rev-parse HEAD`: returned `98806d6be1d1e8dc1ce2ae2f21ff02b02f278a0e` and matched the hosted PR head
- `git cat-file commit HEAD | sed -n '1,/^$/p' | rg '^gpgsig(-sha256)? '`: found the SSH signature header
- `roborev show --job 3291`: Codex found no issues on the exact branch tip

## Upgrade and operation

Pulling the change is sufficient. No package, secret, link, or machine-state migration is required. Existing public and private dotfile links remain untouched. To roll back, restore the previous repository revision; this only restores the retired gate call and does not mutate installed dotfiles.

## Review effectiveness

- `SA [CLEAN]`: The final self-audit found no unresolved issue after the pre-caught findings were fixed
- `PC1 [PRE-CAUGHT]`: The reviewer context still claimed the retired private guard ran; the context now names the actual chezmoi canary
- `PC2 [PRE-CAUGHT]`: Just comments still cited the removed variable and guard rationale; those references are removed
- `3291 [CLEAN]`: The exact-tip Codex review found no issues

## Issue references

Fixes #247
