### PR TITLE
fix(chezmoi): preserve lsrc runtime layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -272,6 +272,7 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Fixed
 
+- The approval-bound chezmoi canary now invokes the exact selected `lsrc` through an owner-only wrapper instead of relocating it with a symlink. Homebrew's `lsrc` derives its support library from its invocation path, so the temporary symlink broke `../share/rcm/rcm.sh` and blocked the live approval plan before mutation. The regression fixture uses the same executable-relative layout and proves the selected real script runs ([#232](https://github.com/tgautier/dotfiles/issues/232)).
 - Live cutover backup and restore now accept the private companion's current eight-column target manifest. The public parser pins the seven-column rcm ownership prefix while accepting trailing private metadata it does not consume, and fixtures cover the current chezmoi source suffix, a further metadata suffix, and a reordered-prefix rejection ([#232](https://github.com/tgautier/dotfiles/issues/232)).
 - The Linux validation environment now installs `rcm`, whose `lsrc` command is
   the independent rcm-side oracle for the chezmoi target-map parity guard

--- a/bin/chezmoi-cutover
+++ b/bin/chezmoi-cutover
@@ -13,6 +13,7 @@ import json
 import os
 from pathlib import Path
 import selectors
+import shlex
 import shutil
 import signal
 import stat
@@ -970,7 +971,12 @@ def prepare_approval(
             with tempfile.TemporaryDirectory(prefix="chezmoi-canary-tools-") as temporary:
                 tool_directory = Path(temporary)
                 (tool_directory / "chezmoi").symlink_to(executable)
-                (tool_directory / "lsrc").symlink_to(lsrc)
+                lsrc_wrapper = tool_directory / "lsrc"
+                lsrc_wrapper.write_text(
+                    f"#!/bin/sh\nexec {shlex.quote(str(lsrc))} \"$@\"\n",
+                    encoding="utf-8",
+                )
+                lsrc_wrapper.chmod(0o700)
                 environment["PATH"] = (
                     f"{tool_directory}{os.pathsep}{environment.get('PATH', '')}"
                 )

--- a/tests/test_chezmoi_cutover.py
+++ b/tests/test_chezmoi_cutover.py
@@ -216,16 +216,29 @@ class ChezmoiCutoverTests(unittest.TestCase):
                         handle.write("passed\\n")
                     if os.environ.get("FAKE_CANARY_FAIL") == "1":
                         raise SystemExit(37)
-                    for name, variable in (
-                        ("chezmoi", "FAKE_EXPECTED_CHEZMOI"),
-                        ("lsrc", "FAKE_EXPECTED_LSRC"),
+                    expected_chezmoi = os.environ.get("FAKE_EXPECTED_CHEZMOI")
+                    selected_chezmoi = shutil.which("chezmoi")
+                    if expected_chezmoi and (
+                        selected_chezmoi is None
+                        or Path(selected_chezmoi).resolve()
+                        != Path(expected_chezmoi).resolve()
                     ):
-                        expected = os.environ.get(variable)
-                        selected = shutil.which(name)
-                        if expected and (
-                            selected is None
-                            or Path(selected).resolve() != Path(expected).resolve()
-                        ):
+                        raise SystemExit(38)
+                    expected_lsrc = os.environ.get("FAKE_EXPECTED_LSRC")
+                    selected_lsrc = shutil.which("lsrc")
+                    if expected_lsrc:
+                        if selected_lsrc is None:
+                            raise SystemExit(38)
+                        lsrc_probe = subprocess.run(
+                            [selected_lsrc, "--canary-probe"],
+                            check=False,
+                            env=os.environ.copy(),
+                            stdin=subprocess.DEVNULL,
+                            stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL,
+                            timeout=5,
+                        )
+                        if lsrc_probe.returncode != 0:
                             raise SystemExit(38)
                     if os.environ.get("FAKE_CANARY_WAIT") == "1":
                         descendant = subprocess.Popen(
@@ -850,15 +863,30 @@ class ChezmoiCutoverTests(unittest.TestCase):
         self.assertFalse(self.applied.exists())
 
     def test_canary_uses_the_exact_selected_chezmoi_and_lsrc(self) -> None:
-        selected_lsrc = self.root / "selected-lsrc"
-        selected_lsrc.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        selected_root = self.root / "selected-rcm"
+        selected_lsrc = selected_root / "bin/lsrc"
+        selected_library = selected_root / "share/rcm/probe.sh"
+        selected_lsrc.parent.mkdir(parents=True)
+        selected_library.parent.mkdir(parents=True)
+        selected_library.write_text("probe_loaded=1\n", encoding="utf-8")
+        selected_lsrc.write_text(
+            "#!/bin/sh\n"
+            ': "${FAKE_LSRC_LOG:?}"\n'
+            '. "$(dirname "$0")/../share/rcm/probe.sh"\n'
+            '[ "${probe_loaded:-}" = "1" ] || exit 39\n'
+            '[ "${1:-}" = "--canary-probe" ] || exit 40\n'
+            'printf "%s\\n" "$0" > "$FAKE_LSRC_LOG"\n',
+            encoding="utf-8",
+        )
         selected_lsrc.chmod(0o700)
+        lsrc_log = self.root / "selected-lsrc.log"
         completed = self._run(
             "plan",
             private=True,
             extra_environment={
                 "FAKE_EXPECTED_CHEZMOI": str(self.fake_chezmoi),
                 "FAKE_EXPECTED_LSRC": str(selected_lsrc),
+                "FAKE_LSRC_LOG": str(lsrc_log),
             },
             extra_arguments=[
                 "--backup",
@@ -872,6 +900,10 @@ class ChezmoiCutoverTests(unittest.TestCase):
 
         self.assertEqual(completed.returncode, 0, completed.stderr)
         self.assertIn("approval_sha256=", completed.stdout)
+        self.assertEqual(
+            Path(lsrc_log.read_text(encoding="utf-8").strip()).resolve(),
+            selected_lsrc.resolve(),
+        )
 
     def test_sigterm_during_plan_stops_canary_descendant_without_restore(self) -> None:
         self._make_repository(self.private, private=True)

--- a/tests/test_chezmoi_cutover.py
+++ b/tests/test_chezmoi_cutover.py
@@ -863,7 +863,7 @@ class ChezmoiCutoverTests(unittest.TestCase):
         self.assertFalse(self.applied.exists())
 
     def test_canary_uses_the_exact_selected_chezmoi_and_lsrc(self) -> None:
-        selected_root = self.root / "selected-rcm"
+        selected_root = self.root / "selected rcm's layout"
         selected_lsrc = selected_root / "bin/lsrc"
         selected_library = selected_root / "share/rcm/probe.sh"
         selected_lsrc.parent.mkdir(parents=True)


### PR DESCRIPTION
## Summary

Keep the approval-bound chezmoi canary compatible with executables that load support files relative to their invocation path.

The operator now exposes the exact selected `lsrc` through an owner-only temporary wrapper that `exec`s the resolved executable at its real path. Homebrew's `lsrc` can therefore load its sibling rcm library while the approval still binds the selected path and bytes.

## Why

The live non-mutating approval plan failed before any HOME change because the canary relocated `lsrc` with a temporary symlink. `lsrc` derives `../share/rcm/rcm.sh` from `$0`, so the relocation preserved executable identity but destroyed its runtime layout.

Prepending the original installation directory would also expose unrelated tools from that directory. A single safely quoted wrapper keeps the canary's PATH narrow, preserves exact executable selection, and lets the real process observe its original invocation path.

## Plan and progress

- [x] Reproduce the failure through the live non-mutating approval plan.
- [x] Replace the layout-breaking `lsrc` symlink with an exact-path wrapper.
- [x] Add behavioral coverage for sibling-library loading and selected-script identity.
- [x] Cover spaces and apostrophes in the selected executable path.
- [x] Update the changelog.
- [x] Run focused, complete, and live non-mutating validation.
- [x] Complete Codex Roborev on the exact branch range.
- [x] Push the exact attested tip over SSH.
- [x] Publish and read back the exact-tip local status.

## Upgrade and operation

Pull this public update before regenerating the approval-bound cutover plan. The retained owner-only rcm backup remains valid and should be verified again immediately before planning.

This PR does not run chezmoi apply or change HOME ownership. Rcm remains the live owner, and the complete restore artifact remains available.

## Validation

- [x] Focused checks: `PYTHONDONTWRITEBYTECODE=1 PYTHONWARNINGS=error python3 -m unittest discover -s tests -p 'test_chezmoi_cutover.py' -v` passed all 44 operator tests.
- [x] Complete CI: `just ci-attest` passed the complete local gate and attested the clean branch tip.
- [x] Exact-tip evidence: `just ci-publish` published and read back `local/exact-tip=success` for 85037846987e5a5afd4ac84455f94714105ebfd1.
- [x] External review: Roborev job `3367` completed with Codex and reported no issues across the full branch range.

Validation limit: The live non-mutating plan verified the retained 46-target backup, passed public/private parity, reviewed both sources' status, diff, and dry run, and produced an apply approval; no real chezmoi apply or live rcm restore was run.

## Review effectiveness

- `PC1 [PRE-CAUGHT]`: the first regression path did not exercise shell quoting. The self-audit added spaces and an apostrophe while retaining sibling-library loading and exact-script assertions.
- `SA [CLEAN]`: no self-audit finding remained at the reviewed tip.
- `3367 [CLEAN]`: Codex found no issues in the complete branch range.

## Issue references

Addresses #232
