### PR TITLE
chore(git): remove unused template placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,7 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Removed
 
+- The unused `git_template/hooks/gitkeep` placeholder and its rcm target. The effective `init.templateDir` is unset, no repository config include points Git at this directory, and the tracked per-repository `.githooks` mechanism does not use Git's copy-on-init template mechanism. After pulling, run `just link-inventory`; if `.git_template/hooks/gitkeep` is obsolete, use the approval-bound cleanup and restore flow in `docs/rcm-link-reconciliation.md` rather than deleting unreviewed HOME paths ([#224](https://github.com/tgautier/dotfiles/issues/224)).
 - The retired private keyword-guard call from `just ci`. The public gate no
   longer depends on a recipe that the companion repository does not provide
   ([#247](https://github.com/tgautier/dotfiles/issues/247)).

--- a/README.md
+++ b/README.md
@@ -241,7 +241,6 @@ config/
 tmux.conf               # tmux config (C-a prefix, vi mode, platform clipboard)
 gitconfig               # SSH signing via 1Password, rebase-based pulls
 gitignore               # Global gitignore (OS, editor, build noise)
-git_template/           # Git init template directory
 agignore                # ack/ag ignore patterns
 editorconfig            # Cross-editor whitespace defaults
 psqlrc                  # psql prompt and output defaults
@@ -330,7 +329,6 @@ Run `just git-hooks` once in each checkout or worktree. The full machine bootstr
 | ------------------------- | ---------- | ----------------------------------------------------------------- |
 | `gitconfig`               | Git        | SSH signing via 1Password, `pull.ff=only`, `gh` credential helper |
 | `gitignore`               | Git        | Global ignores — OS, editor and build noise                       |
-| `git_template/`           | Git        | Init template dir — linked, but not wired to `init.templateDir`   |
 | `tmux.conf`               | tmux       | `C-a` prefix, vi copy mode, platform-aware clipboard              |
 | `editorconfig`            | Editors    | UTF-8, LF, 2-space indent; tabs for `Makefile`                    |
 | `psqlrc`                  | psql       | Unicode borders, timing, `¤` for null, coloured prompt            |

--- a/docs/chezmoi-inventory.md
+++ b/docs/chezmoi-inventory.md
@@ -42,7 +42,7 @@ The guard:
 1. Compares the exact chezmoi target/source map with the `shadow` rows
 1. Applies into the isolated destination and verifies bytes plus executable modes
 1. Applies twice and requires an empty diff after each apply
-1. Runs sabotage fixtures for a misnamed target, omitted shadow and deferred rows, a duplicate row, a missing source, and an extra source
+1. Runs sabotage fixtures for a misnamed target, omitted shadow and deferred rows, a retired disposition, a duplicate row, a missing source, and an extra source
 
 The guard now maps `zsh/zaliases` and `zsh/zcompletion` to `~/.zsh/zaliases` and `~/.zsh/zcompletion`, matching both rcm and `zshrc`. The previous source names rendered an extra dot in each target while the hand-maintained canary still passed.
 

--- a/docs/chezmoi-inventory.md
+++ b/docs/chezmoi-inventory.md
@@ -20,7 +20,6 @@ The dispositions cover every current target:
 - `defer-homebrew-link`: the four Brewfile links remain rcm-owned while `HOMEBREW_BUNDLE_FILE` depends on them
 - `repository-only`: `CLAUDE.md` stays as project guidance and will not become a global home target
 - `defer-machine-overrides`: mise configuration waits for an explicit machine-local override strategy
-- `drop-empty-placeholder`: the empty git-template marker is intentionally not reproduced by chezmoi
 - `defer-private-overlay`: Git defaults wait for a public/private split that keeps identity and signing configuration private
 - `retire-at-cutover`: `rcrc` remains active during shadow operation and disappears only after chezmoi owns deployment
 
@@ -49,8 +48,10 @@ The guard now maps `zsh/zaliases` and `zsh/zcompletion` to `~/.zsh/zaliases` and
 
 ## Upgrade and rollback
 
-This shadow change does not alter installed dotfiles. Pull the repository and run `just ci`; keep using `just link` for active rcm deployment. Do not run chezmoi against the real home as part of this phase.
+Pull the repository and run `just ci`; keep using `just link` for active rcm deployment. Do not run chezmoi against the real home as part of this phase.
 
-Rollback is a repository revert only: restore the previous revision and rerun `just ci`. Existing rcm links and their targets remain untouched because every chezmoi apply in the guard is confined to a temporary destination.
+The removed empty Git-template marker may leave `~/.git_template/hooks/gitkeep` as an obsolete rcm symlink. Run `just link-inventory` after pulling. If the inventory reports that exact target as obsolete, follow the approval-bound plan, cleanup, and verification steps in [Rcm link reconciliation](rcm-link-reconciliation.md). Review every path in the generated plan because it can include other obsolete links.
+
+Before HOME cleanup, rollback is a repository revert followed by `just ci` and `just link`. After cleanup, restore the retained approved plan before reverting the repository, as described in the reconciliation guide. Every chezmoi apply in the guard remains confined to a temporary destination.
 
 The future cutover remains blocked until the exact guard passes from a fresh checkout, `just link-inventory` reconciles current and historical rcm HOME links with no unresolved obsolete set after the approval-bound cleanup decision, and the cutover PR records the backup, apply, verification, and rcm rollback sequence for macOS, Linux, and WSL2.

--- a/docs/chezmoi-targets.tsv
+++ b/docs/chezmoi-targets.tsv
@@ -13,7 +13,6 @@ bin/rcm-links	.bin/rcm-links	retire-at-cutover	-	executable
 config/ghostty/config	.config/ghostty/config	shadow	dot_config/ghostty/config	file
 config/mise/config.toml	.config/mise/config.toml	defer-machine-overrides	-	file
 editorconfig	.editorconfig	shadow	dot_editorconfig	file
-git_template/hooks/gitkeep	.git_template/hooks/gitkeep	drop-empty-placeholder	-	file
 gitconfig	.gitconfig	defer-private-overlay	-	file
 gitignore	.gitignore	shadow	dot_gitignore	file
 psqlrc	.psqlrc	shadow	dot_psqlrc	file

--- a/tests/check-chezmoi-targets
+++ b/tests/check-chezmoi-targets
@@ -92,7 +92,7 @@ main() {
                     [[ -f "$repo_root/home/$chezmoi_source" ]] || fail "missing chezmoi source at line $line_no: $chezmoi_source"
                     printf '%s\t%s\n' "$target" "$chezmoi_source" >> "$tmp/expected-map"
                     ;;
-                defer-homebrew-link|repository-only|defer-machine-overrides|drop-empty-placeholder|defer-private-overlay|retire-at-cutover)
+                defer-homebrew-link|repository-only|defer-machine-overrides|defer-private-overlay|retire-at-cutover)
                     [[ "$chezmoi_source" == - ]] || fail "deferred target has a chezmoi source at line $line_no: $target"
                     ;;
                 *) fail "unknown disposition at line $line_no: $disposition" ;;

