### PR TITLE
Switch routine deployment ownership to chezmoi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,8 @@ grouped by **date** rather than by semantic version. Newest first.
 
 ### Changed
 
+- Routine deployment now preserves the live chezmoi ownership split. `just link`, and therefore the linking phase of `just setup`, runs an isolated public/private parity preflight, invokes rcm without force only for the six public `defer-*` manifest rows through explicit `-d` and source operands, runs the optional private dedicated-owner aggregate with output withheld, and applies each chezmoi source twice without force. Retained targets refuse regular files and foreign links before rcm; chezmoi uses conflict errors instead of overwriting modified targets; status, diff, and dry-run must settle after each pass. A routine failure remains safely rerunnable and never silently triggers the broad rollback graph. The unchanged `rcrc` and digest-bound backup continue to provide explicit full rollback until fresh-machine and supported-profile acceptance permit rcm retirement ([#232](https://github.com/tgautier/dotfiles/issues/232)).
+
 - Elixir 1.20.2 → 1.20.3 in `config/mise/config.toml`; OTP-29 suffix unchanged.
 - The stale-symlink sweep is split in two: `_scan-stale-symlinks` finds and
   prints stale links, `cleanup-symlinks` confirms and removes them. The scan

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,16 +14,16 @@ Personal financial workflows, vault-specific content, employer-tied notes, colle
 
 ## Repository Overview
 
-Cross-platform personal dotfiles for macOS and Linux/WSL2, managed with **rcm** (Thoughtbot's dotfile manager). Symlinks are created via `rcup`, configured in `rcrc`. A companion private repo (`dotfiles-private`) is merged via `DOTFILES_DIRS` in `rcrc`; it hosts plaintext shell secrets, personal workflow config, and the global Claude Code config.
+Cross-platform personal dotfiles for macOS and Linux/WSL2, deployed primarily with chezmoi. The manifest-deferred public targets remain rcm links, private dedicated installers retain their declared targets, and the unchanged complete rcm graph remains the digest-bound rollback authority. An optional private companion provides a second chezmoi source and dedicated-owner aggregate without exposing its values through the public operator.
 
 ## Key Commands
 
 ```sh
-# Re-apply the rcm symlinks (uses DOTFILES_DIRS from rcrc). Required for an
-# edit to a symlinked dotfile — gitconfig, zshrc, zshenv, tmux.conf — to take
-# effect on this machine. `just update` does NOT re-link. Prefer this over a
-# bare `rcup`, which finds the same config only once ~/.rcrc is itself linked.
-# Run it from this checkout — ~/.justfile points at the private repo's justfile
+# Refresh config through its manifest-declared owner. The command runs an
+# isolated ownership/source preflight, only the deferred public rcm links, the
+# optional private dedicated-owner aggregate, then conflict-refusing chezmoi
+# apply passes. Never use broad rcup for routine deployment: it is rollback.
+# Run this from the public checkout; ~/.justfile points at the private repo.
 just link
 
 # Install packages (auto-selects the platform Brewfile and, on macOS, the

--- a/Justfile
+++ b/Justfile
@@ -331,7 +331,7 @@ lint-just:
     fi
     echo "lint-just empty-match detection OK"
 
-# Bootstrap this machine: profile, packages, symlinks, runtimes, hooks, tools (idempotent)
+# Bootstrap this machine: profile, packages, dotfiles, runtimes, hooks, tools (idempotent)
 setup: _ensure-profile
     #!/usr/bin/env bash
     set -euo pipefail
@@ -355,10 +355,9 @@ setup: _ensure-profile
     #    package upgrading cleanly.
     brew bundle install --no-upgrade --file="{{brewfile}}"
 
-    # 2. Symlink dotfiles. Delegated to `link` so the RCRC-prefixed invocation
-    #    lives in exactly one place. Called here rather than declared as a
-    #    dependency because dependencies run before the recipe body, and rcm
-    #    itself comes from the `brew bundle` in step 1.
+    # 2. Refresh dotfiles through their manifest-declared owners. Called here
+    #    rather than declared as a dependency because dependencies run before
+    #    the recipe body, and chezmoi and rcm come from the bundle in step 1.
     just link
 
     # 3. Language runtimes from the pinned mise config. Install mise first if the
@@ -394,23 +393,20 @@ git-hooks:
     git config --local core.hooksPath .githooks
     @echo "Git hooks wired for this checkout"
 
-# Run this after editing any dotfile rcm links into $HOME (gitconfig, zshrc,
-# zshenv, tmux.conf, …) — the edit lands in this repo, but the running machine
-# only picks it up once the links are re-applied. `just update` does NOT
-# re-link: it upgrades installed software, not local config. RCRC points rcm at
-# this repo's in-tree config, so every DOTFILES_DIRS entry is linked even on a
-# machine that has never been bootstrapped — `~/.rcrc` is itself one of the
-# symlinks rcm creates, so a bare `rcup` only finds the same config after the
-# first run. That makes this the authoritative invocation, and `setup` calls it
-# rather than repeating it. An absent private repo is skipped, not fatal.
+# Run this after editing managed config. The operator validates public/private
+# ownership in isolation, refreshes only the manifest-deferred public rcm links,
+# runs the private dedicated owners when that checkout exists, then applies the
+# public and private chezmoi sources without force. Both apply passes must finish
+# settled. The unchanged broad rcm configuration remains available only to the
+# digest-bound full rollback. An absent private repo is skipped, not fatal.
 #
 # Must be run from this checkout: `~/.justfile` is a symlink to the PRIVATE
 # repo's justfile, so `just link` from $HOME resolves there and fails with an
 # unknown-recipe error. The [doc] attribute carries the summary because `just
 # --list` would otherwise show only the last line of this comment.
-[doc("Re-apply the rcm symlinks (run after editing a symlinked dotfile)")]
+[doc("Refresh dotfiles through their manifest-declared owners")]
 link:
-    RCRC="{{dotfiles_dir}}/rcrc" rcup
+    python3 bin/chezmoi-cutover link --public-dir {{quote(public_dir)}} --private-dir {{quote(private_dir)}}
 
 # Symlink the system libsqlite3 into a dedicated ~/.local/lib/flutter-ffi dir for
 # Dart/Flutter (Drift) FFI, which dlopen()s the unversioned 'libsqlite3.so' the

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Dotfiles
 
-Cross-platform dotfiles for macOS and Linux/WSL2 Ubuntu, managed with
-[rcm](https://github.com/thoughtbot/rcm).
+Cross-platform dotfiles for macOS and Linux/WSL2 Ubuntu, deployed primarily with [chezmoi](https://www.chezmoi.io/). A small manifest-declared set remains linked through [rcm](https://github.com/thoughtbot/rcm), which is also retained as the full rollback authority during migration acceptance.
 
 ## Features
 
@@ -9,6 +8,7 @@ Cross-platform dotfiles for macOS and Linux/WSL2 Ubuntu, managed with
 - Platform detection (`$PLATFORM`) with automatic path configuration
 - Homebrew integration with platform-specific Brewfiles
 - Runtime version management via [mise](https://mise.jdx.dev/)
+- Conflict-refusing public/private chezmoi deployment through `just link`
 - Optimized shell startup with intelligent caching
 - [tmux](docs/tmux.md) with vi-style bindings and platform-aware clipboard
 - Exact-tip local shipping gate with [just](https://just.systems/), commit signature-header checks, and no hosted CI minutes
@@ -29,8 +29,8 @@ Cross-platform dotfiles for macOS and Linux/WSL2 Ubuntu, managed with
    ```sh
    mkdir -p ~/Workspace/tgautier
    git clone https://github.com/tgautier/dotfiles.git ~/Workspace/tgautier/dotfiles
-   # Optional: clone the private companion repo alongside it (merged via
-   # DOTFILES_DIRS). If absent, setup links the public repo only.
+   # Optional: clone the private companion repo alongside it. If absent,
+   # setup deploys the public source only.
    ```
 
 3. **Sign in to the App Store** (the Brewfile's `mas` entries fail without
@@ -46,7 +46,7 @@ Cross-platform dotfiles for macOS and Linux/WSL2 Ubuntu, managed with
    ```
 
    `just setup` prompts for the machine profile (work/personal) on first run,
-   then installs all packages for that profile, links every dotfiles repo,
+   then installs all packages for that profile, deploys the selected sources,
    installs mise and the pinned runtimes, and enables git hooks and tools.
    It is idempotent — re-run it anytime.
 
@@ -120,8 +120,8 @@ Cross-platform dotfiles for macOS and Linux/WSL2 Ubuntu, managed with
    ```sh
    mkdir -p ~/Workspace/tgautier
    git clone https://github.com/tgautier/dotfiles.git ~/Workspace/tgautier/dotfiles
-   # Optional: clone the private companion repo alongside it (merged via
-   # DOTFILES_DIRS). If absent, setup links the public repo only.
+   # Optional: clone the private companion repo alongside it. If absent,
+   # setup deploys the public source only.
    ```
 
 6. **Bootstrap and run setup** (uses `Brewfile.linux` automatically):
@@ -132,7 +132,7 @@ Cross-platform dotfiles for macOS and Linux/WSL2 Ubuntu, managed with
    just setup
    ```
 
-   `just setup` installs all packages, links every dotfiles repo, installs
+   `just setup` installs all packages, deploys the selected sources, installs
    mise and the pinned runtimes, and enables git hooks and tools (the
    work/personal machine profile is macOS-only — Linux has no overlay).
    It is idempotent — re-run it anytime.
@@ -177,9 +177,7 @@ Or run individual update steps:
 
 ### Applying config changes
 
-`just update` upgrades installed software — it does **not** re-apply symlinks.
-After editing a dotfile that rcm links into `$HOME` (`gitconfig`, `zshrc`,
-`zshenv`, `tmux.conf`, …), re-link so the running machine picks the change up:
+`just update` upgrades installed software; it does not deploy local config changes. After editing managed config, refresh the running machine through the declared owners:
 
 ```sh
 cd ~/Workspace/tgautier/dotfiles
@@ -189,13 +187,11 @@ just link
 The `cd` matters: `~/.justfile` is a symlink to the private repo's justfile, so
 `just link` from `$HOME` resolves there and fails with an unknown-recipe error.
 
-`just setup` also re-links, but it is the whole bootstrap — `just link` is the
-one step.
+`just setup` also runs the same refresh, but it is the whole bootstrap. Use `just link` for config deployment alone.
 
-Prefer it over a bare `rcup`. This repo's `rcrc` lives in-tree, and the recipe
-passes `RCRC=` explicitly, so it works on any machine — including one that has
-never been bootstrapped. A bare `rcup` reads the same config only *after* the
-first bootstrap, because `~/.rcrc` is itself one of the symlinks rcm creates.
+The recipe first runs the public/private ownership and source parity check in isolation. It then uses rcm only for the six public targets whose manifest disposition starts with `defer-`, invokes the private dedicated-owner aggregate when that checkout exists, and applies the public and private chezmoi sources twice. Neither routine owner uses force: rcm runs only after exact-link or absence preflight, and chezmoi enables conflict errors. A modified or pre-existing managed file therefore stops the refresh instead of being overwritten. Empty status, diff, and dry-run state after each pass proves idempotence.
+
+Do not use bare `rcup` for routine deployment. The unchanged broad `rcrc` graph is retained for the digest-bound full rollback and would return migrated targets to symlinks. If `just link` stops after one owner has run, resolve the reported conflict or tool failure and rerun it; each owner is designed to converge independently.
 
 ### Custom checkout locations
 
@@ -203,15 +199,12 @@ Both repos default to `~/Workspace/tgautier/`. Override per machine with two
 environment variables, which are a single shared contract — set one and every
 consumer moves together:
 
-| Variable               | Default                                 | Used by                                                          |
-| ---------------------- | --------------------------------------- | ---------------------------------------------------------------- |
-| `DOTFILES_DIR`         | `~/Workspace/tgautier/dotfiles`         | `DOTFILES_DIRS` in `rcrc`, the stale-symlink scanner             |
-| `DOTFILES_PRIVATE_DIR` | `~/Workspace/tgautier/dotfiles-private` | the above, plus `EXCLUDES` in `rcrc`                             |
+| Variable               | Default                                 | Used by                                                            |
+| ---------------------- | --------------------------------------- | ------------------------------------------------------------------ |
+| `DOTFILES_DIR`         | `~/Workspace/tgautier/dotfiles`         | chezmoi orchestration, retained rcm links, rollback, and inventory |
+| `DOTFILES_PRIVATE_DIR` | `~/Workspace/tgautier/dotfiles-private` | optional private chezmoi source, dedicated owners, and rollback    |
 
-Export them before `just link` / `just setup` so `rcrc` sees them — rcm sources
-`rcrc` as shell, which is what lets it read the environment at all. A trailing
-slash is fine: `rcrc` strips it and the scanner normalises with zsh's `:a`. An
-absent private repo is skipped, not fatal.
+Export them before `just link` or `just setup`. The operator passes the same paths to chezmoi, the retained rcm helper, the optional private dedicated owners, inventory, and rollback. A trailing slash is normalized. An absent private repository is skipped, not fatal.
 
 ## Documentation
 
@@ -252,7 +245,7 @@ Brewfile.work           # macOS work-only casks/apps
 Brewfile.personal       # macOS personal-only casks/apps
 Brewfile.linux          # Linux Homebrew packages
 .chezmoiroot            # Selects home/ as the chezmoi source state
-home/                   # Shadow chezmoi sources; rcm still owns deployment
+home/                   # Active public chezmoi source state
 tests/                  # Isolated parity checker and sabotage fixtures
 Justfile                # Bootstrap, CI and update recipes
 .githooks/              # Local identity, complete-CI, signature, and exact-tip push gate
@@ -270,8 +263,7 @@ which are self-describing.
 
 ## Scripts (`bin/`)
 
-rcm links each script into `~/.bin`, which `zshenv` adds to `PATH` (alongside
-`~/.bin.local` for machine-local scripts that stay out of this repo).
+Chezmoi installs each managed script into `~/.bin`, which `zshenv` adds to `PATH` alongside `~/.bin.local` for machine-local scripts that stay out of this repository.
 
 | Script        | Description                                                                 |
 | ------------- | --------------------------------------------------------------------------- |
@@ -279,7 +271,7 @@ rcm links each script into `~/.bin`, which `zshenv` adds to `PATH` (alongside
 | `kshow`       | Print ConfigMap/Secret `.data`, base64-decoding secret values (`-n` ns)     |
 | `obsidian`    | macOS-only wrapper proxying to the CLI bundled in `Obsidian.app` (v1.12+)   |
 | `op-ssh-sign` | Cross-platform 1Password SSH signing (WSL delegates to `op-ssh-sign-wsl`)   |
-| `rcm-links`   | Inventory HOME links and run approved cleanup or cutover recovery           |
+| `rcm-links`   | Inventory HOME links, refresh retained rcm targets, and perform recovery    |
 
 ## Shell functions (`zsh/functions/`)
 
@@ -407,6 +399,7 @@ Individual targets:
 | `just test-chezmoi-canary` | Run public parity plus optional private ownership and source canaries in isolation |
 | `just test-local-gate` | Fixture-test identity, signature-header ancestry, and exact-tip evidence |
 | `just ci-publish` | Publish the pushed exact-tip attestation for strict GitHub branch protection |
+| `just link` | Refresh retained rcm links, private dedicated targets, and public/private chezmoi sources |
 | `just chezmoi-status` | Inspect public/private chezmoi status without changing managed targets |
 | `just chezmoi-diff` | Print the local public/private target-state diff |
 | `just chezmoi-apply-dry-run` | Preview both applies without changing managed targets |

--- a/bin/chezmoi-cutover
+++ b/bin/chezmoi-cutover
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Inspect and apply the staged chezmoi cutover with verified rcm recovery."""
+"""Inspect, deploy, and recover the public and optional private dotfile sources."""
 
 from __future__ import annotations
 
@@ -30,6 +30,7 @@ MAX_SOURCE_BYTES = 64 * 1024 * 1024
 CHEZMOI_TIMEOUT_SECONDS = 120
 CANARY_TIMEOUT_SECONDS = 180
 RCM_HELPER_TIMEOUT_SECONDS = 90
+DEDICATED_OWNER_TIMEOUT_SECONDS = 180
 PROCESS_GROUP_CLEANUP_SECONDS = 2
 PROCESS_GROUP_TERM_GRACE_SECONDS = 0.1
 
@@ -106,7 +107,7 @@ def recoverable_termination_signals(
                 ) from exc
 
 
-def mark_apply_committed(state: TerminationState) -> None:
+def mark_operation_committed(state: TerminationState) -> None:
     """Atomically commit success before termination handlers are removed."""
 
     try:
@@ -117,7 +118,7 @@ def mark_apply_committed(state: TerminationState) -> None:
         state.committed = True
         signal.pthread_sigmask(signal.SIG_SETMASK, previous_mask)
     except (AttributeError, OSError) as exc:
-        raise CutoverError(f"cannot commit the apply signal handoff: {exc}") from exc
+        raise CutoverError(f"cannot commit the completion signal handoff: {exc}") from exc
 
 
 def lexical_absolute(path: Path) -> Path:
@@ -316,6 +317,8 @@ def command_arguments(
         arguments.extend(("apply", "--include", "files", "--dry-run", "--verbose"))
     elif operation == "apply":
         arguments.extend(("apply", "--include", "files", "--force"))
+    elif operation == "safe-apply":
+        arguments.extend(("apply", "--include", "files", "--error-on-conflict"))
     else:
         raise CutoverError(f"unsupported operator command: {operation}")
     return arguments
@@ -797,6 +800,198 @@ def verify_backup(
         raise CutoverError("cutover backup digest differs from the reviewed confirmation")
 
 
+def run_retained_link_helper(
+    *,
+    public: Path,
+    private: Path,
+    home: Path,
+    rcup: Path,
+) -> None:
+    """Delegate the remaining rcm links to the manifest-scoped helper."""
+
+    helper = require_regular_file(public / "bin/rcm-links", label="rcm link helper")
+    returncode, captured = capture_bounded_process(
+        [
+            sys.executable,
+            str(helper),
+            "link-retained",
+            "--home",
+            str(home),
+            "--public-dir",
+            str(public),
+            "--private-dir",
+            str(private),
+            "--rcup",
+            str(rcup),
+        ],
+        cwd=public,
+        environment=command_environment(home),
+        stderr=subprocess.DEVNULL,
+        timeout=RCM_HELPER_TIMEOUT_SECONDS,
+        label="retained rcm link helper",
+    )
+    if returncode != 0:
+        raise CutoverError(f"retained rcm link helper failed with status {returncode}")
+    try:
+        summary = captured.decode("utf-8").strip()
+    except UnicodeError as exc:
+        raise CutoverError("retained rcm link helper returned invalid output") from exc
+    prefix = "retained rcm links complete\ttargets="
+    count = summary.removeprefix(prefix)
+    if not summary.startswith(prefix) or not count.isascii() or not count.isdecimal():
+        raise CutoverError("retained rcm link helper returned an invalid summary")
+    if int(count) < 1:
+        raise CutoverError("retained rcm link helper reported no targets")
+    print(f"==> retained rcm links verified ({count})", file=sys.stderr)
+
+
+def run_dedicated_private_owners(
+    *,
+    private: Path,
+    public: Path,
+    home: Path,
+    just: Path,
+) -> None:
+    """Run the private aggregate without exposing companion command output."""
+
+    justfile = require_regular_file(private / "Justfile", label="private Justfile")
+    environment = command_environment(home)
+    environment["DOTFILES_DIR"] = str(public)
+    environment["DOTFILES_PRIVATE_DIR"] = str(private)
+    returncode = run_bounded_process(
+        [
+            str(just),
+            "--no-dotenv",
+            "--justfile",
+            str(justfile),
+            "--working-directory",
+            str(private),
+            "dedicated-targets-install",
+        ],
+        cwd=private,
+        environment=environment,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=DEDICATED_OWNER_TIMEOUT_SECONDS,
+        label="private dedicated target installers",
+    )
+    if returncode != 0:
+        raise CutoverError(
+            f"private dedicated target installers failed with status {returncode}; output withheld"
+        )
+    print("==> private dedicated targets verified", file=sys.stderr)
+
+
+def run_parity_check(
+    *,
+    checker: Path,
+    executable: Path,
+    lsrc: Path,
+    public: Path,
+    private: Path,
+    home: Path,
+) -> None:
+    """Validate the current public and optional private ownership contracts."""
+
+    checker = require_regular_file(checker, label="chezmoi parity checker")
+    environment = command_environment(home)
+    environment["DOTFILES_DIR"] = str(public)
+    environment["DOTFILES_PRIVATE_DIR"] = str(private)
+    print("==> isolated public/private chezmoi parity check", file=sys.stderr)
+    try:
+        with tempfile.TemporaryDirectory(prefix="chezmoi-link-tools-") as temporary:
+            tool_directory = Path(temporary)
+            (tool_directory / "chezmoi").symlink_to(executable)
+            lsrc_wrapper = tool_directory / "lsrc"
+            lsrc_wrapper.write_text(
+                f"#!/bin/sh\nexec {shlex.quote(str(lsrc))} \"$@\"\n",
+                encoding="utf-8",
+            )
+            lsrc_wrapper.chmod(0o700)
+            environment["PATH"] = (
+                f"{tool_directory}{os.pathsep}{environment.get('PATH', '')}"
+            )
+            returncode = run_bounded_process(
+                [str(checker), str(public), str(public / "docs/chezmoi-targets.tsv")],
+                cwd=public,
+                environment=environment,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=CANARY_TIMEOUT_SECONDS,
+                label="chezmoi parity check",
+            )
+    except OSError as exc:
+        raise CutoverError(f"cannot prepare exact parity-check executables: {exc}") from exc
+    if returncode != 0:
+        raise CutoverError(
+            f"chezmoi parity check failed with status {returncode}; output withheld"
+        )
+
+
+def link_current_state(
+    *,
+    executable: Path,
+    sources: Sequence[SourceState],
+    public: Path,
+    private: Path,
+    home: Path,
+    cache_root: Path,
+    state_root: Path,
+    lsrc: Path,
+    rcup: Path,
+    just: Path,
+    parity_check: Path,
+    termination: TerminationState,
+) -> None:
+    """Refresh each target through its current owner and prove idempotence."""
+
+    run_parity_check(
+        checker=parity_check,
+        executable=executable,
+        lsrc=lsrc,
+        public=public,
+        private=private,
+        home=home,
+    )
+    run_retained_link_helper(
+        public=public,
+        private=private,
+        home=home,
+        rcup=rcup,
+    )
+    if len(sources) == 2:
+        run_dedicated_private_owners(
+            private=private,
+            public=public,
+            home=home,
+            just=just,
+        )
+    for pass_number in (1, 2):
+        for source in sources:
+            capture_operation(
+                "safe-apply",
+                executable=executable,
+                source=source,
+                home=home,
+                cache_root=cache_root,
+                state_root=state_root,
+                show_output=False,
+            )
+        require_settled_state(
+            executable=executable,
+            sources=sources,
+            home=home,
+            cache_root=cache_root,
+            state_root=state_root,
+            label=f"link pass {pass_number}",
+            before_operation=lambda: None,
+        )
+    mark_operation_committed(termination)
+    print("dotfile ownership refresh complete: all owners are idempotent", file=sys.stderr)
+
+
 def observation_digests(
     *,
     executable: Path,
@@ -1194,7 +1389,7 @@ def apply_with_recovery(
             label="second apply",
             before_operation=require_approved_execution,
         )
-        mark_apply_committed(termination)
+        mark_operation_committed(termination)
         print("chezmoi apply complete: both sources are idempotent", file=sys.stderr)
         return
     except (CutoverError, KeyboardInterrupt, TerminationRequested) as exc:
@@ -1229,7 +1424,10 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     repository = Path(__file__).resolve().parent.parent
     home_default = Path.home()
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("operation", choices=("status", "diff", "dry-run", "plan", "apply"))
+    parser.add_argument(
+        "operation",
+        choices=("status", "diff", "dry-run", "link", "plan", "apply"),
+    )
     parser.add_argument(
         "--home",
         type=path_argument,
@@ -1258,7 +1456,9 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser.add_argument("--apply-confirm")
     parser.add_argument("--lsrc", default="lsrc")
     parser.add_argument("--rcup", default="rcup")
+    parser.add_argument("--just", default="just")
     parser.add_argument("--canary", type=path_argument)
+    parser.add_argument("--parity-check", type=path_argument)
     return parser.parse_args(argv)
 
 
@@ -1299,7 +1499,32 @@ def main(argv: Sequence[str] | None = None) -> int:
                     label=f"{source.label} chezmoi cache directory",
                 )
             executable = resolve_executable(args.chezmoi, label="chezmoi")
-            if args.operation in {"status", "diff", "dry-run"}:
+            if args.operation == "link":
+                lsrc = resolve_executable(args.lsrc, label="lsrc")
+                rcup = resolve_executable(args.rcup, label="rcup")
+                just = resolve_executable(args.just, label="just")
+                public = sources[0].root
+                private = lexical_absolute(args.private_dir)
+                parity_check = lexical_absolute(
+                    args.parity_check
+                    if args.parity_check is not None
+                    else public / "tests/check-chezmoi-targets"
+                )
+                link_current_state(
+                    executable=executable,
+                    sources=sources,
+                    public=public,
+                    private=private,
+                    home=home,
+                    cache_root=cache_root,
+                    state_root=state_root,
+                    lsrc=lsrc,
+                    rcup=rcup,
+                    just=just,
+                    parity_check=parity_check,
+                    termination=termination,
+                )
+            elif args.operation in {"status", "diff", "dry-run"}:
                 run_operation(
                     args.operation,
                     executable=executable,

--- a/bin/rcm-links
+++ b/bin/rcm-links
@@ -45,6 +45,9 @@ PRIVATE_TARGET_HEADER = (
     "target_shape",
     "mode",
 )
+RETAINED_PUBLIC_DISPOSITIONS = frozenset(
+    {"defer-homebrew-link", "defer-machine-overrides", "defer-private-overlay"}
+)
 
 
 class InventoryError(Exception):
@@ -331,6 +334,153 @@ def load_cutover_targets(
     if not targets:
         raise InventoryError("cutover target manifests contain no active rcm targets")
     return tuple(sorted(targets, key=lambda target: target.target.as_posix()))
+
+
+def load_retained_rcm_targets(
+    *,
+    public_manifest: Path,
+    public: Path,
+) -> tuple[CutoverTarget, ...]:
+    """Load only public targets that deliberately remain rcm-owned."""
+
+    rows = load_tsv_rows(
+        public_manifest,
+        header=PUBLIC_TARGET_HEADER,
+        label="public chezmoi target manifest",
+    )
+    retained: list[CutoverTarget] = []
+    seen_sources: set[PurePosixPath] = set()
+    seen_targets: set[PurePosixPath] = set()
+    for line_number, row in enumerate(rows, start=2):
+        source_value, target_value, disposition, chezmoi_source, mode = row
+        if disposition not in RETAINED_PUBLIC_DISPOSITIONS:
+            continue
+        if chezmoi_source != "-" or mode not in {"file", "executable"}:
+            raise InventoryError(
+                f"public manifest line {line_number} has an invalid retained rcm contract"
+            )
+        source = require_relative_path(
+            source_value,
+            label=f"public manifest line {line_number} source",
+            wildcard=False,
+        )
+        if source.parts[0].startswith("-"):
+            raise InventoryError(
+                f"public manifest line {line_number} source must not look like an option: {source}"
+            )
+        target = require_relative_path(
+            target_value,
+            label=f"public manifest line {line_number} target",
+            wildcard=False,
+        )
+        if not target.parts[0].startswith("."):
+            raise InventoryError(
+                f"public manifest line {line_number} HOME target must start with a dot: {target}"
+            )
+        if source in seen_sources:
+            raise InventoryError(f"duplicate retained rcm source: {source}")
+        if target in seen_targets:
+            raise InventoryError(f"duplicate retained rcm target: {target}")
+        source_path = public / source
+        try:
+            metadata = source_path.lstat()
+        except OSError as exc:
+            raise InventoryError(f"cannot inspect retained rcm source {source}: {exc}") from exc
+        if not stat.S_ISREG(metadata.st_mode):
+            raise InventoryError(f"retained rcm source is not a regular file: {source}")
+        executable = bool(stat.S_IMODE(metadata.st_mode) & 0o111)
+        if executable != (mode == "executable"):
+            raise InventoryError(f"retained rcm source mode differs from its manifest: {source}")
+        seen_sources.add(source)
+        seen_targets.add(target)
+        retained.append(CutoverTarget("public", source, target))
+    if not retained:
+        raise InventoryError("public manifest contains no retained rcm targets")
+    return tuple(sorted(retained, key=lambda item: item.target.as_posix()))
+
+
+def preflight_retained_rcm_links(
+    targets: Sequence[CutoverTarget],
+    *,
+    home: Path,
+    public: Path,
+) -> None:
+    """Refuse to replace user files or links owned by another source."""
+
+    for target in targets:
+        current = home
+        for part in target.target.parts[:-1]:
+            current /= part
+            try:
+                metadata = current.lstat()
+            except FileNotFoundError:
+                break
+            except OSError as exc:
+                raise InventoryError(
+                    f"cannot inspect retained rcm ancestor {current}: {exc}"
+                ) from exc
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise InventoryError(
+                    f"retained rcm ancestor is not a real directory: {current}"
+                )
+        else:
+            target_path = home / target.target
+            try:
+                metadata = target_path.lstat()
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                raise InventoryError(
+                    f"cannot inspect retained rcm target {target.target}: {exc}"
+                ) from exc
+            if not stat.S_ISLNK(metadata.st_mode):
+                raise InventoryError(
+                    f"retained rcm target is not an owned symlink: {target.target}"
+                )
+            expected = str(lexical_absolute(public / target.source))
+            try:
+                actual = os.readlink(target_path)
+            except OSError as exc:
+                raise InventoryError(
+                    f"cannot read retained rcm link {target.target}: {exc}"
+                ) from exc
+            if actual != expected:
+                raise InventoryError(
+                    f"retained rcm target is a foreign symlink: {target.target}"
+                )
+
+
+def link_retained_rcm_targets(
+    targets: Sequence[CutoverTarget],
+    *,
+    home: Path,
+    public: Path,
+    private: Path,
+    rcup: str,
+) -> tuple[CutoverLink, ...]:
+    """Install only manifest-deferred public links and verify exact ownership."""
+
+    preflight_retained_rcm_links(targets, home=home, public=public)
+    environment = command_environment(
+        {
+            "HOME": str(home),
+            "RCRC": str(public / "rcrc"),
+            "DOTFILES_DIR": str(public),
+            "DOTFILES_PRIVATE_DIR": str(private),
+        }
+    )
+    sources = sorted(target.source.as_posix() for target in targets)
+    run_bounded(
+        [rcup, "-K", "-d", str(public), *sources],
+        cwd=public,
+        env=environment,
+    )
+    return capture_cutover_links(
+        targets,
+        home=home,
+        public=public,
+        private=None,
+    )
 
 
 def load_owner_patterns(path: Path) -> list[OwnerPattern]:
@@ -1760,6 +1910,18 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     )
     restore_parser.add_argument("--plan", type=Path, required=True)
     restore_parser.add_argument("--confirm", required=True)
+    retained_parser = subparsers.add_parser(
+        "link-retained",
+        help="install only public targets that remain rcm-owned",
+    )
+    add_common_arguments(
+        retained_parser,
+        repository=repository,
+        public_default=public_default,
+        private_default=private_default,
+    )
+    retained_parser.add_argument("--public-targets", type=Path, default=None)
+    retained_parser.add_argument("--rcup", default="rcup")
     backup_parser = subparsers.add_parser(
         "cutover-backup",
         help="capture an exact digest-bound backup of every manifested rcm link",
@@ -1800,13 +1962,14 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     cutover_restore_parser.add_argument("--rcup", default="rcup")
     args = parser.parse_args(argv)
     if args.command in {
+        "link-retained",
         "cutover-backup",
         "cutover-backup-verify",
         "cutover-restore",
     }:
         if args.public_targets is None:
             args.public_targets = args.public_dir / "docs/chezmoi-targets.tsv"
-        if args.private_targets is None:
+        if args.command != "link-retained" and args.private_targets is None:
             args.private_targets = args.private_dir / "docs/chezmoi-private-targets.tsv"
     return args
 
@@ -1825,6 +1988,20 @@ def main(argv: Sequence[str] | None = None) -> int:
             private,
             label="private dotfiles repository",
         )
+        if args.command == "link-retained":
+            targets = load_retained_rcm_targets(
+                public_manifest=lexical_absolute(args.public_targets),
+                public=public,
+            )
+            linked = link_retained_rcm_targets(
+                targets,
+                home=home,
+                public=public,
+                private=private,
+                rcup=args.rcup,
+            )
+            print(f"retained rcm links complete\ttargets={len(linked)}")
+            return 0
         if args.command in {
             "cutover-backup",
             "cutover-backup-verify",

--- a/docs/chezmoi-cutover-backup.md
+++ b/docs/chezmoi-cutover-backup.md
@@ -34,7 +34,7 @@ The backup command creates one regular file with mode `0600`. It refuses an exis
 
 Review the target list and keep the printed SHA-256 digest with the file. The digest confirms the reviewed artifact during restore. It does not replace local review of the target list.
 
-`just link-cutover-backup` and `just link-cutover-backup-verify` do not change HOME. Keep using `just link` while rcm owns deployment.
+`just link-cutover-backup` and `just link-cutover-backup-verify` do not change HOME. After the first live cutover, `just link` preserves the mixed ownership split while this artifact retains the complete rcm rollback state.
 
 Creating and verifying this backup does not authorize a bare chezmoi apply. Continue with [Chezmoi operator cutover](chezmoi-operator-cutover.md), which binds the reviewed status, diff, dry run, source and recovery state, selected executables, canary, and this backup to the guarded apply and automatic recovery path.
 
@@ -65,4 +65,4 @@ Pull this checkpoint and run `just ci` before creating a live backup. Before a r
 
 Before any live backup exists, restore the earlier repository revision and run `just ci` to roll back this code change. No HOME action is required.
 
-After chezmoi changes HOME, run `just chezmoi-recover` before reverting repository code. Keep the backup until rcm ownership, dedicated private installers, shell startup, and the complete local gate pass.
+After chezmoi changes HOME, run `just chezmoi-recover` before reverting repository code. Keep the backup through the routine-owner switch, fresh-machine and supported-profile acceptance, shell startup checks, and final rcm retirement.

--- a/docs/chezmoi-inventory.md
+++ b/docs/chezmoi-inventory.md
@@ -52,7 +52,7 @@ The guard now maps `zsh/zaliases` and `zsh/zcompletion` to `~/.zsh/zaliases` and
 
 ## Upgrade and rollback
 
-Pull the private companion repository first when it is installed, then pull this repository and run `just test-chezmoi-canary`. The command changes no HOME file: the public and private source-state canaries each own separate temporary config, cache, persistent-state, destination, and operator-HOME paths. A machine without the private repository continues to run the complete public-only parity canary without private paths or target identifiers in its output. Keep using `just link` for active rcm deployment, and run `just ci` before publishing changes.
+Pull the private companion repository first when it is installed, then pull this repository and run `just test-chezmoi-canary`. The command changes no HOME file: the public and private source-state canaries each own separate temporary config, cache, persistent-state, destination, and operator-HOME paths. A machine without the private repository continues to run the complete public-only parity canary without private paths or target identifiers in its output. Use `just link` for the current mixed-owner deployment and run `just ci` before publishing changes.
 
 After the canary passes, `just chezmoi-status`, `just chezmoi-diff`, and `just chezmoi-apply-dry-run` inspect the real HOME through explicit public and private source roots. They do not modify managed targets, but they create owner-only operator metadata under `${XDG_STATE_HOME:-$HOME/.local/state}/dotfiles/chezmoi` and `${XDG_CACHE_HOME:-$HOME/.cache}/dotfiles/chezmoi`. The diff and verbose dry run can display complete private target contents; review them only in the local terminal and never paste their output into this public repository. Do not invoke bare `chezmoi apply`.
 
@@ -62,4 +62,4 @@ The removed empty Git-template marker may leave `~/.git_template/hooks/gitkeep` 
 
 Before any real apply, restore the earlier public revision and run `just ci`; no HOME action is required. After an apply starts, run the retained digest through `just chezmoi-recover` and verify the restored inventory before reverting repository code. A code revert cannot reconstruct targets already converted from links to regular files.
 
-The future cutover remains blocked until the exact guard passes from a fresh checkout, `just link-inventory` reports the approved live baseline, a live backup passes verification, and the cutover PR records the apply and post-apply checks for macOS, Linux, and WSL2.
+The live cutover and routine-owner switch are complete on the current machine. Rcm retirement remains blocked until fresh-machine and supported-profile acceptance pass with and without the private companion, the retained backup is reverified, and the final cleanup proves no supported workflow needs the broad rcm graph.

--- a/docs/chezmoi-operator-cutover.md
+++ b/docs/chezmoi-operator-cutover.md
@@ -1,6 +1,6 @@
 # Chezmoi operator cutover
 
-This runbook reviews and applies the staged public and optional private chezmoi sources without changing `just setup` or `just link`. Rcm remains installed and the retained link backup remains the recovery authority throughout this checkpoint.
+This runbook records the approval-bound first live apply of the public and optional private chezmoi sources. Rcm remains installed and the retained link backup remains the recovery authority throughout migration acceptance. Routine deployment now uses the guarded `just link` ownership refresh documented below.
 
 ## Prepare a current recovery point
 
@@ -72,17 +72,20 @@ The dedicated chezmoi cache, state databases, and lock file can remain. A later 
 
 ## Preserve a working state after success
 
-After a successful apply, the migrated targets are regular chezmoi-managed files while deferred targets remain rcm links. Keep rcm and the backup. Do not run `just link` or `just setup`: both still invoke rcm and would deliberately return the migrated targets to symlinks before the later cutover switch lands.
+After a successful first apply, the migrated targets are regular chezmoi-managed files while deferred targets remain rcm links. Keep rcm and the backup. `just link` and `just setup` now preserve that ownership split: the operator runs isolated parity checks, refreshes only manifest-deferred public rcm links, invokes the optional private dedicated-owner aggregate, and applies both chezmoi sources without force. It applies twice and requires empty status, diff, and dry-run state after each pass.
+
+A regular file or foreign link at a retained rcm target fails before `rcup`. A changed or pre-existing chezmoi target fails through `--error-on-conflict` instead of being overwritten. A failure after an earlier owner succeeds does not automatically restore the full rcm graph because that would undo the successful cutover. Resolve the conflict or tool failure and rerun `just link`; use the retained backup and `just chezmoi-recover` only when intentionally rolling the complete migration back.
 
 Run the nonmutating checks:
 
 ```sh
 just chezmoi-status
 just chezmoi-diff
+just link
 just ci
 ```
 
-Status and diff must remain empty for both sources. Perform the separately reviewed shell, dedicated-installer, and supported-profile acceptance checks before treating the live trial as cutover evidence.
+Status and diff must remain empty for both sources before and after the routine refresh. Perform the separately reviewed shell, dedicated-installer, fresh-machine, and supported-profile acceptance checks before retiring rcm or deleting the backup.
 
 To end the trial or roll back this operator checkpoint, restore rcm before reverting repository code:
 

--- a/docs/rcm-link-reconciliation.md
+++ b/docs/rcm-link-reconciliation.md
@@ -60,6 +60,6 @@ Restore refuses an absent path that acquired a current rcm or dedicated owner, a
 
 ## Working-state boundary
 
-Pulling the change and running `just ci`, `just link-inventory`, or `just link-cleanup-plan` leaves installed dotfiles untouched. Only `just link-cleanup` and `just link-restore` mutate HOME, and both require the private plan plus its separately approved digest. Continue using `just link` for active deployment, and do not run chezmoi against the real HOME.
+Pulling the change and running `just ci`, `just link-inventory`, or `just link-cleanup-plan` leaves installed dotfiles untouched. `just link-cleanup` and `just link-restore` mutate only the approved obsolete-link set. The current `just link` routine is a separate guarded mutation path: it refreshes retained rcm links, optional private dedicated targets, and the public/private chezmoi sources. Do not run bare `rcup` or bare `chezmoi apply` against the real HOME.
 
 Before cleanup, rollback is a repository revert followed by `just ci`. After cleanup, use `just link-restore` with the retained approved plan before reverting repository code; a repository revert alone cannot recreate obsolete links that rcm no longer owns. Preserve the verified post-cleanup inventory, then follow [Chezmoi cutover backup and rcm restore](chezmoi-cutover-backup.md).

--- a/tests/test_chezmoi_cutover.py
+++ b/tests/test_chezmoi_cutover.py
@@ -41,11 +41,15 @@ class ChezmoiCutoverTests(unittest.TestCase):
         self.applied = self.root / "applied"
         self.backup = self.root / "rcm-links.json"
         self.canary_log = self.root / "canary.log"
+        self.parity_log = self.root / "parity.json"
+        self.just_log = self.root / "just.json"
         self.ready = self.root / "apply-ready"
         self.restore_ready = self.root / "restore-ready"
         self.descendant_pid = self.root / "descendant.pid"
         self.output_pid = self.root / "output.pid"
         self.fake_chezmoi = self.root / "fake-chezmoi"
+        self.fake_parity = self.root / "fake-parity"
+        self.fake_just = self.root / "fake-just"
         self.home.mkdir()
         self._make_repository(self.public, private=False)
         self.script = self.public / "bin/chezmoi-cutover"
@@ -133,6 +137,67 @@ class ChezmoiCutoverTests(unittest.TestCase):
             encoding="utf-8",
         )
         self.fake_chezmoi.chmod(0o700)
+        self.fake_parity.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env python3
+                import json
+                import os
+                from pathlib import Path
+                import shutil
+                import sys
+
+                Path(os.environ["FAKE_PARITY_LOG"]).write_text(
+                    json.dumps(
+                        {
+                            "arguments": sys.argv[1:],
+                            "chezmoi": str(Path(shutil.which("chezmoi")).resolve()),
+                            "lsrc": str(Path(shutil.which("lsrc")).resolve()),
+                            "private": os.environ.get("DOTFILES_PRIVATE_DIR"),
+                            "public": os.environ.get("DOTFILES_DIR"),
+                        },
+                        sort_keys=True,
+                    ),
+                    encoding="utf-8",
+                )
+                if os.environ.get("FAKE_PARITY_FAIL") == "1":
+                    print("private fixture detail", file=sys.stderr)
+                    raise SystemExit(41)
+                """
+            ),
+            encoding="utf-8",
+        )
+        self.fake_parity.chmod(0o700)
+        self.fake_just.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env python3
+                import json
+                import os
+                from pathlib import Path
+                import sys
+
+                Path(os.environ["FAKE_JUST_LOG"]).write_text(
+                    json.dumps(
+                        {
+                            "arguments": sys.argv[1:],
+                            "cwd": str(Path.cwd()),
+                            "home": os.environ.get("HOME"),
+                            "private": os.environ.get("DOTFILES_PRIVATE_DIR"),
+                            "public": os.environ.get("DOTFILES_DIR"),
+                        },
+                        sort_keys=True,
+                    ),
+                    encoding="utf-8",
+                )
+                if os.environ.get("FAKE_JUST_FAIL") == "1":
+                    print("private fixture detail", file=sys.stderr)
+                    raise SystemExit(43)
+                """
+            ),
+            encoding="utf-8",
+        )
+        self.fake_just.chmod(0o700)
 
     def _make_repository(self, root: Path, *, private: bool) -> None:
         (root / "home").mkdir(parents=True)
@@ -174,6 +239,15 @@ class ChezmoiCutoverTests(unittest.TestCase):
                                 "FAKE_RCM_SUMMARY",
                                 "cutover backup verified\\ttargets=1\\t"
                                 f"approval_sha256={os.environ['FAKE_BACKUP_DIGEST']}",
+                            )
+                        )
+                    elif command == "link-retained":
+                        if os.environ.get("FAKE_RCM_LINK_FAIL") == "1":
+                            raise SystemExit(35)
+                        print(
+                            os.environ.get(
+                                "FAKE_RCM_LINK_SUMMARY",
+                                "retained rcm links complete\\ttargets=6",
                             )
                         )
                     elif command == "cutover-restore":
@@ -269,6 +343,10 @@ class ChezmoiCutoverTests(unittest.TestCase):
             checker = root / "tests/check-chezmoi-targets"
             checker.write_text("# fixture checker\n", encoding="utf-8")
         if private:
+            (root / "Justfile").write_text(
+                "dedicated-targets-install:\n    @true\n",
+                encoding="utf-8",
+            )
             docs = root / "docs"
             docs.mkdir()
             (docs / "chezmoi-private-targets.tsv").write_text(
@@ -300,6 +378,8 @@ class ChezmoiCutoverTests(unittest.TestCase):
                 "FAKE_RCM_RESTORE_READY": str(self.restore_ready),
                 "FAKE_BACKUP_DIGEST": BACKUP_DIGEST,
                 "FAKE_CANARY_LOG": str(self.canary_log),
+                "FAKE_PARITY_LOG": str(self.parity_log),
+                "FAKE_JUST_LOG": str(self.just_log),
                 "FAKE_CHEZMOI_READY": str(self.ready),
                 "FAKE_DESCENDANT_PID": str(self.descendant_pid),
                 "CHEZMOI_CONFIG_FILE": str(self.root / "foreign-config"),
@@ -328,6 +408,10 @@ class ChezmoiCutoverTests(unittest.TestCase):
             str(self.state),
             "--chezmoi",
             str(self.fake_chezmoi),
+            "--just",
+            str(self.fake_just),
+            "--parity-check",
+            str(self.fake_parity),
         ]
         if extra_arguments:
             arguments.extend(extra_arguments)
@@ -377,6 +461,122 @@ class ChezmoiCutoverTests(unittest.TestCase):
             json.loads(line)
             for line in self.log.read_text(encoding="utf-8").splitlines()
         ]
+
+    def test_link_public_only_scopes_rcm_and_applies_without_force(self) -> None:
+        completed = self._run("link")
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("retained rcm links verified (6)", completed.stderr)
+        self.assertIn("all owners are idempotent", completed.stderr)
+        self.assertFalse(self.just_log.exists())
+        self.assertEqual([record[0] for record in self._rcm_records()], ["link-retained"])
+        parity = json.loads(self.parity_log.read_text(encoding="utf-8"))
+        self.assertEqual(
+            parity["arguments"],
+            [
+                str(self.public.resolve()),
+                str(self.public.resolve() / "docs/chezmoi-targets.tsv"),
+            ],
+        )
+        self.assertEqual(parity["chezmoi"], str(self.fake_chezmoi.resolve()))
+        self.assertEqual(parity["private"], str(CUTOVER.lexical_absolute(self.private)))
+        self.assertEqual(parity["public"], str(self.public.resolve()))
+        applies = [
+            record for record in self._records()
+            if record["operation"] == "apply" and "--dry-run" not in record["arguments"]
+        ]
+        self.assertEqual(len(applies), 2)
+        for record in applies:
+            self.assertIn("--error-on-conflict", record["arguments"])
+            self.assertNotIn("--force", record["arguments"])
+
+    def test_link_with_private_runs_dedicated_owner_before_two_source_apply(self) -> None:
+        completed = self._run("link", private=True)
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        invocation = json.loads(self.just_log.read_text(encoding="utf-8"))
+        self.assertEqual(invocation["cwd"], str(self.private.resolve()))
+        self.assertEqual(invocation["home"], str(self.home.resolve()))
+        self.assertEqual(invocation["private"], str(CUTOVER.lexical_absolute(self.private)))
+        self.assertEqual(invocation["public"], str(self.public.resolve()))
+        self.assertEqual(
+            invocation["arguments"],
+            [
+                "--no-dotenv",
+                "--justfile",
+                str(CUTOVER.lexical_absolute(self.private) / "Justfile"),
+                "--working-directory",
+                str(CUTOVER.lexical_absolute(self.private)),
+                "dedicated-targets-install",
+            ],
+        )
+        applies = [
+            record for record in self._records()
+            if record["operation"] == "apply" and "--dry-run" not in record["arguments"]
+        ]
+        self.assertEqual(
+            [record["cwd"] for record in applies],
+            [
+                str(self.public.resolve()),
+                str(self.private.resolve()),
+                str(self.public.resolve()),
+                str(self.private.resolve()),
+            ],
+        )
+
+    def test_link_preflight_failure_starts_no_owner_mutation(self) -> None:
+        completed = self._run(
+            "link",
+            private=True,
+            extra_environment={"FAKE_PARITY_FAIL": "1"},
+        )
+
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("parity check failed with status 41; output withheld", completed.stderr)
+        self.assertNotIn("private fixture detail", completed.stderr)
+        self.assertEqual(self._rcm_records(), [])
+        self.assertFalse(self.just_log.exists())
+        self.assertEqual(self._records(), [])
+
+    def test_link_retained_rcm_failure_stops_before_later_owners(self) -> None:
+        completed = self._run(
+            "link",
+            private=True,
+            extra_environment={"FAKE_RCM_LINK_FAIL": "1"},
+        )
+
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("retained rcm link helper failed with status 35", completed.stderr)
+        self.assertFalse(self.just_log.exists())
+        self.assertEqual(self._records(), [])
+
+    def test_link_private_owner_failure_withholds_output_and_stops_before_chezmoi(self) -> None:
+        completed = self._run(
+            "link",
+            private=True,
+            extra_environment={"FAKE_JUST_FAIL": "1"},
+        )
+
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn(
+            "private dedicated target installers failed with status 43; output withheld",
+            completed.stderr,
+        )
+        self.assertNotIn("private fixture detail", completed.stderr)
+        self.assertEqual([record[0] for record in self._rcm_records()], ["link-retained"])
+        self.assertEqual(self._records(), [])
+
+    def test_link_apply_failure_does_not_replace_current_state_with_full_rcm_restore(self) -> None:
+        completed = self._run(
+            "link",
+            private=True,
+            extra_environment={"FAKE_CHEZMOI_FAIL_APPLY_CWD": self.private.name},
+        )
+
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("private chezmoi safe-apply failed with status 29", completed.stderr)
+        self.assertEqual([record[0] for record in self._rcm_records()], ["link-retained"])
+        self.assertTrue(self.just_log.exists())
 
     def _descendant_launcher(self, *, wait: bool) -> Path:
         launcher = self.root / f"descendant-launcher-{wait}"
@@ -1225,7 +1425,7 @@ class ChezmoiCutoverTests(unittest.TestCase):
 
     def test_committed_signal_is_recorded_without_ambiguous_failure(self) -> None:
         with CUTOVER.recoverable_termination_signals() as termination:
-            CUTOVER.mark_apply_committed(termination)
+            CUTOVER.mark_operation_committed(termination)
             os.kill(os.getpid(), signal.SIGTERM)
             self.assertEqual(termination.signum, signal.SIGTERM)
             self.assertTrue(termination.committed)
@@ -1240,7 +1440,7 @@ class ChezmoiCutoverTests(unittest.TestCase):
             with CUTOVER.recoverable_termination_signals(
                 retain_committed_handlers=True
             ) as termination:
-                CUTOVER.mark_apply_committed(termination)
+                CUTOVER.mark_operation_committed(termination)
 
             os.kill(os.getpid(), signal.SIGTERM)
             self.assertEqual(termination.signum, signal.SIGTERM)

--- a/tests/test_rcm_links.py
+++ b/tests/test_rcm_links.py
@@ -264,6 +264,136 @@ class RcmLinksInventoryTest(unittest.TestCase):
             str(output),
         )
 
+    def _retained_command(
+        self,
+        public_manifest: Path,
+        rcup: Path,
+    ) -> subprocess.CompletedProcess[str]:
+        return self._command(
+            "link-retained",
+            "--public-targets",
+            str(public_manifest),
+            "--rcup",
+            str(rcup),
+        )
+
+    def _retained_fixture(self) -> tuple[Path, Path]:
+        self._write(self.public, "Brewfile", "brew fixture\n")
+        self._write(self.public, "config/mise/config.toml", "[tools]\n")
+        self._write(self.public, "zshrc", "zsh fixture\n")
+        manifest = self.root / "retained-targets.tsv"
+        manifest.write_text(
+            "rcm_source\ttarget\tdisposition\tchezmoi_source\tmode\n"
+            "Brewfile\t.Brewfile\tdefer-homebrew-link\t-\tfile\n"
+            "config/mise/config.toml\t.config/mise/config.toml\t"
+            "defer-machine-overrides\t-\tfile\n"
+            "zshrc\t.zshrc\tshadow\tdot_zshrc\tfile\n",
+            encoding="utf-8",
+        )
+        rcup = self.root / "fake-rcup"
+        rcup.write_text(
+            f"#!{sys.executable}\n"
+            "import json\n"
+            "import os\n"
+            "from pathlib import Path\n"
+            "import sys\n"
+            "arguments = sys.argv[1:]\n"
+            "Path(os.environ['FAKE_RCUP_LOG']).write_text(\n"
+            "    json.dumps({'arguments': arguments, 'environment': {\n"
+            "        name: os.environ.get(name)\n"
+            "        for name in ('DOTFILES_DIR', 'DOTFILES_PRIVATE_DIR', 'HOME', 'RCRC')\n"
+            "    }}),\n"
+            "    encoding='utf-8',\n"
+            ")\n"
+            "directory = Path(arguments[arguments.index('-d') + 1])\n"
+            "home = Path(os.environ['HOME'])\n"
+            "for source in arguments[arguments.index('-d') + 2:]:\n"
+            "    target = home / ('.' + source)\n"
+            "    target.parent.mkdir(parents=True, exist_ok=True)\n"
+            "    if target.is_symlink():\n"
+            "        target.unlink()\n"
+            "    target.symlink_to(directory / source)\n",
+            encoding="utf-8",
+        )
+        rcup.chmod(0o755)
+        return manifest, rcup
+
+    def test_link_retained_targets_scopes_rcm_to_manifest_deferred_public_sources(self) -> None:
+        manifest, rcup = self._retained_fixture()
+        rcup_log = self.root / "rcup.json"
+        with mock.patch.dict(os.environ, {"FAKE_RCUP_LOG": str(rcup_log)}):
+            completed = self._retained_command(manifest, rcup)
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(completed.stdout, "retained rcm links complete\ttargets=2\n")
+        record = json.loads(rcup_log.read_text(encoding="utf-8"))
+        self.assertEqual(
+            record["arguments"],
+            [
+                "-K",
+                "-d",
+                str(self.public),
+                "Brewfile",
+                "config/mise/config.toml",
+            ],
+        )
+        self.assertEqual(
+            record["environment"],
+            {
+                "DOTFILES_DIR": str(self.public),
+                "DOTFILES_PRIVATE_DIR": str(self.private),
+                "HOME": str(self.home),
+                "RCRC": str(self.public / "rcrc"),
+            },
+        )
+        self.assertEqual(os.readlink(self.home / ".Brewfile"), str(self.public / "Brewfile"))
+        self.assertEqual(
+            os.readlink(self.home / ".config/mise/config.toml"),
+            str(self.public / "config/mise/config.toml"),
+        )
+        self.assertFalse((self.home / ".zshrc").exists())
+
+    def test_link_retained_targets_refuses_regular_and_foreign_targets_before_rcm(self) -> None:
+        manifest, rcup = self._retained_fixture()
+        rcup_log = self.root / "rcup.json"
+        target = self.home / ".Brewfile"
+        target.write_text("local override\n", encoding="utf-8")
+        with mock.patch.dict(os.environ, {"FAKE_RCUP_LOG": str(rcup_log)}):
+            regular = self._retained_command(manifest, rcup)
+        self.assertEqual(regular.returncode, 2)
+        self.assertIn("retained rcm target is not an owned symlink: .Brewfile", regular.stderr)
+        self.assertFalse(rcup_log.exists())
+
+        target.unlink()
+        target.symlink_to(self.root / "foreign")
+        with mock.patch.dict(os.environ, {"FAKE_RCUP_LOG": str(rcup_log)}):
+            foreign = self._retained_command(manifest, rcup)
+        self.assertEqual(foreign.returncode, 2)
+        self.assertIn("retained rcm target is a foreign symlink: .Brewfile", foreign.stderr)
+        self.assertFalse(rcup_log.exists())
+
+    def test_link_retained_targets_uses_only_the_public_rcm_directory(self) -> None:
+        manifest, _fake_rcup = self._retained_fixture()
+        self._write(self.private, "Brewfile", "private fixture\n")
+        rcup = shutil.which("rcup")
+        self.assertIsNotNone(rcup, "rcup must be installed for the retained-link fixture")
+
+        completed = self._command(
+            "link-retained",
+            "--public-targets",
+            str(manifest),
+            "--rcup",
+            str(rcup),
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(os.readlink(self.home / ".Brewfile"), str(self.public / "Brewfile"))
+        self.assertEqual(
+            os.readlink(self.home / ".config/mise/config.toml"),
+            str(self.public / "config/mise/config.toml"),
+        )
+        self.assertFalse((self.home / ".zshrc").exists())
+
     @staticmethod
     def _plan_digest(payload: dict[str, object]) -> str:
         digest_payload = {key: value for key, value in payload.items() if key != "approval_sha256"}


### PR DESCRIPTION
## Summary

Switch routine dotfile deployment from broad `rcup` to the ownership split already established by the live chezmoi cutover.

- make `just link` and the linking phase of `just setup` use the guarded public/private operator
- refresh only the six public `defer-*` targets through rcm, with explicit source operands and no force
- run the optional private dedicated-owner aggregate with output withheld
- apply public and private chezmoi sources twice with conflict errors and settled-state verification
- retain the unchanged broad `rcrc` graph and digest-bound backup for explicit full rollback
- update project guidance, migration runbooks, README, and CHANGELOG to describe the current ownership boundary

Part of #232.

## Why

The live cutover already converted migrated targets to regular chezmoi-managed files, but `just link` still invoked broad `rcup`. Running the documented routine command could therefore undo the cutover by returning migrated targets to symlinks. This change makes the normal command preserve the current ownership map while keeping the proven rollback path available until acceptance is complete.

## Safety and rollback

- An isolated parity check validates the current public and optional private contracts before HOME mutation.
- Retained rcm targets must be absent or exact public-owned symlinks; regular files, foreign links, and non-directory ancestors fail before `rcup`.
- Routine rcm receives one public directory and the exact deferred source list. It does not use force and cannot traverse the complete rollback graph.
- Chezmoi runs noninteractively with `--error-on-conflict`, never routine `--force`; status, diff, and dry-run must be empty after both passes.
- Private owner output is withheld on success and failure.
- A partial routine failure is rerunnable and does not silently restore broad rcm ownership. Intentional full rollback still requires the retained backup digest through `just chezmoi-recover`.

## Validation

- complete `just ci` gate passed on the committed tip
- exact clean-HEAD local CI attestation was published and read back for `149dc8e`
- Codex Roborev job 3370 completed with no findings on the exact branch range
- fixture coverage includes public-only and private ordering, no-force arguments, preflight refusal, withheld failures, partial-apply behavior, and settled idempotence
- an integration fixture uses the installed `rcup` to prove `-d` and source operands select the public deferred targets even when the private repository contains a same-named source

## Delivery plan

- [x] implement the manifest-scoped retained-rcm helper and routine operator
- [x] switch `just link` and `just setup`
- [x] update behavioral tests, operator documentation, README, project guidance, and CHANGELOG
- [x] pass the complete local gate and exact-tip Codex review
- [x] complete final PR merge-gate read-back and squash merge at the reviewed head
- [x] fast-forward the canonical checkout and run the guarded `just link` from that stable path
- [x] record current-machine mixed-owner and login-shell acceptance
- [ ] continue fresh-machine and supported-profile acceptance before rcm retirement
