### PR TITLE
fix(chezmoi): accept private manifest metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -272,6 +272,7 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Fixed
 
+- Live cutover backup and restore now accept the private companion's current eight-column target manifest, including its chezmoi source mapping. The public fixtures use that same schema so a future cross-repository header change fails before the operator reaches HOME ([#232](https://github.com/tgautier/dotfiles/issues/232)).
 - The Linux validation environment now installs `rcm`, whose `lsrc` command is
   the independent rcm-side oracle for the chezmoi target-map parity guard
   ([#248](https://github.com/tgautier/dotfiles/issues/248)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -272,7 +272,7 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Fixed
 
-- Live cutover backup and restore now accept the private companion's current eight-column target manifest, including its chezmoi source mapping. The public fixtures use that same schema so a future cross-repository header change fails before the operator reaches HOME ([#232](https://github.com/tgautier/dotfiles/issues/232)).
+- Live cutover backup and restore now accept the private companion's current eight-column target manifest. The public parser pins the seven-column rcm ownership prefix while accepting trailing private metadata it does not consume, and fixtures cover the current chezmoi source suffix, a further metadata suffix, and a reordered-prefix rejection ([#232](https://github.com/tgautier/dotfiles/issues/232)).
 - The Linux validation environment now installs `rcm`, whose `lsrc` command is
   the independent rcm-side oracle for the chezmoi target-map parity guard
   ([#248](https://github.com/tgautier/dotfiles/issues/248)).

--- a/bin/rcm-links
+++ b/bin/rcm-links
@@ -44,6 +44,7 @@ PRIVATE_TARGET_HEADER = (
     "future_owner",
     "target_shape",
     "mode",
+    "chezmoi_source",
 )
 
 
@@ -292,10 +293,17 @@ def load_cutover_targets(
                 future_owner,
                 target_shape,
                 mode,
+                chezmoi_source,
             ) = row
-            if not disposition or not future_owner or not target_shape or not mode:
+            if (
+                not disposition
+                or not future_owner
+                or not target_shape
+                or not mode
+                or not chezmoi_source
+            ):
                 raise InventoryError(
-                    f"private chezmoi target manifest line {line_number} has an empty ownership field"
+                    f"private chezmoi target manifest line {line_number} has an empty required field"
                 )
             if current_owner == "public-rcm-precedence":
                 relative = require_relative_path(

--- a/bin/rcm-links
+++ b/bin/rcm-links
@@ -44,7 +44,6 @@ PRIVATE_TARGET_HEADER = (
     "future_owner",
     "target_shape",
     "mode",
-    "chezmoi_source",
 )
 
 
@@ -186,6 +185,7 @@ def load_tsv_rows(
     *,
     header: tuple[str, ...],
     label: str,
+    allow_trailing_fields: bool = False,
 ) -> list[tuple[str, ...]]:
     try:
         with path.open("r", encoding="utf-8", newline="") as handle:
@@ -194,18 +194,25 @@ def load_tsv_rows(
         raise InventoryError(f"cannot read {label} {path}: {exc}") from exc
     if not rows:
         raise InventoryError(f"{label} is empty: {path}")
-    if tuple(rows[0]) != header:
+    actual_header = tuple(rows[0])
+    header_matches = (
+        actual_header[: len(header)] == header
+        if allow_trailing_fields
+        else actual_header == header
+    )
+    if not header_matches:
+        requirement = "start with" if allow_trailing_fields else "be exactly"
         raise InventoryError(
-            f"{label} header must be exactly {header!r}; got {tuple(rows[0])!r}"
+            f"{label} header must {requirement} {header!r}; got {actual_header!r}"
         )
     parsed: list[tuple[str, ...]] = []
     for line_number, fields in enumerate(rows[1:], start=2):
-        if len(fields) != len(header):
+        if len(fields) != len(actual_header):
             raise InventoryError(
                 f"{label} line {line_number} has {len(fields)} fields; "
-                f"expected {len(header)}"
+                f"expected {len(actual_header)}"
             )
-        parsed.append(tuple(fields))
+        parsed.append(tuple(fields[: len(header)]))
     if not parsed:
         raise InventoryError(f"{label} has no rows: {path}")
     return parsed
@@ -283,6 +290,7 @@ def load_cutover_targets(
             private_manifest,
             header=PRIVATE_TARGET_HEADER,
             label="private chezmoi target manifest",
+            allow_trailing_fields=True,
         )
         for line_number, row in enumerate(private_rows, start=2):
             (
@@ -293,17 +301,10 @@ def load_cutover_targets(
                 future_owner,
                 target_shape,
                 mode,
-                chezmoi_source,
             ) = row
-            if (
-                not disposition
-                or not future_owner
-                or not target_shape
-                or not mode
-                or not chezmoi_source
-            ):
+            if not disposition or not future_owner or not target_shape or not mode:
                 raise InventoryError(
-                    f"private chezmoi target manifest line {line_number} has an empty required field"
+                    f"private chezmoi target manifest line {line_number} has an empty ownership field"
                 )
             if current_owner == "public-rcm-precedence":
                 relative = require_relative_path(

--- a/tests/test_rcm_links.py
+++ b/tests/test_rcm_links.py
@@ -202,8 +202,8 @@ class RcmLinksInventoryTest(unittest.TestCase):
         )
         private_manifest = self.root / "private-targets.tsv"
         private_manifest.write_text(
-            "rcm_source\ttarget\tcurrent_owner\tdisposition\tfuture_owner\ttarget_shape\tmode\n"
-            "zshrc.local\t.zshrc.local\tprivate-rcm\tmigrate\tprivate-chezmoi\tprivate-file\t0600\n",
+            "rcm_source\ttarget\tcurrent_owner\tdisposition\tfuture_owner\ttarget_shape\tmode\tchezmoi_source\n"
+            "zshrc.local\t.zshrc.local\tprivate-rcm\tmigrate\tprivate-chezmoi\tprivate-file\t0600\tprivate_dot_zshrc.local\n",
             encoding="utf-8",
         )
         self._write_fake_lsrc(

--- a/tests/test_rcm_links.py
+++ b/tests/test_rcm_links.py
@@ -350,6 +350,46 @@ class RcmLinksInventoryTest(unittest.TestCase):
         self.assertEqual(completed.returncode, 2)
         self.assertIn("source must not look like an option: -option", completed.stderr)
 
+    def test_cutover_backup_accepts_trailing_private_metadata(self) -> None:
+        public_manifest, private_manifest = self._configure_cutover_fixture()
+        lines = private_manifest.read_text(encoding="utf-8").splitlines()
+        private_manifest.write_text(
+            "\n".join(f"{line}\tfixture_metadata" for line in lines) + "\n",
+            encoding="utf-8",
+        )
+
+        completed = self._cutover_backup(
+            public_manifest,
+            private_manifest,
+            self.root / "private-metadata.json",
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
+    def test_cutover_backup_rejects_reordered_private_ownership_columns(self) -> None:
+        public_manifest, private_manifest = self._configure_cutover_fixture()
+        content = private_manifest.read_text(encoding="utf-8")
+        private_manifest.write_text(
+            content.replace(
+                "target_shape\tmode\tchezmoi_source",
+                "target_shape\tchezmoi_source\tmode",
+                1,
+            ),
+            encoding="utf-8",
+        )
+
+        completed = self._cutover_backup(
+            public_manifest,
+            private_manifest,
+            self.root / "reordered-private.json",
+        )
+
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn(
+            "private chezmoi target manifest header must start with",
+            completed.stderr,
+        )
+
     def test_cutover_commands_derive_manifests_from_effective_repositories(self) -> None:
         public_override = self.root / "public-override"
         private_override = self.root / "private-override"


### PR DESCRIPTION
## Summary

Make the live rcm backup and restore boundary compatible with the private companion's current target manifest and future trailing metadata.

The public helper now owns and validates the required seven-column rcm prefix. It accepts additional private columns without interpreting them, while still requiring every data row to match the complete declared header width.

## Why

The non-mutating live cutover backup stopped before touching HOME because the private manifest gained a chezmoi source column. The public helper had coupled itself to the private repository's complete schema even though it consumes only the rcm ownership fields.

This change makes that repository boundary explicit: required ownership fields remain ordered and strict, while private-only metadata can evolve as trailing columns.

## Plan and progress

- [x] Reproduce the failure through the live non-mutating backup path.
- [x] Define the public-owned prefix and private-owned suffix contract.
- [x] Add accepted current-schema and future-suffix fixtures.
- [x] Add reordered-prefix and malformed-width rejection coverage.
- [x] Update the changelog.
- [x] Run focused and complete local validation.
- [x] Complete Codex Roborev on the exact branch range.
- [x] Push the exact attested tip over SSH.
- [x] Publish and read back the exact-tip local status.

## Upgrade and operation

1. Pull the private companion update first so its current manifest is present.
2. Pull this public update.
3. Retry the cutover backup and verify the resulting owner-only artifact.
4. Review the later cutover plan separately before any real chezmoi apply.

This PR does not apply chezmoi or change HOME ownership. The existing rcm state and rollback material remain in place.

## Validation

- [x] Focused checks: `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p 'test_rcm_links.py' -v` passed all 30 focused tests.
- [x] Complete CI: `just ci-attest` passed the complete local gate and attested the clean branch tip.
- [x] Exact-tip evidence: `just ci-publish` published and read back `local/exact-tip=success` for bd4602807b5c8422d911375541ddab5d775b468f.
- [x] External review: Roborev job `3366` completed with Codex and reported no issues across the full branch range.

Validation limit: A live non-mutating mode-0600 backup was created and independently verified with 46 targets, comprising 35 public and 11 private targets; validation intentionally excludes a real chezmoi apply and live rcm restore.

## Review effectiveness

- `PC1 [PRE-CAUGHT]`: the first implementation pinned all eight private columns. The pre-review audit replaced that coupling with the public-owned prefix contract before publication.
- `SA [CLEAN]`: no self-audit findings remained at the reviewed tip.
- `3366 [CLEAN]`: Codex found no issues in the complete branch range.

## Issue references

Addresses #232