--- a/tests/test-chezmoi-canary
+++ b/tests/test-chezmoi-canary
@@ -65,6 +65,9 @@ main() {
     awk 'BEGIN { FS=OFS="\t" } $2 != ".Brewfile" { print }' "$manifest" > "$tmp/deferred-omitted.tsv"
     expect_failure 'deferred omission' 'rcm target map mismatch' "$checker" "$repo_root" "$tmp/deferred-omitted.tsv"
 
+    awk 'BEGIN { FS=OFS="\t" } $2 == ".Brewfile" { $3="drop-empty-placeholder" } { print }' "$manifest" > "$tmp/retired-disposition.tsv"
+    expect_failure 'retired disposition' 'unknown disposition' "$checker" "$repo_root" "$tmp/retired-disposition.tsv"
+
     awk 'NR == 2 { print } { print }' "$manifest" > "$tmp/duplicate.tsv"
     expect_failure duplicate 'duplicate manifest' "$checker" "$repo_root" "$tmp/duplicate.tsv"
 
@@ -76,7 +79,7 @@ main() {
     printf 'unexpected fixture\n' > "$tmp/extra/home/dot_unexpected"
     expect_failure extra 'target map mismatch' "$checker" "$tmp/extra" "$tmp/extra/docs/chezmoi-targets.tsv"
 
-    printf 'chezmoi canary fixtures OK (misnamed, shadow/deferred omission, duplicate, missing, extra)\n'
+    printf 'chezmoi canary fixtures OK (misnamed, shadow/deferred omission, retired disposition, duplicate, missing, extra)\n'
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

- Remove the unused `git_template/hooks/gitkeep` source and its rcm target.
- Retire `drop-empty-placeholder` from the chezmoi inventory contract and add a rejection fixture.
- Remove the dead target from current README and migration inventory surfaces.
- Document a working upgrade and rollback path through the approval-bound historical-link reconciliation flow.

## Why

The effective `init.templateDir` is unset, no repository config include points Git at this directory, and the tracked `.githooks` flow is a separate per-repository mechanism. Keeping an empty placeholder linked into HOME therefore adds deployment state without behavior.

The issue suggested the older broad stale-symlink scanner. A removed top-level source can escape that scanner, so this change uses the current historical ownership inventory and digest-bound cleanup and restore workflow instead.

## Plan

- [x] Verify the Git template directory has no active consumer.
- [x] Remove the tracked placeholder and machine-readable target.
- [x] Retire the special disposition and pin its rejection.
- [x] Update current documentation, upgrade guidance, rollback guidance, and changelog.
- [x] Run the full local gate and exact-tip review.
- [x] Publish the exact-tip local status without hosted Actions.

## Upgrade and rollback

After pulling, run `just ci` and continue using `just link` for active rcm deployment. Run `just link-inventory`; if the exact `.git_template/hooks/gitkeep` target is reported as obsolete, inspect every path in a generated `just link-cleanup-plan` before separately approving and applying it. No HOME cleanup happens automatically.

Before cleanup, revert the repository change, run `just ci`, and run `just link`. After cleanup, retain the approved plan through the rollback window and run `just link-restore` before reverting the repository. Do not apply chezmoi to the real HOME in this phase.

## Validation

- Complete `just ci` gate at final tip `0dc07a3e2d0db086545925de551b917324de0c5e`
- Exact-tip `just ci-attest` and published `local/exact-tip=success`
- ShellCheck and Bash syntax checks
- Markdown lint: 0 issues
- Python inventory suite: 13 tests passed
- Chezmoi parity: 35 rcm targets, 26 exact shadow mappings, idempotent apply
- Canary sabotage fixtures, including the retired disposition
- Local shipping-gate fixtures: 40 passed
- Isolated HOME probe: removed target classified as `obsolete/broken`
- Roborev job 3333: one low documentation finding, fixed
- Roborev exact-tip job 3334: no issues

No hosted GitHub Actions run is required or triggered by this workflow.

## Review effectiveness

The pre-review audit corrected two issues before review: stale cleanup guidance that could miss the removed root, and an overly broad claim about Git never reading the directory. Review then found one omitted fixture in a nearby documentation list; the list is now synchronized with the executable suite.

Fixes #224
Advances #232